### PR TITLE
fix: support rootless Docker in reset-hard script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -739,6 +739,8 @@ services:
     network_mode: host
     environment:
       COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-cleaner-druppie-docker-compose}
+      # Host project directory for Docker volume mount resolution (required for rootless Docker)
+      HOST_PROJECT_DIR: ${PWD}
       # Init container env vars for re-initialization (use localhost since we're on host network)
       KEYCLOAK_URL: http://localhost:${KEYCLOAK_PORT:-8180}
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}

--- a/scripts/reset-hard.sh
+++ b/scripts/reset-hard.sh
@@ -18,9 +18,16 @@ echo ""
 
 cd /project
 
+# Use host project directory for Docker volume mount resolution (required for rootless Docker).
+# When this script runs inside a container, relative paths in docker-compose.yml resolve to
+# /project/... on the host, which doesn't exist. --project-directory tells Docker to resolve
+# paths relative to the actual host directory instead.
+PROJECT_DIR="${HOST_PROJECT_DIR:-/project}"
+COMPOSE="docker compose --project-directory $PROJECT_DIR"
+
 # Step 1: Stop all services and remove volumes
 echo "--- Step 1: Stopping all services and removing volumes ---"
-docker compose --profile dev --profile prod --profile infra down -v 2>/dev/null || true
+$COMPOSE --profile dev --profile prod --profile infra down -v 2>/dev/null || true
 echo "  Done"
 echo ""
 
@@ -36,7 +43,7 @@ echo ""
 
 # Step 3: Start infrastructure
 echo "--- Step 3: Starting infrastructure ---"
-docker compose --profile infra up -d
+$COMPOSE --profile infra up -d
 echo ""
 
 # Step 4: Wait for services to be healthy

--- a/scripts/reset-hard.sh
+++ b/scripts/reset-hard.sh
@@ -23,7 +23,7 @@ cd /project
 # /project/... on the host, which doesn't exist. --project-directory tells Docker to resolve
 # paths relative to the actual host directory instead.
 PROJECT_DIR="${HOST_PROJECT_DIR:-/project}"
-COMPOSE="docker compose --project-directory $PROJECT_DIR"
+COMPOSE="docker compose -f /project/docker-compose.yml --project-directory $PROJECT_DIR"
 
 # Step 1: Stop all services and remove volumes
 echo "--- Step 1: Stopping all services and removing volumes ---"

--- a/scripts/reset-hard.sh
+++ b/scripts/reset-hard.sh
@@ -18,12 +18,16 @@ echo ""
 
 cd /project
 
-# Use host project directory for Docker volume mount resolution (required for rootless Docker).
-# When this script runs inside a container, relative paths in docker-compose.yml resolve to
-# /project/... on the host, which doesn't exist. --project-directory tells Docker to resolve
-# paths relative to the actual host directory instead.
-PROJECT_DIR="${HOST_PROJECT_DIR:-/project}"
-COMPOSE="docker compose -f /project/docker-compose.yml --project-directory $PROJECT_DIR"
+# Rootless Docker fix: when this script runs inside a container, compose resolves relative
+# volume paths (./druppie/...) to /project/druppie/... on the host. Rootless Docker can't
+# mkdir /project at the system root. Fix: create a symlink so compose resolves paths to the
+# actual host directory, which the daemon can access.
+if [ -n "$HOST_PROJECT_DIR" ] && [ "$HOST_PROJECT_DIR" != "/project" ]; then
+    mkdir -p "$(dirname "$HOST_PROJECT_DIR")"
+    ln -sf /project "$HOST_PROJECT_DIR"
+    cd "$HOST_PROJECT_DIR"
+fi
+COMPOSE="docker compose"
 
 # Step 1: Stop all services and remove volumes
 echo "--- Step 1: Stopping all services and removing volumes ---"


### PR DESCRIPTION
## Summary
- The `reset-hard` script runs `docker compose` from inside a container where the repo is mounted at `/project`
- Docker resolves relative volume mount paths (like `./druppie/...`) to `/project/druppie/...` on the host, which doesn't exist
- Rootless Docker cannot `mkdir /project` at the system root, causing `permission denied` errors
- Passes `HOST_PROJECT_DIR=${PWD}` from the host into the container and uses `--project-directory` so Docker resolves paths correctly

## Test plan
- [ ] Run `docker compose --profile reset-hard run --rm reset-hard` with rootless Docker (no sudo)
- [ ] Verify all infra containers start without "mkdir /project: permission denied" errors
- [ ] Verify reset-hard still works with rootful Docker (sudo) as before