### PR TITLE
Fix BA to always use multiple choice and load skill before asking

### DIFF
--- a/druppie/agents/definitions/business_analyst.yaml
+++ b/druppie/agents/definitions/business_analyst.yaml
@@ -98,12 +98,15 @@ system_prompt: |
   QUESTION TOOL SELECTION
   =============================================================================
 
-  **Default: hitl_ask_multiple_choice_question.** When in doubt, prefer this.
+  **ALWAYS use hitl_ask_multiple_choice_question.** This is not a preference —
+  it is the rule. Every question you ask MUST be multiple choice. Think of the
+  most likely answers and offer them as choices. 
 
-  **Exception: hitl_ask_question.** Use only for genuinely open-ended questions
-  where you cannot suggest answers (e.g., "What is your organization's name?"),
-  or when providing information rather than asking (advice, rejection reasons,
-  out-of-scope responses).
+  **The ONLY exceptions where you may use hitl_ask_question (free-text):**
+  - Asking for a proper name you cannot guess (e.g., "What is your organization's name?")
+  - Providing information rather than asking (advice, rejection reasons, out-of-scope responses)
+
+  If you are unsure whether a question can be multiple choice: **it can.**
 
   =============================================================================
   DRUPPIE WORKFLOW MODES

--- a/druppie/agents/loop.py
+++ b/druppie/agents/loop.py
@@ -151,7 +151,9 @@ class AgentLoop:
             f"{s.name} ({s.description})" for s in available
         )
         description = (
-            f"Invoke a skill to get its instructions. "
+            f"Invoke a skill to load its instructions. "
+            f"IMPORTANT: Call this BEFORE your first user-facing question "
+            f"to load question guidelines. "
             f"Available: {skill_descriptions}"
         )
 

--- a/druppie/skills/asking-user-friendly-questions/SKILL.md
+++ b/druppie/skills/asking-user-friendly-questions/SKILL.md
@@ -1,33 +1,25 @@
 ---
 name: asking-user-friendly-questions
 description: >
-  General guidelines for asking user-friendly questions. Covers tool
-  selection, language, and tone.
+  Guidelines for asking short, clear questions via HITL tools.
 ---
 
 # Asking User-Friendly Questions
 
-## Tool Selection
+## Rules
 
+1. **One question per tool call** — never batch multiple questions together
+2. **Keep it short** — max 1-2 sentences. Front-load the core ask, cut filler
+3. **Plain language** — no jargon, no technical terms
 **hitl_ask_multiple_choice_question** — presents the user with a set of
 predefined options to choose from.
 
 **hitl_ask_question** — presents the user with an open-ended text input
 to respond freely.
 
-## How to Ask
-
-- **One question at a time** — never batch multiple questions together
-- **Plain language** — no jargon; prefer everyday words over technical
-  terms
-- **Explain why** — briefly state why the answer matters
-- **Offer defaults** — if the user is unsure, suggest a sensible default
-  so the conversation keeps moving
-- **Keep it short** — 1-3 sentences per question, front-load the core ask
 
 ## Tone
 
-- Professional but approachable — curious, non-judgmental
-- Acknowledge what the user said before redirecting
-- Summarize understanding frequently so the user can confirm or correct
+- Professional but approachable
+- Acknowledge what the user said before moving on
 - Never propose unsolicited actions — ask first


### PR DESCRIPTION
- BA YAML: enforce hitl_ask_multiple_choice_question as the rule, not preference
- SKILL.md: concise guidelines — one question per call, keep it short, plain language
- loop.py: invoke_skill description tells LLM to load skills before first question