### PR TITLE
docs: Update documentation for Docker Compose setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,27 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Important: Branch Policy
+
+- **Default branch**: `colab-dev` (NOT `main`)
+- **Always branch from**: `colab-dev`
+- **PRs target**: `colab-dev`
+- **Note**: `main` is deprecated and will be deleted in the future
+
+When creating new branches:
+```bash
+git checkout colab-dev
+git pull origin colab-dev
+git checkout -b feature/your-feature-name
+```
+
+## Documentation Reminder
+
+When making significant changes, remember to update the `/docs` folder:
+- `docs/FEATURES.md` - New features or feature changes
+- `docs/KNOWN_ISSUES.md` - Known bugs or limitations
+- `docs/TECHNICAL.md` - Architecture or technical changes
+
 ## Project Overview
 
 Druppie is a governance platform for AI agents with MCP (Model Context Protocol) tool permissions and approval workflows. Agents can only act through MCP tools - no direct file output.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,14 +2,14 @@
 
 Known bugs, implementation gaps, and limitations of the Druppie platform.
 
-Last updated: 2026-02-04
+Last updated: 2026-02-05
 
 ---
 
 ## Summary
 
 - Per-Agent Model Selection Ignored
-- Setup / Core Problems
+- Hardcoded API URLs in Frontend Debug Pages
 - Dead Code in LLMService.get_llm()
 - Duplicate Tool Descriptions Sent to LLM
 - Inconsistent [COMMON_INSTRUCTIONS] Across Agents
@@ -49,19 +49,12 @@ Last updated: 2026-02-04
 - **Impact:** All agents use the same model and temperature regardless of their YAML configuration. Cannot use a cheap/fast model for the router and a capable model for the developer.
 - **Fix needed:** Replace the singleton with a factory that caches LLM instances per `(provider, model, temperature)` tuple, or pass model/temperature overrides into `achat()`.
 
-### Setup / Core Problems
+### Hardcoded API URLs in Frontend Debug Pages
 
-- **Severity:** Medium
-- **Locations:**
-  - `setup_dev.sh` — development setup script
-  - `frontend/src/services/api.js:10`, `frontend/src/pages/Debug.jsx:33`, `DebugMCP.jsx:15`, `DebugProjects.jsx:22`, `DebugChat.jsx:13`, `DebugApprovals.jsx:15` — hardcoded API URLs
-- The development setup is fragile and not system-independent:
-  - `setup_dev.sh` assumes specific system dependencies and OS-level configurations that may not be present on all machines. It does not work reliably across devices.
-  - The default `VITE_API_URL` is `http://localhost:8000` but the backend runs on port 8100. This works when `setup_dev.sh` sets the correct environment variable, but breaks when running the frontend standalone. The wrong default is duplicated across six files.
-- **Fixes needed:**
-  - Make the setup process system-independent: either move to full containerization (with hot-reload support for dev) or use a more robust installation process (e.g., Conda environments) to ensure consistent setup across machines.
-  - Centralize the API base URL so it is defined in one place and all files import from there. Fix the default to match the actual backend port.
-  - Write a clear setup/usage guide (README) so new developers can get the project running without tribal knowledge.
+- **Severity:** Low
+- **Locations:** `frontend/src/pages/Debug.jsx:33`, `DebugMCP.jsx:15`, `DebugProjects.jsx:22`, `DebugChat.jsx:13`, `DebugApprovals.jsx:15`
+- Some debug pages have hardcoded API URLs instead of using the centralized API client.
+- **Fix needed:** Refactor debug pages to use the shared API client from `frontend/src/services/api.js`.
 
 ### Dead Code in LLMService.get_llm()
 
@@ -204,7 +197,7 @@ Last updated: 2026-02-04
 
 ### Keycloak in Development Mode
 
-- **Location:** `druppie/docker-compose.yml:137`
+- **Location:** `docker-compose.yml` (keycloak service)
 - Keycloak runs with the `start-dev` command, which is explicitly not production-ready.
 - No TLS configuration is present.
 - Suitable for development only.

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -216,7 +216,7 @@ The frontend uses polling for real-time updates:
 
 ### 4.1 Design Principles
 
-- **No migrations**: Models are updated directly. The database is reset with `./setup.sh clean && ./setup.sh all`.
+- **No migrations**: Models are updated directly. The database is reset with `docker compose --profile reset-hard up` (full wipe) or `docker compose --profile reset-db up` (soft reset, keeps users).
 - **No JSON/JSONB columns**: All data is normalized into proper relational tables. (excep raw API requests for debugging for now. Might be other things too, needs to be checked and updated)
 - **No legacy/fallback code**: Clean architecture only.
 
