### PR TITLE
feat: add Deepseek LLM provider support

### DIFF
--- a/druppie/agents/definitions/llm_profiles.yaml
+++ b/druppie/agents/definitions/llm_profiles.yaml
@@ -12,6 +12,8 @@ profiles:
       model: Qwen/Qwen2.5-72B-Instruct
     - provider: zai
       model: glm-4.7
+    - provider: deepseek
+      model: deepseek-chat
     - provider: ollama
       model: gpt-oss:120b
     - provider: azure_foundry
@@ -20,12 +22,14 @@ profiles:
   cheap:
     - provider: deepinfra
       model: Qwen/Qwen2.5-72B-Instruct
+    - provider: deepseek
+      model: deepseek-chat
+    - provider: zai
+      model: glm-4.7
     - provider: ollama
       model: gpt-oss:20b
     - provider: azure_foundry
       model: GPT-5-MINI
-    - provider: zai
-      model: glm-4.7
 
 
   ollama:

--- a/druppie/llm/litellm_provider.py
+++ b/druppie/llm/litellm_provider.py
@@ -198,6 +198,7 @@ PROVIDER_CONFIGS = {
         "model_env": "DEEPSEEK_MODEL",
         "base_url_env": "DEEPSEEK_BASE_URL",
         "default_base_url": "https://api.deepseek.com/v1",
+        "max_tokens_limit": 8192,
     },
     "azure_foundry": {
         "prefix": "openai",  # OpenAI-compatible API
@@ -285,6 +286,9 @@ class ChatLiteLLM(BaseLLM):
         # Some providers (e.g. Azure OpenAI) require max_completion_tokens instead of max_tokens
         self._use_max_completion_tokens = config.get("use_max_completion_tokens", False)
 
+        # Provider-specific max_tokens ceiling (e.g. Deepseek caps at 8192)
+        self._max_tokens_limit = config.get("max_tokens_limit", 16384)
+
         # SSL verification (disabled for self-signed certs, e.g. Ollama)
         # Set globally on litellm — the per-call ssl_verify kwarg has known bugs
         self._ssl_verify = config.get("ssl_verify", True)
@@ -355,7 +359,7 @@ class ChatLiteLLM(BaseLLM):
     def _build_kwargs(self, messages, tools, max_tokens_override=None):
         """Build common kwargs for LiteLLM completion calls."""
         effective_tools = tools or self._bound_tools
-        effective_max_tokens = min(max_tokens_override or self.max_tokens, 16384)
+        effective_max_tokens = min(max_tokens_override or self.max_tokens, self._max_tokens_limit)
 
         token_param = "max_completion_tokens" if self._use_max_completion_tokens else "max_tokens"
         kwargs = {

--- a/druppie/llm/service.py
+++ b/druppie/llm/service.py
@@ -42,6 +42,7 @@ class LLMService:
     PROVIDERS = {
         "zai": "ZAI_API_KEY",
         "deepinfra": "DEEPINFRA_API_KEY",
+        "deepseek": "DEEPSEEK_API_KEY",
         "azure_foundry": "FOUNDRY_API_KEY",
         "ollama": None,
     }
@@ -136,7 +137,8 @@ class LLMService:
 
         if resolved.fallback_provider:
             fallback_key_env = self.PROVIDERS.get(resolved.fallback_provider)
-            if fallback_key_env and os.getenv(fallback_key_env):
+            # Allow fallback if: key env is None (optional, e.g. Ollama) or key is set
+            if fallback_key_env is None or os.getenv(fallback_key_env):
                 fallback = ChatLiteLLM(
                     provider=resolved.fallback_provider,
                     model=resolved.fallback_model,


### PR DESCRIPTION
## Summary
- Add `deepseek-chat` to default and cheap LLM profile chains
- Register `DEEPSEEK_API_KEY` in provider registry
- Add configurable `max_tokens_limit` (Deepseek caps at 8192)
- Fix fallback provider logic for providers without required API key env vars

## Test plan
- [ ] Set `DEEPSEEK_API_KEY` and verify Deepseek provider is used in the chain
- [ ] Verify max_tokens is capped at 8192 for Deepseek calls
- [ ] Verify fallback works when Deepseek key is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)