### PR TITLE
feat: add dockerized nuke profile for full rebuild from scratch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,9 @@ docker compose --profile dev down
 docker compose --profile infra --profile reset-hard run --rm reset-hard
 docker compose --profile dev up -d --build   # Always --build after reset (MCP servers have no volume mount)
 
+# Full nuke & rebuild (destroys everything including images, rebuilds from scratch)
+docker compose --profile nuke run --rm nuke
+
 # Purge sandbox dependency cache (npm, pnpm, bun, uv, pip)
 docker compose --profile reset-cache run --rm reset-cache
 

--- a/Dockerfile.reset
+++ b/Dockerfile.reset
@@ -23,9 +23,11 @@ RUN pip install --no-cache-dir requests pyyaml
 COPY scripts/setup_keycloak.py /app/scripts/setup_keycloak.py
 COPY scripts/setup_gitea.py /app/scripts/setup_gitea.py
 COPY scripts/reset-hard.sh /app/scripts/reset-hard.sh
+COPY scripts/nuke.sh /app/scripts/nuke.sh
 COPY iac/ /app/iac/
 
 # Fix line endings (in case files were copied from Windows) and make executable
-RUN sed -i 's/\r$//' /app/scripts/reset-hard.sh && chmod +x /app/scripts/reset-hard.sh
+RUN sed -i 's/\r$//' /app/scripts/reset-hard.sh /app/scripts/nuke.sh && \
+    chmod +x /app/scripts/reset-hard.sh /app/scripts/nuke.sh
 
 ENTRYPOINT ["/app/scripts/reset-hard.sh"]

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ cd cleaner-druppie
 cp .env.example .env
 # Edit .env and add your LLM API key (ZAI_API_KEY or DEEPINFRA_API_KEY)
 
-# 3. Build and start everything from scratch
-docker compose --profile nuke run --rm nuke
+# 3. Start (first time includes --profile init)
+docker compose --profile dev --profile init up -d --build
 
 # 4. Open the app
 open http://localhost:5273

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ cd cleaner-druppie
 cp .env.example .env
 # Edit .env and add your LLM API key (ZAI_API_KEY or DEEPINFRA_API_KEY)
 
-# 3. Start (first time includes --profile init)
-docker compose --profile dev --profile init up -d
+# 3. Build and start everything from scratch
+docker compose --profile nuke run --rm nuke
 
 # 4. Open the app
 open http://localhost:5273
@@ -25,8 +25,6 @@ First startup takes a few minutes to build images and initialize services.
 > **Already cloned without `--recursive`?** Run: `git submodule update --init`
 
 ## Daily Usage
-
-After first-time setup, skip `--profile init`:
 
 ```bash
 docker compose --profile dev up -d    # Start
@@ -103,15 +101,23 @@ docker compose logs -f sandbox-manager       # Sandbox manager
 # Soft reset - clears projects, sessions, chats (keeps user accounts, make sure to logout in the browser because tokens are kept there in cache.)
 docker compose --profile reset-db run --rm reset-db
 
-# Hard reset - wipes EVERYTHING and re-initializes Keycloak & Gitea
+# Hard reset - wipes all data volumes and re-initializes Keycloak & Gitea
 docker compose --profile reset-hard run --rm reset-hard
 docker compose --profile dev up -d --build   # Rebuild + start (MCP servers need --build)
+
+# Full nuke - destroys EVERYTHING (containers, volumes, images) and rebuilds from scratch
+docker compose --profile nuke run --rm nuke
+
+# Nuke without restarting (tear down only)
+START_AFTER=false docker compose --profile nuke run --rm nuke
 ```
 
 **Soft reset keeps:** User accounts, Keycloak config, Gitea repos
 **Soft reset clears:** Projects, sessions, agent runs, messages, approvals, questions
 
-**Hard reset clears:** Everything (all databases, Keycloak, Gitea, workspace files)
+**Hard reset clears:** All data (databases, Keycloak, Gitea, workspace files). Keeps Docker images.
+
+**Nuke clears:** Everything including Docker images. Rebuilds all images and starts fresh.
 
 ## What is `--profile init`?
 
@@ -227,10 +233,9 @@ GITEA_PORT=3101
 docker compose logs -f
 ```
 
-**Fresh start:**
+**Fresh start (nuclear option):**
 ```bash
