### PR TITLE
docs: Update documentation for Docker Compose setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ git checkout -b feature/your-feature-name
 
 When making significant changes, remember to update the `/docs` folder:
 - `docs/FEATURES.md` - New features or feature changes
-- `docs/KNOWN_ISSUES.md` - Known bugs or limitations
+- `docs/BACKLOG.md` - Bugs, technical debt, and improvement ideas
 - `docs/TECHNICAL.md` - Architecture or technical changes
 
 ## Project Overview

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
-# Known Issues
+# Backlog
 
-Known bugs, implementation gaps, and limitations of the Druppie platform.
+Bugs, implementation gaps, technical debt, and improvement ideas for the Druppie platform.
 
 Last updated: 2026-02-05
 
@@ -12,6 +12,7 @@ Last updated: 2026-02-05
 - Dead Code in LLMService.get_llm()
 - Duplicate Tool Descriptions Sent to LLM
 - Inconsistent [COMMON_INSTRUCTIONS] Across Agents
+- Reusable System Prompt Library
 - Cancel/Resume Endpoint Missing on Backend
 - Token/Cost Tracking Half Implemented and Buggy
 - Custom LLM Provider Parsing Sometimes Unreliable
@@ -36,6 +37,7 @@ Last updated: 2026-02-05
 - Skill: MCP Server Integration for Generated Applications
 - Language Matching
 - Prompt Injection Protection
+- Compliance Agent for Input Validation
 
 ---
 
@@ -73,6 +75,22 @@ Last updated: 2026-02-05
 - `_common.md` contains shared rules for agent communication: summary relay format, `done()` tool output format, and workspace state context.
 - **Impact:** Agents without common instructions may not follow the same communication protocol (e.g., inconsistent `done()` summaries), which could affect downstream agents that depend on structured output from previous agents.
 - **Fix needed:** Add `[COMMON_INSTRUCTIONS]` to all agents that participate in the execution workflow (developer, reviewer, tester). Router may be excluded intentionally.
+
+### Reusable System Prompt Library
+
+- **Current state:** Agent system prompts are defined inline in each agent's YAML file, with only `_common.md` as a shared component injected via the `[COMMON_INSTRUCTIONS]` placeholder.
+- **Desired improvement:** Create a library of reusable system prompt fragments in a dedicated folder (e.g., `druppie/agents/prompts/`). Each fragment would be a separate file focusing on a specific capability or behavior (e.g., `code_quality.md`, `security_awareness.md`, `user_communication.md`, `git_workflow.md`). Agent YAML definitions would then specify which prompt files to include:
+  ```yaml
+  system_prompt_includes:
+    - _common.md
+    - code_quality.md
+    - security_awareness.md
+  ```
+- **Benefits:**
+  - Easier to maintain consistent behavior across agents
+  - Can compose agent personalities from building blocks
+  - Reduces duplication of instructions across agent definitions
+  - Makes it easier to update a behavior across all agents that use it
 
 ### Cancel/Resume Endpoint Missing on Backend
 
@@ -251,3 +269,17 @@ Last updated: 2026-02-05
   - Validate and sanitize user inputs before they are injected into prompts
   - Consider input classification: run a lightweight check on user messages to flag potential injection attempts before they reach the agent pipeline
 - **Research needed:** Evaluate existing prompt injection defense techniques (input/output guardrails, instruction hierarchy, canary tokens) and their applicability to a multi-agent pipeline where user input flows through multiple agents.
