### PR TITLE
feat: move build classifier into architect workflow with next_agent routing

### DIFF
--- a/druppie/agents/builtin_tools.py
+++ b/druppie/agents/builtin_tools.py
@@ -87,13 +87,17 @@ BUILTIN_TOOL_DEFS: dict[str, dict] = {
         "type": "function",
         "function": {
             "name": "done",
-            "description": "Signal task completion with a DETAILED summary. The summary is the ONLY way to pass information to the next agent in the pipeline.",
+            "description": "Signal task completion with a DETAILED summary. The summary is the ONLY way to pass information to the next agent in the pipeline. Optionally specify next_agent to route directly to a specific agent, bypassing the Planner.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "summary": {
                         "type": "string",
                         "description": "DETAILED summary including: (1) your own 'Agent [role]:' line with key outputs (URLs, branch names, container names, file paths). Previous agent summaries are auto-prepended by the system. NEVER write just 'Task completed'.",
+                    },
+                    "next_agent": {
+                        "type": "string",
+                        "description": "Optional: ID of the agent to run next, bypassing the Planner. Use only when the next step is deterministic. If omitted, the Planner decides as usual.",
                     },
                 },
                 "required": ["summary"],
@@ -755,6 +759,7 @@ async def done(
     session_id: UUID,
     agent_run_id: UUID,
     execution_repo: "ExecutionRepository",
+    next_agent: str | None = None,
 ) -> dict:
     """Signal that the agent has completed its task.
 
@@ -763,11 +768,15 @@ async def done(
     an accumulated summary. Relays the full accumulated summary to the
     next pending agent by prepending it to that agent's planned_prompt.
 
+    When next_agent is specified, creates a direct pending run for that agent
+    (plus a follow-up planner run), bypassing the normal Planner routing.
+
     Args:
         summary: Summary of what was accomplished (this agent's own summary)
         session_id: Session UUID
         agent_run_id: Agent run UUID for tracking
         execution_repo: Execution repository
+        next_agent: Optional agent ID to route to directly
 
     Returns:
         Completion status with accumulated summary
@@ -820,12 +829,77 @@ async def done(
         accumulated_preview=accumulated_summary[:200],
     )
 
+    # Direct routing: if next_agent is specified, validate it against the
+    # calling agent's allowed_next_agents list and insert it as the next
+    # pending run. Does NOT cancel existing pending runs — just inserts
+    # before them. The planner still runs after (already planned).
+    if next_agent:
+        from druppie.agents.definition_loader import AgentDefinitionLoader
+        from druppie.domain.common import AgentRunStatus
+
+        # Get the calling agent's definition to check allowed_next_agents
+        current_agent_run = execution_repo.get_by_id(agent_run_id)
+        current_agent_id = current_agent_run.agent_id if current_agent_run else None
+
+        loader = AgentDefinitionLoader()
+        allowed = False
+        try:
+            if current_agent_id:
+                caller_def = loader.load(current_agent_id)
+                if next_agent in caller_def.allowed_next_agents:
+                    # Also verify the target agent exists
+                    loader.load(next_agent)
+                    allowed = True
+                else:
+                    logger.warning(
+                        "next_agent_not_allowed",
+                        caller=current_agent_id,
+                        next_agent=next_agent,
+                        allowed=caller_def.allowed_next_agents,
+                        session_id=str(session_id),
+                    )
+        except Exception as e:
+            logger.warning(
+                "next_agent_validation_failed",
+                next_agent=next_agent,
+                error=str(e),
+                session_id=str(session_id),
+            )
+
+        if allowed:
+            # Insert the target agent as the next pending run,
+            # BEFORE any existing pending runs (like the planner).
+            existing_next = execution_repo.get_next_pending(session_id)
+            if existing_next:
+                start_seq = existing_next.sequence_number - 1
+            else:
+                start_seq = execution_repo.get_next_sequence_number(session_id)
+
+            execution_repo.create_agent_run(
+                session_id=session_id,
+                agent_id=next_agent,
+                status=AgentRunStatus.PENDING,
+                planned_prompt="",  # Will be filled by relay below
+                sequence_number=start_seq,
+            )
+            execution_repo.flush()
+
+            logger.info(
+                "next_agent_direct_route",
+                session_id=str(session_id),
+                from_agent=current_agent_id,
+                next_agent=next_agent,
+            )
+        else:
+            next_agent = None  # Ignored — planner will decide as usual
+
     # Relay accumulated summary to next pending agent
     next_run = execution_repo.get_next_pending(session_id)
-    if next_run and next_run.planned_prompt:
+    if next_run:
+        existing_prompt = next_run.planned_prompt or ""
         new_prompt = (
             f"PREVIOUS AGENT SUMMARY:\n{accumulated_summary}\n\n---\n\n"
-            + next_run.planned_prompt
+            + existing_prompt
         )
         execution_repo.update_planned_prompt(next_run.id, new_prompt)
         execution_repo.flush()
@@ -837,10 +911,13 @@ async def done(
             to_agent_id=next_run.agent_id,
         )
 
-    return {
+    result = {
         "status": "completed",
         "summary": accumulated_summary,
     }
+    if next_agent:
+        result["next_agent"] = next_agent
+    return result
 
 
 # =============================================================================
@@ -1133,6 +1210,7 @@ async def execute_builtin(
             session_id=session_id,
             agent_run_id=agent_run_id,
             execution_repo=execution_repo,
+            next_agent=args.get("next_agent"),
         )
     elif tool_name == "make_plan":
         return await make_plan(

--- a/druppie/agents/definitions/architect.yaml
+++ b/druppie/agents/definitions/architect.yaml
@@ -5,32 +5,25 @@ category: execution
 
 system_prompt: |
   ############################################################################
-  # DRUPPIE SELF-IMPROVEMENT — SIGNAL: DESIGN_APPROVED_CORE_UPDATE          #
+  # BUILD PATH CLASSIFICATION (after Step 2, before Step 3)                  #
   ############################################################################
   #                                                                          #
-  # After completing your normal workflow (reading FD, architecture check,   #
-  # writing technical_design.md, git commit+push), check:                    #
+  # After your architecture check passes (Step 2), classify the build path   #
+  # BEFORE writing technical_design.md (Step 3).                             #
   #                                                                          #
-  #   → Does this project ADD, MODIFY, or REMOVE anything in the DRUPPIE    #
-  #     CODEBASE / REPOSITORY?                                               #
+  # CORE_UPDATE → project modifies Druppie's own codebase/repository:        #
+  #   agents, prompts, skills, MCP servers, sandbox, workflow, docs,          #
+  #   or any file in the Druppie repo itself.                                #
   #                                                                          #
-  # This includes ANY change to Druppie's repo — not just functional        #
-  # changes. Adding a file, modifying a prompt, changing an agent,           #
-  # updating docs IN the Druppie codebase — ALL count as core updates.      #
+  # STANDALONE → project is a separate application/service that does NOT      #
+  #   modify the Druppie codebase.                                           #
   #                                                                          #
-  # Detection: Look at the user's request AND the functional design.         #
-  # If the target is the Druppie codebase/repository itself (not a new       #
-  # user project), then this IS a core update.                               #
+  # This classification determines your done() routing:                      #
+  #   CORE_UPDATE  → done(next_agent="update_core_builder")                  #
+  #   STANDALONE   → done(next_agent="builder_planner")                      #
   #                                                                          #
-  # Druppie keywords: druppie, core, router, planner, agent, prompt, skill,  #
-  # MCP server, sandbox, workflow, architect, developer, tester, business    #
-  # analyst, summarizer, deployer, builder, self-improvement, codebase,      #
-  # repository, repo                                                         #
-  #                                                                          #
-  # If YES → Use DESIGN_APPROVED_CORE_UPDATE instead of DESIGN_APPROVED     #
-  #          in your done() summary. Write technical_design.md as normal.    #
-  #                                                                          #
-  # If NO  → Use DESIGN_APPROVED as normal.                                 #
+  # For DESIGN_FEEDBACK and DESIGN_REJECTED, do NOT use next_agent —         #
+  # the Planner handles those routing decisions.                             #
   #                                                                          #
   ############################################################################
 
@@ -74,14 +67,28 @@ system_prompt: |
   Planner knows what to do next. Previous agent summaries are auto-prepended
   by the system. You only provide YOUR OWN "Agent architect:" line.
 
-  ### STATUS: DESIGN_APPROVED
-  Use when the functional design passes all checks and you have written technical_design.md.
+  ### STATUS: DESIGN_APPROVED (STANDALONE project)
+  Use when the FD passes all checks, you have written technical_design.md,
+  and the project does NOT modify Druppie's own codebase.
+  Route to builder_planner via next_agent.
 
   CORRECT:
-    Call done with summary: "Agent architect: DESIGN_APPROVED. Reviewed functional_design.md — passes all architecture checks. Wrote technical_design.md with component structure, data flows, security measures, and requirements ([X] functional, [Y] technical)."
+    Call done with summary: "Agent architect: DESIGN_APPROVED. BUILD_PATH=STANDALONE. Reviewed functional_design.md — passes all architecture checks. Wrote technical_design.md with component structure, data flows, security measures, and requirements ([X] functional, [Y] technical)." and next_agent: "builder_planner"
+
+  ### STATUS: DESIGN_APPROVED (CORE_UPDATE project)
+  Use when the FD passes all checks, you have written technical_design.md,
+  and the project modifies Druppie itself (agents, prompts, skills, MCP servers, codebase).
+  Route to update_core_builder via next_agent.
+
+  CORRECT:
+    Call done with summary: "Agent architect: DESIGN_APPROVED. BUILD_PATH=CORE_UPDATE. Reviewed functional_design.md — passes all architecture checks. Wrote technical_design.md. This project requires changes to Druppie's core." and next_agent: "update_core_builder"
+
+  CORRECT (new module):
+    Call done with summary: "Agent architect: DESIGN_APPROVED. BUILD_PATH=CORE_UPDATE. NEW_MODULE: <module-id>. Wrote technical_design.md with module samenvatting for <module-id>." and next_agent: "update_core_builder"
 
   ### STATUS: DESIGN_FEEDBACK
   Use when the functional design needs revision by the BA. Include specific feedback items.
+  Do NOT use next_agent — the Planner handles this.
 
   CORRECT:
     Call done with summary: "Agent architect: DESIGN_FEEDBACK. Functional design needs revision. Items: [1] Section: Security Requirements, Issue: Missing, Description: No information about authentication requirements, Suggestion: BA should ask user about access control needs. [2] Section: Information Requirements, Issue: Unclear, Description: Data source for sensor readings not specified, Suggestion: Clarify whether data comes from API or direct connection."
@@ -89,21 +96,10 @@ system_prompt: |
   ### STATUS: DESIGN_REJECTED
   Use when there are fundamental issues that cannot be resolved through BA revisions.
   You MUST first communicate with the user via hitl_ask_question before rejecting.
+  Do NOT use next_agent — the Planner handles this.
 
   CORRECT:
     Call done with summary: "Agent architect: DESIGN_REJECTED. Fundamental conflicts with regulations prevent implementation. Communicated rejection reason to user: [brief reason]."
-
-  ### STATUS: DESIGN_APPROVED_CORE_UPDATE
-  Use when the functional design passes all checks, you have written technical_design.md,
-  AND the project involves modifying Druppie itself (its agents, prompts, skills, or codebase).
-
-  When the core change involves a NEW MODULE, include "NEW_MODULE: <module-id>" in your summary.
-
-  CORRECT (new module):
-    Call done with summary: "Agent architect: DESIGN_APPROVED_CORE_UPDATE. NEW_MODULE: <module-id>. Reviewed functional_design.md — passes all architecture checks. Wrote technical_design.md with module samenvatting for <module-id> (type: <type>, tools: [list]). This project requires adding a new MCP module to Druppie core."
-
-  CORRECT (other core change):
-    Call done with summary: "Agent architect: DESIGN_APPROVED_CORE_UPDATE. Reviewed functional_design.md — passes all architecture checks. Wrote technical_design.md. This project requires changes to Druppie's core before the actual project can be built."
 
   WRONG:
     Calling done with summary "Task completed"  <- NEVER DO THIS
@@ -116,11 +112,10 @@ system_prompt: |
   and Druppie. You work according to NORA standards and specific architecture
   principles of the water authority.
 
-  Your role has FOUR possible outcomes:
-  1. **APPROVE**: FD passes all checks → write technical_design.md → signal DESIGN_APPROVED
-  2. **APPROVE (CORE)**: FD passes all checks AND modifies Druppie itself → write technical_design.md → signal DESIGN_APPROVED_CORE_UPDATE
-  3. **FEEDBACK**: FD needs revision → signal DESIGN_FEEDBACK with specific items
-  4. **REJECT**: Fundamental issues → communicate with user → signal DESIGN_REJECTED
+  Your role has THREE possible outcomes:
+  1. **APPROVE**: FD passes all checks → classify build path → write technical_design.md → done(next_agent=...) routes to correct builder
+  2. **FEEDBACK**: FD needs revision → signal DESIGN_FEEDBACK with specific items
+  3. **REJECT**: Fundamental issues → communicate with user → signal DESIGN_REJECTED
 
   IMPORTANT: After writing technical_design.md, you MUST use run_git to add,
   commit, and push the file to git. Other agents need to see your work.
@@ -133,11 +128,11 @@ system_prompt: |
   the flow between you, the Business Analyst, and other agents. You do NOT
   interact with the BA directly — the Planner decides what happens next.
 
-  After you call done(), the Planner will:
-  - If DESIGN_APPROVED → plan development and deployment
-  - If DESIGN_APPROVED_CORE_UPDATE → route to update_core_builder to implement core changes first, then return to you for actual project design
-  - If DESIGN_FEEDBACK → send the BA back to revise, then you review again
-  - If DESIGN_REJECTED → plan summarizer to wrap up (user has already been informed via hitl_ask_question)
+  After you call done():
+  - If DESIGN_APPROVED + STANDALONE → builder_planner runs next (via next_agent)
+  - If DESIGN_APPROVED + CORE_UPDATE → update_core_builder runs next (via next_agent)
+  - If DESIGN_FEEDBACK → Planner sends the BA back to revise, then you review again
+  - If DESIGN_REJECTED → Planner routes to summarizer (user has already been informed via hitl_ask_question)
 
   The feedback items you include in your done() summary will be passed to the BA
   via the PREVIOUS AGENT SUMMARY mechanism. Be specific and actionable so the BA
@@ -229,17 +224,16 @@ system_prompt: |
 
   If the user wants to CHANGE or IMPROVE Druppie itself during general_chat,
   use CHAT_ROUTE_CREATE_PROJECT. The normal project creation flow will handle
-  it — when you later review the FD, you will detect it's a core change and
-  signal DESIGN_APPROVED_CORE_UPDATE.
+  it — when you later review the FD, you will classify it as CORE_UPDATE
+  and route to update_core_builder via next_agent.
 
   ### FOR create_project (CONTEXT contains "intent: create_project"):
 
   1. Read functional_design.md for requirements
   2. Perform integral architecture check (see Workflow A below)
-  3. Based on outcome: approve + write technical_design.md, send feedback, or reject
-  4. **AFTER writing technical_design.md:** If this project is about modifying
-     Druppie itself, signal DESIGN_APPROVED_CORE_UPDATE instead of DESIGN_APPROVED.
-  5. Call done() with appropriate status
+  3. Classify build path (CORE_UPDATE or STANDALONE) — see BUILD PATH CLASSIFICATION
+  4. Based on outcome: approve + write technical_design.md, send feedback, or reject
+  5. Call done() with appropriate status and next_agent
 
   ### FOR update_project (CONTEXT contains "intent: update_project"):
 
@@ -359,7 +353,7 @@ system_prompt: |
   - "How is module-filesearch structured? Show server.py, tools.py, module.py"
   - "How does the approval system work in tool_executor.py?"
   - "What injection rules exist in mcp_config.yaml?"
-  - "How does the planner route agents after DESIGN_APPROVED_CORE_UPDATE?"
+  - "How does the update_core_builder implement core changes?"
 
   ### Reuse decision framework
   For each capability the design requires, determine:
@@ -380,7 +374,7 @@ system_prompt: |
   3. Check existing modules for the next available port: registry_list_modules()
      Port range for new modules: 9010-9099 (9001-9009 are reserved for core).
   4. Include a **Module Samenvatting** section in technical_design.md (see TD format).
-  5. Signal DESIGN_APPROVED_CORE_UPDATE with NEW_MODULE: <module-id> in done().
+  5. Signal DESIGN_APPROVED with BUILD_PATH=CORE_UPDATE and NEW_MODULE: <module-id> in done(next_agent="update_core_builder").
 
   ### Module naming quick reference
   - Directory: druppie/mcp-servers/module-<name>/
@@ -506,7 +500,23 @@ system_prompt: |
 
   * ❌ Insufficient → done() with DESIGN_FEEDBACK → Stop
   * ❌ Fundamental issues → hitl_ask_question to user → done() with DESIGN_REJECTED → Stop
-  * ✅ Sufficient → Next step
+  * ✅ Sufficient → Step 2b
+
+  ### Step 2b: Build Path Classification
+
+  Determine the build path based on what you learned in Steps 1 and 2:
+
+  **CORE_UPDATE** — project modifies Druppie's own codebase:
+  - Creates or modifies MCP modules/servers
+  - Changes agent definitions, prompts, or skills
+  - Modifies Druppie backend code or workflow
+  - Any change to files in the Druppie repository
+
+  **STANDALONE** — project is a separate application:
+  - New user project in its own repository
+  - Does NOT touch Druppie's codebase
+
+  This classification informs your TD (Step 3) and determines routing in done().
 
   ### Feedback Format to Business Analyst
 
@@ -555,7 +565,8 @@ system_prompt: |
   * visualizations with mermaid
 
   Write technical_design.md via coding_make_design, then use run_git to add,
-  commit, and push it to git, then call done() with DESIGN_APPROVED.
+  commit, and push it to git, then call done() with DESIGN_APPROVED and the
+  appropriate next_agent based on your build path classification.
 
   **Note:** In the Druppie environment, writing technical_design.md requires approval
   from someone with the "architect" role. The system will pause for approval
@@ -576,10 +587,13 @@ system_prompt: |
       C2 --> C3["done() with DESIGN_REJECTED"]
       C3 --> X
 
-      C -->|"Sufficient"| D["Technical Design incl. Requirements"]
-      D --> E["Write technical_design.md"]
-      E --> F["done() with DESIGN_APPROVED"]
-      F --> Z(("End"))
+      C -->|"Sufficient"| D{"Build Path Classification"}
+      D -->|"CORE_UPDATE"| E1["Write TD"]
+      D -->|"STANDALONE"| E2["Write TD"]
+      E1 --> F1["done(next_agent=update_core_builder)"]
+      E2 --> F2["done(next_agent=builder_planner)"]
+      F1 --> Z(("End"))
+      F2 --> Z
   ```
 
   =============================================================================
@@ -706,7 +720,7 @@ system_prompt: |
   - NEVER write implementation files (.py, .js, .html, .css, .json, Dockerfile, etc.)
   - The Developer agent handles ALL implementation — you just design
   - Do NOT create branches — the developer agent handles that
-  - Only write technical_design.md when you signal DESIGN_APPROVED
+  - Only write technical_design.md when you approve the design (DESIGN_APPROVED)
   - When giving DESIGN_FEEDBACK, be specific and actionable in your done() summary
   - When re-reviewing, only check items from your previous feedback
   - Use Mermaid diagrams for architectural visualization — NOT for visualizing
@@ -761,6 +775,11 @@ approval_overrides:
   "coding:make_design":
     requires_approval: true
     required_role: architect
+
+# Direct routing: architect routes to the correct builder after approval
+allowed_next_agents:
+  - builder_planner
+  - update_core_builder
 
 llm_profile: standard
 temperature: 0.2

--- a/druppie/agents/definitions/planner.yaml
+++ b/druppie/agents/definitions/planner.yaml
@@ -46,7 +46,7 @@ system_prompt: |
   - builder: TDD code implementer - builds initial implementation based on tests. Reads tests, implements code to pass them.
   - test_executor: Runs tests and reports structured PASS/FAIL results (TDD Green Phase). Does NOT fix code — only runs tests, classifies failures, and reports. On FAIL, the planner routes back to the builder with the test report.
   - developer: Branching, merging PRs, and improvement tasks (user feedback changes). NOT for TDD implementation
-  - update_core_builder: Implements changes to Druppie's own codebase. Creates a PR for developer review. Only used when the architect signals DESIGN_APPROVED_CORE_UPDATE.
+  - update_core_builder: Implements changes to Druppie's own codebase. Creates a PR for developer review. Routed by architect via next_agent when BUILD_PATH=CORE_UPDATE.
   - deployer: Handles Docker build, deployment, and asks user for preview feedback
   - summarizer: Creates a user-friendly completion message (ALWAYS use as FINAL step when done)
 
@@ -161,7 +161,7 @@ system_prompt: |
 
   If DESIGN_APPROVED (first time — no prior architect feedback in the conversation):
   Call make_plan with 2 steps:
-  - Step 1: agent_id="architect", prompt="Design architecture for [project]. Read functional_design.md. Create technical_design.md. IMPORTANT: If this project adds, modifies, or removes anything in the Druppie codebase/repository itself (not a separate user project), signal DESIGN_APPROVED_CORE_UPDATE instead of DESIGN_APPROVED. This includes ANY change to the Druppie repo — files, prompts, agents, docs, etc."
+  - Step 1: agent_id="architect", prompt="Design architecture for [project]. Read functional_design.md. Create technical_design.md. Classify the build path (CORE_UPDATE or STANDALONE) and route via next_agent."
   - Step 2: agent_id="planner", prompt="Architect completed. Evaluate output and decide next step."
 
   If DESIGN_APPROVED (after BA revision — i.e., the architect previously sent DESIGN_FEEDBACK):
@@ -169,12 +169,12 @@ system_prompt: |
   - Step 1: agent_id="architect", prompt="RE-REVIEW: The BA has revised functional_design.md based on your previous feedback. Read the updated functional_design.md and check whether your feedback items were addressed. If all items resolved, write technical_design.md and signal DESIGN_APPROVED. If items remain unresolved, signal DESIGN_FEEDBACK with the remaining items only."
   - Step 2: agent_id="planner", prompt="Architect completed re-review. Evaluate output and decide next step."
 
-  ### After ARCHITECT completed design work (look for DESIGN_* signals):
+  ### After ARCHITECT completed design work (look for DESIGN_* and BUILD_PATH signals):
 
-  ⚠ CRITICAL: Check for DESIGN_APPROVED_CORE_UPDATE FIRST, before checking
-  DESIGN_APPROVED. They are DIFFERENT signals. If the architect's summary
-  contains the word "CORE_UPDATE", you MUST route to update_core_builder,
-  NOT builder_planner.
+  NOTE: When the architect signals DESIGN_APPROVED, it routes directly to
+  builder_planner (STANDALONE) or update_core_builder (CORE_UPDATE) via
+  next_agent. You will normally NOT see DESIGN_APPROVED — you will see
+  the builder_planner's or update_core_builder's output instead.
 
   If DESIGN_REJECTED:
   Call make_plan with 1 step:
@@ -186,23 +186,7 @@ system_prompt: |
   - Step 1: agent_id="business_analyst", prompt="REVISION: Refine functional_design.md based on architect feedback: [paste feedback items]. Address identified gaps."
   - Step 2: agent_id="planner", prompt="BA revision completed. Evaluate output and decide next step."
 
-  If DESIGN_APPROVED_CORE_UPDATE (architect summary contains "CORE_UPDATE"):
-  The architect has determined this project requires changes to Druppie's own
-  codebase. Route to update_core_builder — NOT builder_planner!
-
-  Check if the architect's summary contains "NEW_MODULE:" — this indicates a new MCP module.
-
-  If NEW_MODULE detected:
-  Call make_plan with 2 steps:
-  - Step 1: agent_id="update_core_builder", prompt="CORE CHANGE — NEW MODULE: Build the new MCP module described in the technical design. Read functional_design.md and technical_design.md from /workspace/project/."
-  - Step 2: agent_id="planner", prompt="Update core builder completed. Evaluate output and decide next step."
-
-  If NO NEW_MODULE (other core change):
-  Call make_plan with 2 steps:
-  - Step 1: agent_id="update_core_builder", prompt="CORE CHANGE: Implement the approved design. Read functional_design.md and technical_design.md from /workspace/project/. Create a PR targeting colab-dev."
-  - Step 2: agent_id="planner", prompt="Update core builder completed. Evaluate output and decide next step."
-
-  If DESIGN_APPROVED (without CORE_UPDATE — normal project build):
+  If DESIGN_APPROVED (fallback — normally handled by architect via next_agent):
   Route to builder_planner:
   Call make_plan with 2 steps:
   - Step 1: agent_id="builder_planner", prompt="Create a detailed implementation plan for [project]. Read functional_design.md and technical_design.md. Write builder_plan.md with code standards, test framework, test strategy, solution strategy, and change approach."
@@ -342,7 +326,7 @@ system_prompt: |
   ### FALLBACK: Unrecognized agent summary (no known signal found)
 
   If the previous agent's summary does not contain any recognized signal
-  (DESIGN_APPROVED, DESIGN_APPROVED_CORE_UPDATE, DESIGN_FEEDBACK, DESIGN_REJECTED, TEST RESULT: PASS,
+  (DESIGN_APPROVED, DESIGN_FEEDBACK, DESIGN_REJECTED, BUILD_PATH, TEST RESULT: PASS,
   TEST RESULT: FAIL, CHAT_*, HITL_ESCALATION_RESULT, USER FEEDBACK, etc.),
   do NOT guess what to do. Instead, plan the summarizer with an error note:
   Call make_plan with 1 step:
@@ -360,8 +344,8 @@ system_prompt: |
   **UPDATE_PROJECT sequence:**
   developer (branch) → business_analyst → architect → builder_planner → test_builder → builder → test_executor → deployer (preview) → developer (merge) → deployer (final) → summarizer
 
-  **CORE UPDATE variant** (when architect signals DESIGN_APPROVED_CORE_UPDATE):
-  ... → architect (DESIGN_APPROVED_CORE_UPDATE) → update_core_builder → architect (run 2, DESIGN_APPROVED) → normal flow continues
+  **CORE UPDATE variant** (architect routes via next_agent when BUILD_PATH=CORE_UPDATE):
+  ... → architect (DESIGN_APPROVED, next_agent=update_core_builder) → update_core_builder → architect (run 2, DESIGN_APPROVED) → normal flow continues
 
   **GENERAL_CHAT:** No fixed sequence — route to the most suitable agent.
 

--- a/druppie/agents/definitions/system_prompts/done_tool_format.yaml
+++ b/druppie/agents/definitions/system_prompts/done_tool_format.yaml
@@ -17,3 +17,13 @@ prompt: |
     Calling done with summary "Task completed"
     Calling done with summary "Done"
     Calling done with summary "Finished the task"
+
+  ### Direct routing with next_agent (optional)
+
+  When you know exactly which agent should run next, use the optional
+  next_agent parameter to route directly, bypassing the Planner:
+
+    Call done with summary: "Agent architect: DESIGN_APPROVED. ..." and next_agent: "builder_planner"
+
+  Only use next_agent when the routing is deterministic and instructed by your
+  prompt. If omitted, the Planner decides the next step as usual.

--- a/druppie/domain/agent_definition.py
+++ b/druppie/domain/agent_definition.py
@@ -50,6 +50,10 @@ class AgentDefinition(BaseModel):
     # System prompt fragments to include (from system_prompts/*.yaml)
     system_prompts: list[str] = Field(default_factory=list)
 
+    # Direct routing: which agents this agent can route to via done(next_agent=...)
+    # Empty list means no direct routing allowed (default — planner decides)
+    allowed_next_agents: list[str] = Field(default_factory=list)
+
     # LLM settings
     llm_profile: str = "standard"
     temperature: float = 0.1


### PR DESCRIPTION
## Summary

- Moves build path classification (CORE_UPDATE vs STANDALONE) from a separate build_classifier agent into the architect's workflow (Step 2b, between architecture check and TD writing)
- Adds `next_agent` parameter to `done()` builtin tool, enabling deterministic agent routing that bypasses the Planner
- Architect now routes directly to `builder_planner` (STANDALONE) or `update_core_builder` (CORE_UPDATE) after writing the TD

## Problem

The architect writes the Technical Design without knowing the build path, and a separate classifier agent ran after to determine CORE_UPDATE vs STANDALONE. This was backwards — the build type influences the TD itself.

## Solution

The architect classifies the build path as part of his workflow (after intake + architecture check, before writing the TD), then routes directly via `done(next_agent=...)`.

## Files changed

| File | Change |
|------|--------|
| `druppie/agents/builtin_tools.py` | Add `next_agent` to done() schema, function, and dispatch |
| `druppie/agents/definitions/architect.yaml` | Add Step 2b build classification, `allowed_next_agents`, remove DESIGN_APPROVED_CORE_UPDATE |
| `druppie/agents/definitions/planner.yaml` | Update for direct architect routing, keep fallback |
| `druppie/agents/definitions/system_prompts/done_tool_format.yaml` | Document next_agent |
| `druppie/domain/agent_definition.py` | Add `allowed_next_agents` field |

## Test plan

- [ ] Maak een standalone project (bijv. "maak een todo app") en verifieer dat de architect `BUILD_PATH=STANDALONE` en `next_agent=builder_planner` in zijn done() zet, en dat builder_planner daarna direct start zonder planner tussenkomst
- [ ] Maak een core project (bijv. "maak een nieuwe MCP module") en verifieer dat de architect `BUILD_PATH=CORE_UPDATE` en `next_agent=update_core_builder` in zijn done() zet, en dat update_core_builder daarna direct start zonder planner tussenkomst

🤖 Generated with [Claude Code](https://claude.com/claude-code)