-docker compose --profile reset-hard run --rm reset-hard
-docker compose --profile dev up -d --build
+docker compose --profile nuke run --rm nuke
 ```
 
 **Container won't start:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@
 #   docker compose --profile prod --profile init up -d       # Full production
 #   docker compose --profile reset-db run --rm reset-db      # Reset app database
 #   docker compose --profile reset-hard run --rm reset-hard  # Full reset + re-init
+#   docker compose --profile nuke run --rm nuke              # Full nuke & rebuild from scratch
 #   docker compose down                                       # Stop everything
 #
 # Ports:
@@ -759,6 +760,28 @@ services:
     volumes:
       - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock
       - .:/project
+
+  # Full nuke & rebuild - destroys EVERYTHING (containers, volumes, images) and rebuilds from scratch
+  # Usage: docker compose --profile nuke run --rm nuke
+  # Stop only: START_AFTER=false docker compose --profile nuke run --rm nuke
+  nuke:
+    build:
+      context: .
+      dockerfile: Dockerfile.reset
+    container_name: druppie-nuke
+    profiles: [nuke]
+    network_mode: host
+    environment:
+      COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-cleaner-druppie-docker-compose}
+      START_AFTER: ${START_AFTER:-true}
+      FRONTEND_PORT: ${FRONTEND_PORT:-5273}
+      BACKEND_PORT: ${BACKEND_PORT:-8100}
+      KEYCLOAK_PORT: ${KEYCLOAK_PORT:-8180}
+      GITEA_PORT: ${GITEA_PORT:-3100}
+    volumes:
+      - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock
+      - .:/project
+    entrypoint: ["/app/scripts/nuke.sh"]
 
   # Emergency purge of the shared sandbox dependency cache
   # Usage: docker compose --profile reset-cache run --rm reset-cache

--- a/scripts/nuke.sh
+++ b/scripts/nuke.sh
@@ -41,25 +41,20 @@ echo "--- Step 1: Stopping all containers and removing volumes ---"
 docker compose \
     --profile dev --profile prod --profile infra \
     --profile init --profile reset-db --profile reset-hard \
-    --profile reset-cache --profile scan-cache --profile nuke \
-    down -v --remove-orphans 2>/dev/null || true
+    --profile reset-cache --profile scan-cache \
+    down -v --remove-orphans || true
 echo "  Done"
 echo ""
 
-# Step 2: Remove any remaining named volumes
+# Step 2: Remove any remaining named volumes (catches volumes that survived Step 1)
 echo "--- Step 2: Cleaning up remaining volumes ---"
-for vol in \
-    druppie_new_postgres \
-    druppie_new_keycloak_postgres \
-    druppie_new_gitea_postgres \
-    druppie_new_gitea \
-    druppie_new_workspace \
-    druppie_new_dataset \
-    druppie_init_marker \
-    druppie_sandbox_data \
-    druppie_sandbox_snapshots \
-    druppie_sandbox_dep_cache \
-    druppie_cache_scan_results; do
+VOLUMES=$(docker compose \
+    --profile dev --profile prod --profile infra \
+    --profile init --profile reset-db --profile reset-hard \
+    --profile reset-cache --profile scan-cache \
+    config --volumes 2>/dev/null) || true
+
+for vol in $VOLUMES; do
     if docker volume inspect "$vol" >/dev/null 2>&1; then
         echo "  Removing volume: $vol"
         docker volume rm "$vol" 2>/dev/null || echo "  Warning: Could not remove $vol"
@@ -73,7 +68,7 @@ echo "--- Step 3: Removing built Docker images ---"
 IMAGES=$(docker compose \
     --profile dev --profile prod --profile infra \
     --profile init --profile reset-db --profile reset-hard \
-    --profile reset-cache --profile scan-cache --profile nuke \
+    --profile reset-cache --profile scan-cache \
     config --images 2>/dev/null | sort -u) || true
 
 for img in $IMAGES; do

--- a/scripts/nuke.sh
+++ b/scripts/nuke.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Druppie Platform - Full Nuke & Rebuild
+# =======================================
+# Destroys EVERYTHING (containers, volumes, images) and rebuilds from scratch.
+# As if you just cloned the repo and set up for the first time.
+#
+# Dockerized usage (recommended):
+#   docker compose --profile nuke run --rm nuke
+#   START_AFTER=false docker compose --profile nuke run --rm nuke   # nuke only, don't start
+#
+# Direct usage:
+#   ./scripts/nuke.sh [--stop]
+
+set -e
+
+# When running inside the container, /project is the repo root
+if [ -d /project ]; then
+    cd /project
+else
+    cd "$(dirname "$0")/.."
+fi
+
+START_AFTER="${START_AFTER:-true}"
+if [ "$1" = "--stop" ]; then
+    START_AFTER="false"
+fi
+
+echo "=============================================="
+echo "  Druppie Platform - FULL NUKE & REBUILD"
+echo "=============================================="
+echo ""
+echo "This will destroy EVERYTHING and rebuild from scratch:"
+echo "  - All containers"
+echo "  - All data volumes (databases, Keycloak, Gitea, workspace)"
+echo "  - All built Docker images (backend, frontend, MCP modules, sandbox)"
+echo "  - Init marker (forces re-initialization)"
+echo ""
+
+# Step 1: Stop all containers and remove volumes
+echo "--- Step 1: Stopping all containers and removing volumes ---"
+docker compose \
+    --profile dev --profile prod --profile infra \
+    --profile init --profile reset-db --profile reset-hard \
+    --profile reset-cache --profile scan-cache --profile nuke \
+    down -v --remove-orphans 2>/dev/null || true
+echo "  Done"
+echo ""
+
+# Step 2: Remove any remaining named volumes
+echo "--- Step 2: Cleaning up remaining volumes ---"
+for vol in \
+    druppie_new_postgres \
+    druppie_new_keycloak_postgres \
+    druppie_new_gitea_postgres \
+    druppie_new_gitea \
+    druppie_new_workspace \
+    druppie_new_dataset \
+    druppie_init_marker \
+    druppie_sandbox_data \
+    druppie_sandbox_snapshots \
+    druppie_sandbox_dep_cache \
+    druppie_cache_scan_results; do
+    if docker volume inspect "$vol" >/dev/null 2>&1; then
+        echo "  Removing volume: $vol"
+        docker volume rm "$vol" 2>/dev/null || echo "  Warning: Could not remove $vol"
+    fi
+done
+echo "  Done"
+echo ""
+
+# Step 3: Remove all locally built images (forces full rebuild)
+echo "--- Step 3: Removing built Docker images ---"
+IMAGES=$(docker compose \
+    --profile dev --profile prod --profile infra \
+    --profile init --profile reset-db --profile reset-hard \
+    --profile reset-cache --profile scan-cache --profile nuke \
+    config --images 2>/dev/null | sort -u) || true
+
+for img in $IMAGES; do
+    # Skip upstream images - only remove locally built ones
+    case "$img" in
+        postgres:*|quay.io/*|docker:*) continue ;;
+    esac
+    if docker image inspect "$img" >/dev/null 2>&1; then
+        echo "  Removing image: $img"
+        docker rmi "$img" 2>/dev/null || echo "  Warning: Could not remove $img"
+    fi
+done
+echo "  Done"
+echo ""
+
+# Step 4: Ensure submodules are initialized
+echo "--- Step 4: Initializing git submodules ---"
+if command -v git >/dev/null 2>&1 && [ -d .git ]; then
+    git submodule update --init --recursive
+    echo "  Done"
+else
+    echo "  Skipped (no git available in container)"
+fi
+echo ""
+
+if [ "$START_AFTER" = "true" ]; then
+    # Step 5: Build and start everything from scratch
+    echo "--- Step 5: Building and starting dev environment ---"
+    echo "  This will take a few minutes on first build..."
+    echo ""
+    docker compose --profile dev --profile init up -d --build
+    echo ""
+
+    echo "=============================================="
+    echo "  Nuke & Rebuild Complete!"
+    echo "=============================================="
+    echo ""
+    echo "Services are starting up. Give it a minute for initialization."
+    echo ""
+    echo "  Frontend:       http://localhost:${FRONTEND_PORT:-5273}"
+    echo "  API Docs:       http://localhost:${BACKEND_PORT:-8100}/docs"
+    echo "  Keycloak Admin: http://localhost:${KEYCLOAK_PORT:-8180}"
+    echo "  Gitea:          http://localhost:${GITEA_PORT:-3100}"
+    echo ""
+    echo "Check logs:  docker compose --profile dev logs -f"
+else
+    echo "=============================================="
+    echo "  Nuke Complete (stop mode)"
+    echo "=============================================="
+    echo ""
+    echo "Everything has been removed. To start fresh:"
+    echo "  docker compose --profile dev --profile init up -d --build"
+fi


### PR DESCRIPTION
## Summary
- Adds a `nuke` docker compose profile that destroys everything (containers, volumes, **and** built Docker images) then rebuilds and starts the dev environment from scratch
- New `scripts/nuke.sh` script, dockerized via `Dockerfile.reset` with Docker socket access
- Updated README Quick Start to use `docker compose --profile nuke run --rm nuke` as the standard first-time setup command
- Reset section now documents all three tiers: soft reset, hard reset, and nuke

## Usage
```bash
# Full nuke & rebuild
docker compose --profile nuke run --rm nuke

# Nuke without restarting (tear down only)
START_AFTER=false docker compose --profile nuke run --rm nuke
```

## Test plan
- [ ] Run `docker compose --profile nuke run --rm nuke` from a dirty state and verify all containers, volumes, and images are removed then rebuilt
- [ ] Verify services come up healthy after nuke completes
- [ ] Test `START_AFTER=false` mode stops after cleanup without starting services