+
+### Compliance Agent for Input Validation
+
+- **Current state:** User input flows directly to agents without pre-processing or validation. There is no systematic check for malicious content, prompt injection attempts, or policy violations.
+- **Desired improvement:** Implement a lightweight compliance agent that runs on every user input before it reaches the main agent pipeline. This agent would:
+  - **Validate user messages:** Check new chat messages for prompt injection attempts, policy violations, or malicious content before they reach the Router
+  - **Validate HITL responses:** Check user answers to HITL questions before they are passed back to the waiting agent
+  - **Optionally validate tool results:** Check results from MCP tool calls for unexpected content that could be used as an indirect prompt injection vector (e.g., malicious content in a file read from disk)
+- **Implementation considerations:**
+  - Should be fast and cheap (small model, simple prompt) to avoid adding significant latency
+  - Should return a pass/fail decision with optional sanitized content
+  - Could use a classification approach (is this input safe?) rather than generation
+  - Failed validations should block the input and notify the user with a clear explanation
+- **Related to:** Prompt Injection Protection (this is the runtime enforcement mechanism for those defenses)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -269,7 +269,7 @@ Key sections:
 
 - **`mcps`**: Maps MCP server names to the list of tools the agent is allowed to call. An agent cannot call tools not listed here, even if the MCP server exposes them.
 - **`approval_overrides`**: Overrides the global approval configuration for specific tools. For example, `write_file` requires no approval globally, but the Business Analyst definition adds an override requiring `business_analyst` role approval. The Architect similarly overrides it to require `architect` role approval.
-- **`model` / `temperature` / `max_tokens`**: LLM parameters for this agent (note: this section is currently a known issue -- see KNOWN_ISSUES.md).
+- **`model` / `temperature` / `max_tokens`**: LLM parameters for this agent (note: this section is currently a known issue -- see BACKLOG.md).
 - **`max_iterations`**: Safety limit on the agent's tool-calling loop.
 
 ### Hidden Parameter Injection

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -580,7 +580,7 @@ approval_overrides: {}
 
 `druppie/agents/definitions/_common.md` contains instructions shared across all agents (summary relay format, `done()` output format, workspace state context). The `[COMMON_INSTRUCTIONS]` placeholder in an agent's system prompt is replaced with this content at runtime.
 
-**Note:** Currently only 4 agents include the `[COMMON_INSTRUCTIONS]` placeholder (deployer, architect, business_analyst, planner). The developer, reviewer, tester, and router agents do not, which can lead to inconsistent agent communication -- see KNOWN_ISSUES.md.
+**Note:** Currently only 4 agents include the `[COMMON_INSTRUCTIONS]` placeholder (deployer, architect, business_analyst, planner). The developer, reviewer, tester, and router agents do not, which can lead to inconsistent agent communication -- see BACKLOG.md.
 
 ### 8.3 Agent Runtime Loop
 
@@ -603,7 +603,7 @@ The agent runtime (`druppie/agents/runtime.py`) implements a tool-calling loop:
 
 If the LLM responds without tool calls, the runtime sends a correction message and retries. Agents can only interact through tool calls -- they cannot produce raw text output.
 
-**Note:** Tool information is currently sent to the LLM twice per request: as human-readable text in the system prompt (step 1) and as structured OpenAI function schemas in the API `tools` parameter (step 3). The system prompt text carries extra context the schema cannot (e.g., approval requirements), but tool name, description, and parameters are fully duplicated, wasting tokens on every call -- see KNOWN_ISSUES.md.
+**Note:** Tool information is currently sent to the LLM twice per request: as human-readable text in the system prompt (step 1) and as structured OpenAI function schemas in the API `tools` parameter (step 3). The system prompt text carries extra context the schema cannot (e.g., approval requirements), but tool name, description, and parameters are fully duplicated, wasting tokens on every call -- see BACKLOG.md.
 
 ### 8.4 Summary Relay Mechanism
 


### PR DESCRIPTION
Updated documentation for https://github.com/nuno-git/druppie-fork/pull/7

## Changes

- Updated `docs/TECHNICAL.md` with Docker Compose commands and profiles (replacing old bash script references)
- Updated `CLAUDE.md` with branch policy (use `colab-dev`, not `main`) and documentation reminder
- Renamed `docs/KNOWN_ISSUES.md` to `docs/BACKLOG.md` as it contains not only issues but also improvement ideas and technical debt
- Added new backlog items for:
  - **Reusable System Prompt Library** - a folder of composable prompt fragments that agents can include via YAML configuration
  - **Compliance Agent for Input Validation** - a lightweight agent to validate user messages, HITL responses, and optionally tool results against prompt injection and policy violations
- Removed resolved issues (setup script problems, hardcoded API URLs)
- Updated all cross-references to point to `BACKLOG.md`