@@ -435,7 +435,7 @@ approval_overrides:
 
 ### 7.1 Services
 
-All services are defined in `druppie/docker-compose.yml`:
+All services are defined in `docker-compose.yml` (at the repository root):
 
 ```
 druppie-db          PostgreSQL 15     :5533   Main database
@@ -481,13 +481,57 @@ druppie-db  <-- keycloak (via keycloak-db)
 
 ### 7.5 Development Setup
 
+The setup uses Docker Compose with profiles:
+
 ```bash
-./setup_dev.sh              # Start everything (infra + backend + frontend)
-./setup_dev.sh infra        # Start only infrastructure (DBs, Keycloak, Gitea, MCPs)
-./setup_dev.sh backend      # Start only backend (port 8100)
-./setup_dev.sh stop         # Stop all services
-./setup_dev.sh status       # Check service status
+# First time setup (initialize Keycloak and Gitea)
+cp .env.example .env          # Copy and edit environment variables
+docker compose --profile init up -d
+
+# Development mode (hot reload enabled)
+docker compose --profile dev up -d
+
+# Production mode
+docker compose --profile prod up -d
+
+# Infrastructure only (DBs, Keycloak, Gitea, MCPs)
+docker compose --profile infra up -d
+
+# Stop all services
+docker compose --profile dev --profile prod --profile infra down
+
+# Check status
+docker compose ps
 ```
+
+### 7.6 Database Reset
+
+Two reset options are available:
+
+```bash
+# Soft reset: drops application tables (projects, sessions, etc.), keeps users
+docker compose --profile reset-db up
+
+# Hard reset: wipes all volumes, restarts everything fresh
+docker compose --profile reset-hard up
+```
+
+The soft reset is useful during development when you want to clear session/project data without re-running Keycloak/Gitea setup. The hard reset is a full wipe that requires re-initialization.
+
+### 7.7 Profiles
+
+| Profile | Purpose |
+|---------|---------|
+| `infra` | Infrastructure only (DBs, Keycloak, Gitea, MCP servers) |
+| `dev` | Development mode with hot reload (backend via uvicorn --reload, frontend via Vite HMR) |
+| `prod` | Production mode (static builds) |
+| `init` | One-time Keycloak and Gitea setup (creates realm, users, OAuth apps) |
+| `reset-db` | Soft reset: drops application tables, keeps users |
+| `reset-hard` | Hard reset: wipes all volumes, reinitializes everything |
+
+### 7.8 Cross-Platform Support
+
+The Docker Compose setup works on Windows, macOS, and Linux. Shell scripts use LF line endings (enforced via `.gitattributes`) and Dockerfiles include `sed` commands to strip any CRLF characters that may be introduced on Windows.
 
 ---
 
@@ -685,6 +729,7 @@ Optional:
 | `druppie/core/mcp_config.yaml` | MCP server URLs, tool schemas, approval rules, parameter injection |
 | `druppie/agents/definitions/*.yaml` | Agent definitions (prompt, tools, model config) |
 | `druppie/agents/definitions/_common.md` | Shared prompt instructions for all agents |
-| `druppie/docker-compose.yml` | Infrastructure service definitions |
+| `docker-compose.yml` | Infrastructure service definitions (at repository root) |
 | `.env` | Environment variable overrides |
+| `.env.example` | Documented template for environment variables |
 


### PR DESCRIPTION
## Summary
- Update documentation to reflect the new Docker Compose setup (replacing the old bash scripts)
- Add branch policy to CLAUDE.md (use colab-dev, not main)
- Add documentation reminder for PR contributors

## Changes

### CLAUDE.md
- Added "Branch Policy" section explaining that colab-dev is the default branch and main is deprecated
- Added "Documentation Reminder" section listing docs to update on PRs

### docs/TECHNICAL.md
- Updated section 4.1: Database reset commands now use Docker Compose profiles
- Updated section 7.1: docker-compose.yml path changed from druppie/ to root
- Rewrote section 7.5: Development setup with Docker Compose profile commands
- Added section 7.6: Database reset (soft and hard reset options)
- Added section 7.7: Profile reference table
- Added section 7.8: Cross-platform support (Windows line endings fix)
- Updated section 9.2: Configuration files table with new paths

### docs/KNOWN_ISSUES.md
- Removed "Setup / Core Problems" issue (resolved by Docker Compose migration)
- Added smaller "Hardcoded API URLs in Frontend Debug Pages" issue
- Updated Keycloak docker-compose.yml reference path
- Updated last modified date

## Test plan
- [x] Documentation accurately reflects the new Docker Compose setup
- [x] All bash script references removed
- [x] Branch policy clearly stated