### PR TITLE
feat: sandbox retry observability and frontend improvements

### DIFF
--- a/druppie/api/routes/sandbox.py
+++ b/druppie/api/routes/sandbox.py
@@ -15,6 +15,7 @@ import hashlib
 import hmac
 import json
 import os
+from collections import Counter
 from datetime import datetime, timezone
 from uuid import UUID
 
@@ -181,6 +182,29 @@ def _extract_agent_output(events: list[dict]) -> str:
                 parts.append((ts, content))
     parts.sort(key=lambda x: x[0])
     return "\n".join(c for _, c in parts).strip()
+
+
+def _extract_error_info(events: list[dict]) -> dict:
+    """Extract error details from error, execution_complete, and tool_result events."""
+    errors = []
+    for event in events:
+        event_type = event.get("type")
+        data = event.get("data") or {}
+        if event_type == "error":
+            err = data.get("error", "")
+            if err:
+                errors.append(err)
+        elif event_type == "execution_complete" and not data.get("success", True):
+            err = data.get("error", "")
+            if err and err not in errors:
+                errors.append(f"Execution failed: {err}")
+        elif event_type == "tool_result":
+            err = data.get("error", "")
+            if err:
+                call_id = data.get("callId", "unknown")
+                errors.append(f"Tool {call_id}: {err}")
+    summary = errors[0][:2000] if errors else ""
+    return {"errors": errors[:10], "summary": summary}
 
 
 async def _retry_sandbox_with_next_model(
@@ -387,6 +411,7 @@ async def sandbox_complete_webhook(
     changed_files = []
     agent_output = ""
     event_count = 0
+    error_info = {"errors": [], "summary": ""}
 
     try:
         token = generate_control_plane_token(SANDBOX_API_SECRET)
@@ -401,6 +426,15 @@ async def sandbox_complete_webhook(
                 event_count = len(events)
                 changed_files = _extract_changed_files(events)
                 agent_output = _extract_agent_output(events)
+                error_info = _extract_error_info(events)
+
+                type_counts = Counter(e.get("type") for e in events)
+                logger.info(
+                    "sandbox_webhook_events_fetched",
+                    sandbox_session_id=sandbox_session_id,
+                    event_count=event_count,
+                    type_distribution=dict(type_counts),
+                )
     except Exception as e:
         logger.warning("sandbox_webhook_event_fetch_failed", error=str(e))
 
@@ -426,9 +460,22 @@ async def sandbox_complete_webhook(
             sandbox_mapping, sandbox_mapping.tool_call_id, db
         )
         if retry_initiated:
+            # Update tool call result so the frontend can follow the new sandbox
+            new_sandbox = sandbox_repo.get_latest_by_tool_call_id(sandbox_mapping.tool_call_id)
+            if new_sandbox:
+                execution_repo.update_tool_call(
+                    tool_call.id,
+                    result={
+                        "sandbox_session_id": new_sandbox.sandbox_session_id,
+                        "status": "retrying",
+                        "retry_count": (sandbox_mapping.model_chain_index or 0) + 1,
+                    },
+                    sandbox_waiting_at=datetime.now(timezone.utc),
+                )
             logger.info(
                 "sandbox_webhook_retry_initiated",
                 sandbox_session_id=sandbox_session_id,
+                new_sandbox_session_id=new_sandbox.sandbox_session_id if new_sandbox else None,
                 tool_call_id=str(sandbox_mapping.tool_call_id),
             )
             # Don't complete the tool call — keep it in WAITING_SANDBOX state
@@ -444,6 +491,8 @@ async def sandbox_complete_webhook(
         "event_count": event_count,
         "changed_files": changed_files,
         "agent_output": agent_output[-5000:] if agent_output else "",
+        "error_details": error_info["errors"],
+        "error_summary": error_info["summary"],
     }
 
     # Complete the tool call
@@ -451,6 +500,7 @@ async def sandbox_complete_webhook(
         tool_call.id,
         status=ToolCallStatus.COMPLETED if body.success else ToolCallStatus.FAILED,
         result=result,
+        error=error_info["summary"] if not body.success else None,
     )
     db.commit()
 
@@ -612,11 +662,18 @@ async def sandbox_watchdog_loop() -> None:
                                     await delete_sandbox_git_user(sandbox_mapping.git_user_id)
                                 except Exception as e:
                                     logger.warning("sandbox_watchdog_gitea_cleanup_failed", error=str(e))
-                            # Reset sandbox_waiting_at so watchdog doesn't re-trigger immediately
-                            execution_repo.update_tool_call(
-                                tc.id,
-                                sandbox_waiting_at=datetime.now(timezone.utc),
-                            )
+                            # Update tool call with new sandbox ID + reset watchdog timer
+                            new_sandbox = sandbox_repo.get_latest_by_tool_call_id(tc.id)
+                            update_kwargs = {
+                                "sandbox_waiting_at": datetime.now(timezone.utc),
+                            }
+                            if new_sandbox:
+                                update_kwargs["result"] = {
+                                    "sandbox_session_id": new_sandbox.sandbox_session_id,
+                                    "status": "retrying",
+                                    "retry_count": (sandbox_mapping.model_chain_index or 0) + 1,
+                                }
+                            execution_repo.update_tool_call(tc.id, **update_kwargs)
                             db.commit()
                             logger.info(
                                 "sandbox_watchdog_retry_initiated",

--- a/druppie/repositories/sandbox_session_repository.py
+++ b/druppie/repositories/sandbox_session_repository.py
@@ -75,6 +75,15 @@ class SandboxSessionRepository(BaseRepository):
             .first()
         )
 
+    def get_latest_by_tool_call_id(self, tool_call_id: UUID) -> SandboxSession | None:
+        """Look up the most recent sandbox session for a tool call (after retries)."""
+        return (
+            self.db.query(SandboxSession)
+            .filter_by(tool_call_id=tool_call_id)
+            .order_by(SandboxSession.created_at.desc())
+            .first()
+        )
+
     def mark_completed(self, sandbox_session_id: str) -> None:
         """Mark a sandbox session as completed."""
         session = self.get_by_sandbox_id(sandbox_session_id)

--- a/frontend/src/components/chat/ChatHelpers.jsx
+++ b/frontend/src/components/chat/ChatHelpers.jsx
@@ -187,52 +187,6 @@ export const findPendingQuestion = (timeline) => {
   return null
 }
 
-// --- Extract test results from agent run's tool calls ---
-
-export const extractTestResults = (agentRun) => {
-  const results = []
-  agentRun?.llm_calls?.forEach((llm) => {
-    llm.tool_calls?.forEach((tc) => {
-      if (tc.tool_name === 'run_tests' && tc.status === 'completed' && tc.result) {
-        try {
-          const raw = typeof tc.result === 'string' ? JSON.parse(tc.result) : tc.result
-          if (raw) results.push(raw)
-        } catch { /* malformed result JSON — skip */ }
-      }
-      // Also extract from test_report builtin tool calls
-      if (tc.tool_name === 'test_report' && tc.status === 'completed' && tc.result) {
-        try {
-          const raw = typeof tc.result === 'string' ? JSON.parse(tc.result) : tc.result
-          // Convert test_report format to run_tests format for TestResultCard
-          if (raw && tc.arguments) {
-            const args = typeof tc.arguments === 'string' ? JSON.parse(tc.arguments) : tc.arguments
-            const passed = parseInt(args.passed_count) || 0
-            const failed = parseInt(args.failed_count) || 0
-            const testResult = {
-              success: args.tests_passed || false,
-              framework: 'unknown',
-              exit_code: args.tests_passed ? 0 : 1,
-              stdout: args.summary || '',
-              stderr: '',
-              elapsed_seconds: null,
-              results: {
-                total: passed + failed,
-                passed: passed,
-                failed: failed,
-                skipped: 0,
-                failed_tests: [],
-              },
-              coverage: null,
-            }
-            results.push(testResult)
-          }
-        } catch { /* malformed JSON — skip */ }
-      }
-    })
-  })
-  return results
-}
-
 // --- Extract per-test error messages from test output ---
 
 export const extractTestErrors = (stdout, stderr, framework, failedTestNames) => {
@@ -265,7 +219,7 @@ export const extractTestErrors = (stdout, stderr, framework, failedTestNames) =>
           }
         }
         // Fallback: scan for FAILED lines
-        const failedLine = output.match(new RegExp(`FAILED.*${shortName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}.*?-\\s*(.+)$`, 'm'))
+        const failedLine = output.match(new RegExp(`FAILED.*${shortName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}.*?\\s-\\s(.+)$`, 'm'))
         if (failedLine) {
           errors[testName] = failedLine[1].trim()
         }
@@ -274,7 +228,7 @@ export const extractTestErrors = (stdout, stderr, framework, failedTestNames) =>
       // No FAILURES section, try FAILED summary lines
       for (const testName of failedTestNames) {
         const shortName = testName.split('::').pop()
-        const failedLine = output.match(new RegExp(`FAILED.*${shortName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}.*?-\\s*(.+)$`, 'm'))
+        const failedLine = output.match(new RegExp(`FAILED.*${shortName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}.*?\\s-\\s(.+)$`, 'm'))
         if (failedLine) {
           errors[testName] = failedLine[1].trim()
         }
@@ -315,7 +269,7 @@ export const extractSandboxResults = (agentRun) => {
   const results = []
   agentRun?.llm_calls?.forEach((llm) => {
     llm.tool_calls?.forEach((tc) => {
-      if (tc.tool_name === 'execute_coding_task' && tc.status !== 'waiting_sandbox' && tc.status !== 'pending' && tc.result) {
+      if (tc.tool_name === 'execute_coding_task' && tc.status !== 'waiting_sandbox' && tc.status !== 'retrying' && tc.status !== 'pending' && tc.result) {
         let raw
         try {
           raw = typeof tc.result === 'string' ? JSON.parse(tc.result) : tc.result
@@ -345,7 +299,7 @@ export const extractSurfacedFileWrites = (agentRun) => {
       const args = tc.arguments || {}
 
       if (toolName.includes('write_file') && !toolName.includes('batch')) {
-        if (args.path && args.content) {
+        if (args.path && args.content && !args.path.endsWith('builder_plan.md')) {
           files.push({ path: args.path, content: args.content })
         }
       } else if (toolName.includes('batch_write_files')) {
@@ -400,11 +354,18 @@ export const extractOrderedItems = (agentRun, hasFollowingMessage) => {
         } catch { /* skip */ }
       }
       // Sandbox results
-      if (tc.tool_name === 'execute_coding_task' && tc.status !== 'waiting_sandbox' && tc.status !== 'pending' && tc.result) {
+      if (tc.tool_name === 'execute_coding_task' && tc.status !== 'waiting_sandbox' && tc.status !== 'retrying' && tc.status !== 'pending' && tc.result) {
         try {
           const raw = typeof tc.result === 'string' ? JSON.parse(tc.result) : tc.result
           if (raw?.sandbox_session_id) items.push({ type: 'sandbox', data: raw })
         } catch { /* skip */ }
+      }
+      // Builder plan (builder_planner writing builder_plan.md)
+      if (tc.tool_name?.includes('write_file') && !tc.tool_name?.includes('batch') && tc.status === 'completed') {
+        const args = tc.arguments || {}
+        if (args.path?.endsWith('builder_plan.md') && args.content) {
+          items.push({ type: 'plan', data: { content: args.content } })
+        }
       }
     })
   })

--- a/frontend/src/components/chat/PlanCard.jsx
+++ b/frontend/src/components/chat/PlanCard.jsx
@@ -1,0 +1,90 @@
+/**
+ * PlanCard - Displays the builder_plan.md created by the builder_planner agent.
+ *
+ * Props: { content: string } — the raw markdown content of builder_plan.md
+ */
+
+import { useState, useMemo } from 'react'
+import { ClipboardList, ChevronDown, ChevronRight } from 'lucide-react'
+
+/** Parse markdown into top-level ## sections */
+const parseSections = (markdown) => {
+  const sections = []
+  const lines = markdown.split('\n')
+  let current = null
+
+  for (const line of lines) {
+    const match = line.match(/^##\s+(.+)/)
+    if (match) {
+      if (current) sections.push(current)
+      current = { title: match[1].trim(), lines: [] }
+    } else if (current) {
+      current.lines.push(line)
+    }
+  }
+  if (current) sections.push(current)
+
+  return sections.map((s) => ({
+    title: s.title,
+    body: s.lines.join('\n').trim(),
+  }))
+}
+
+const PlanCard = ({ content }) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const sections = useMemo(() => content ? parseSections(content) : [], [content])
+
+  if (!sections.length) return null
+
+  return (
+    <div className="rounded-xl border bg-gray-50 border-gray-200 border-l-4 border-l-indigo-400 transition-all">
+      {/* Header */}
+      <div className="px-4 pt-3 pb-2">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <ClipboardList className="w-4 h-4 text-indigo-500" />
+            <span className="text-sm font-medium text-gray-800">
+              Builder Plan
+            </span>
+          </div>
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            {isExpanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+            {isExpanded ? 'Collapse' : 'Details'}
+          </button>
+        </div>
+
+        {/* Summary line: section names */}
+        <div className="mt-1.5 flex items-center gap-1 text-xs text-gray-500 flex-wrap">
+          {sections.map((s, i) => (
+            <span key={i} className="flex items-center gap-1">
+              {i > 0 && <span className="text-gray-300">&middot;</span>}
+              <span>{s.title}</span>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Expanded: section contents */}
+      {isExpanded && (
+        <div className="px-4 pb-3 border-t border-gray-200">
+          <div className="mt-2 space-y-3">
+            {sections.map((s, i) => (
+              <div key={i}>
+                <h4 className="text-xs font-semibold text-gray-700">{s.title}</h4>
+                <pre className="mt-1 text-xs text-gray-500 whitespace-pre-wrap break-words font-sans leading-relaxed">
+                  {s.body}
+                </pre>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default PlanCard

--- a/frontend/src/components/chat/SandboxEventCard.jsx
+++ b/frontend/src/components/chat/SandboxEventCard.jsx
@@ -657,6 +657,13 @@ const SandboxSessionSection = ({ result }) => {
         </div>
       )}
 
+      {/* Error summary for failed sandboxes */}
+      {!result.success && result.error_summary && (
+        <div className="text-xs text-red-700 bg-red-50 border border-red-200 rounded px-3 py-2 mb-2">
+          <span className="font-medium">Error: </span>{result.error_summary}
+        </div>
+      )}
+
       {/* Structured summary */}
       {summary && (
         <pre className="text-xs text-gray-600 bg-gray-50 rounded p-2 mb-2 whitespace-pre-wrap font-mono">

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -28,6 +28,7 @@ import {
   findPendingQuestion,
 } from './ChatHelpers'
 import TestResultCard from './TestResultCard'
+import PlanCard from './PlanCard'
 import SandboxEventCard, {
   processEvents,
   groupBySubagent,
@@ -354,6 +355,13 @@ const AgentRunItem = ({ run, timelineIndex, sessionId, hasFollowingMessage }) =>
             </div>
           )
         }
+        if (item.type === 'plan') {
+          return (
+            <div key={i} className="mt-2">
+              <PlanCard content={item.data.content} />
+            </div>
+          )
+        }
         return null
       })}
     </div>
@@ -444,7 +452,7 @@ const findWaitingSandboxId = (timeline) => {
     if (entry.type !== 'agent_run' || !entry.agent_run) continue
     for (const llm of (entry.agent_run.llm_calls || [])) {
       for (const tc of (llm.tool_calls || [])) {
-        if (tc.tool_name === 'execute_coding_task' && tc.status === 'waiting_sandbox') {
+        if (tc.tool_name === 'execute_coding_task' && (tc.status === 'waiting_sandbox' || tc.status === 'retrying')) {
           let result = tc.result
           if (typeof result === 'string') {
             try { result = JSON.parse(result) } catch { continue }

--- a/frontend/src/components/chat/TestResultCard.jsx
+++ b/frontend/src/components/chat/TestResultCard.jsx
@@ -17,7 +17,12 @@ import {
 import { extractTestErrors } from './ChatHelpers'
 
 const formatFramework = (fw) => {
-  const map = { pytest: 'Pytest', vitest: 'Vitest', jest: 'Jest', playwright: 'Playwright', gotest: 'Go Test', shell: 'Shell' }
+  const map = {
+    pytest: 'Pytest', vitest: 'Vitest', jest: 'Jest', playwright: 'Playwright',
+    gotest: 'Go Test', go: 'Go Test', shell: 'Shell',
+    mocha: 'Mocha', cargo: 'Cargo Test', rspec: 'RSpec',
+    maven: 'Maven', gradle: 'Gradle',
+  }
   return map[fw?.toLowerCase()] || fw || 'Tests'
 }
 
@@ -26,12 +31,18 @@ const formatTime = (sec) => {
   return sec >= 60 ? `${(sec / 60).toFixed(1)}m` : `${sec.toFixed(1)}s`
 }
 
+/** Strip ANSI escape codes from text (raw stdout/stderr may contain color codes) */
+const stripAnsi = (text) => text.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
+
 /** Client-side fallback: parse test counts from stdout/stderr when server-side parsing returned zeros */
 const parseResultsFallback = (result) => {
   const res = result.results || {}
   if ((res.total || 0) > 0) return res // Server-side parsing worked
 
-  const output = (result.stdout || '') + '\n' + (result.stderr || '')
+  // If server detected a config error, trust its zero counts — tests didn't actually run
+  if (result.config_error) return res
+
+  const output = stripAnsi((result.stdout || '') + '\n' + (result.stderr || ''))
   if (!output.trim()) return res
 
   let passed = 0, failed = 0, skipped = 0
@@ -60,9 +71,27 @@ const parseResultsFallback = (result) => {
     }
   }
 
+  // Pytest: "1 failed, 3 passed in 0.42s" with === border
+  const hasPytestFooter = output.match(/in \d[\d.]*s\s*={3,}/)
+  if (hasPytestFooter) {
+    const pm = output.match(/(\d+)\s+passed/)
+    const fm = output.match(/(\d+)\s+failed/)
+    const sm = output.match(/(\d+)\s+skipped/)
+    const em = output.match(/(\d+)\s+error/)
+    if (pm || fm) {
+      const p = parseInt(pm?.[1] || '0')
+      const f = parseInt(fm?.[1] || '0') + parseInt(em?.[1] || '0')
+      const s = parseInt(sm?.[1] || '0')
+      return { ...res, passed: p, failed: f, skipped: s, total: p + f + s }
+    }
+  }
+
   // Generic: "N passed", "N failed"
-  const passedM = output.match(/(\d+)\s+(?:passing|passed)/)
-  const failedM = output.match(/(\d+)\s+(?:failing|failed)/)
+  // Use multiline per-line matching to skip "Test Suites:" lines (those count suites, not tests)
+  const lines = output.split('\n').filter(l => !l.match(/Test Suites:/))
+  const filteredOutput = lines.join('\n')
+  const passedM = filteredOutput.match(/(\d+)\s+(?:passing|passed)/)
+  const failedM = filteredOutput.match(/(\d+)\s+(?:failing|failed)/)
   const skippedM = output.match(/(\d+)\s+(?:pending|skipped)/)
   if (passedM || failedM) {
     passed = parseInt(passedM?.[1] || '0')
@@ -83,7 +112,7 @@ const TestRunSection = ({ result }) => {
   const failed = r.failed || 0
   const total = r.total || 0
   const failedNames = r.failed_tests || []
-  const isPass = result.success && result.exit_code === 0 && failed === 0
+  const isPass = result.exit_code === 0 && failed === 0
   const errors = extractTestErrors(result.stdout, result.stderr, result.framework, failedNames)
 
   // Detect if we couldn't parse any test data
@@ -107,10 +136,12 @@ const TestRunSection = ({ result }) => {
         )}
         {noCounts ? (
           <span className="text-amber-600 italic">
-            {hasOutput ? 'Unable to parse results' : 'No test output'}
-            {result.exit_code && result.exit_code !== 0 && (
-              <span className="text-gray-500"> (exit {result.exit_code})</span>
-            )}
+            {result.config_error ? result.config_error
+              : !hasOutput ? 'No test output'
+              : result.exit_code === 5 && result.framework === 'pytest' ? 'No tests collected'
+              : result.exit_code > 1 ? `Framework error (exit ${result.exit_code})`
+              : result.exit_code === 1 ? 'Tests failed (counts unavailable)'
+              : 'Unable to parse results'}
           </span>
         ) : (
           <span className="text-gray-500">{passed}/{total} passed</span>
@@ -188,23 +219,29 @@ const TestResultCard = ({ testResults, isRunning }) => {
 
   // Detect various failure modes
   const noCounts = totalTests === 0 && totalPassed === 0 && totalFailed === 0
-  const testRunFailed = noCounts && !lastRun.success
-  const allPass = lastRun.success && lastRun.exit_code === 0 && totalFailed === 0 && !testRunFailed
+  const testRunFailed = noCounts && lastRun.exit_code !== 0
+  const allPass = lastRun.exit_code === 0 && totalFailed === 0 && !testRunFailed
 
   const iterations = testResults.length
   const hasOutput = lastRun.stdout || lastRun.stderr
 
   // Build inline summary parts
   const summaryParts = []
-  if (testRunFailed) {
+  if (testRunFailed && lastRun.config_error) {
+    summaryParts.push(lastRun.config_error)
+  } else if (testRunFailed && !hasOutput) {
+    summaryParts.push('No test output')
+  } else if (testRunFailed && lastRun.exit_code === 5 && lastRun.framework === 'pytest') {
+    summaryParts.push('No tests collected')
+  } else if (testRunFailed && lastRun.exit_code > 1) {
+    summaryParts.push(`Framework error (exit ${lastRun.exit_code})`)
+  } else if (testRunFailed) {
     summaryParts.push('Test run failed')
-    if (lastRun.exit_code) summaryParts.push(`exit ${lastRun.exit_code}`)
+  } else if (noCounts && hasOutput && lastRun.exit_code === 0) {
+    summaryParts.push('Unable to parse counts (likely passed)')
   } else if (noCounts && hasOutput) {
-    // We have output but couldn't parse counts
-    summaryParts.push('Results parsing failed')
-    if (lastRun.exit_code && lastRun.exit_code !== 0) summaryParts.push(`exit ${lastRun.exit_code}`)
+    summaryParts.push('Unable to parse counts')
   } else if (noCounts) {
-    // No output at all
     summaryParts.push('No test output')
   } else {
     // Normal case: we have counts


### PR DESCRIPTION
## Summary
- Extract error details from sandbox events and surface them in the UI
- Track sandbox retries with new `get_latest_by_tool_call_id` repo method
- Better test result error categorization (config errors, exit code 5, framework errors)
- Strip ANSI codes in frontend test output parsing; improved pytest fallback
- Add PlanCard component to display `builder_plan.md` content
- Handle `retrying` status for sandbox tool calls in frontend

## Test plan
- [ ] Trigger a sandbox failure and verify error summary appears in SandboxEventCard
- [ ] Trigger sandbox retry and verify frontend follows the new sandbox session
- [ ] Verify test results with ANSI output display correctly
- [ ] Verify PlanCard renders builder_plan.md sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)