### PR TITLE
fix: correct MCP coding server URL and make CPU limit optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,8 +113,15 @@ INTERNAL_API_KEY=druppie-internal-secret-key
 # MCP Microservices toggle
 USE_MCP_MICROSERVICES=true
 
-# MCP Coding Server URL (internal Docker network URL)
-MCP_CODING_URL=http://mcp-coding:9001
+# MCP Server URLs (internal Docker network URLs)
+# These match the service names in docker-compose.yml (module-*)
+# Only override if you're running MCP servers outside Docker Compose
+# MCP_CODING_URL=http://module-coding:9001
+# MCP_DOCKER_URL=http://module-docker:9002
+# MCP_FILESEARCH_URL=http://module-filesearch:9004
+# MCP_WEB_URL=http://module-web:9005
+# MCP_ARCHIMATE_URL=http://module-archimate:9006
+# MCP_REGISTRY_URL=http://module-registry:9007
 
 # =============================================================================
 # PORT CONFIGURATION (optional - defaults shown)

--- a/.env.example
+++ b/.env.example
@@ -113,16 +113,6 @@ INTERNAL_API_KEY=druppie-internal-secret-key
 # MCP Microservices toggle
 USE_MCP_MICROSERVICES=true
 
-# MCP Server URLs (internal Docker network URLs)
-# These match the service names in docker-compose.yml (module-*)
-# Only override if you're running MCP servers outside Docker Compose
-# MCP_CODING_URL=http://module-coding:9001
-# MCP_DOCKER_URL=http://module-docker:9002
-# MCP_FILESEARCH_URL=http://module-filesearch:9004
-# MCP_WEB_URL=http://module-web:9005
-# MCP_ARCHIMATE_URL=http://module-archimate:9006
-# MCP_REGISTRY_URL=http://module-registry:9007
-
 # =============================================================================
 # PORT CONFIGURATION (optional - defaults shown)
 # =============================================================================

--- a/background-agents/packages/local-sandbox-manager/src/docker_manager.py
+++ b/background-agents/packages/local-sandbox-manager/src/docker_manager.py
@@ -95,7 +95,11 @@ class DockerContainerManager:
             "--cgroupns=host",         # Share host cgroup namespace (required for DinD on cgroup v2)
             # Resource limits
             f"--memory={config.DOCKER_MEMORY_LIMIT}",
-            f"--cpus={config.DOCKER_CPU_LIMIT}",
+            *(
+                [f"--cpus={config.DOCKER_CPU_LIMIT}"]
+                if config.DOCKER_CPU_LIMIT and config.DOCKER_CPU_LIMIT != "0"
+                else []
+            ),
             f"--pids-limit={config.DOCKER_PIDS_LIMIT}",
             # Tmpfs for /tmp (faster I/O, auto-cleaned)
             "--tmpfs=/tmp:rw,exec,size=2g",


### PR DESCRIPTION
## Summary

**Root cause:** `.env.example` had `MCP_CODING_URL=http://mcp-coding:9001` — a stale hostname from before the MCP servers were renamed to modules. The Docker service is `module-coding`, not `mcp-coding`. Anyone who copied `.env.example` to `.env` got a broken coding MCP server.

**Impact:** The tool registry silently failed to load ALL coding tools (`make_design`, `read_file`, `write_file`, `list_dir`, `run_git`, etc.) at backend startup. This meant:
- BA agent had 7 tools instead of 11 — could not call `coding_make_design` to write `functional_design.md`
- Architect agent had no `coding_make_design` — fell back to `execute_coding_task` (sandbox) for everything
- No agent could read project files or commit to git via MCP tools

The agents appeared to "misbehave" but they were actually working correctly with the tools they had — the tools just weren't loaded.

**Fixes:**
1. **`.env.example`**: Removed the MCP URL section entirely. The correct defaults are in `docker-compose.yml` (`http://module-*:port`) and should never be overridden. This prevents the bug from recurring.
2. **`docker_manager.py`**: Made `--cpus` flag conditional — kernels without CPU CFS scheduler support fail with "NanoCPUs can not be set". Setting `SANDBOX_CPU_LIMIT=0` now skips the flag.

## Test plan
- [x] Fresh backend start → logs show `loaded_mcp_tools count=18 server=coding`
- [x] New chat session → BA has 11 tools (was 7)
- [x] BA can call `coding_make_design` to write `functional_design.md`
- [ ] Set `SANDBOX_CPU_LIMIT=0` → sandbox containers start without CPU limit errors