### PR TITLE
fix: cancel stale pending runs in continue_session

### DIFF
--- a/druppie/agents/builtin_tools.py
+++ b/druppie/agents/builtin_tools.py
@@ -895,9 +895,11 @@ async def done(
         else:
             next_agent = None  # Ignored — planner will decide as usual
 
-    # Relay accumulated summary to next pending agent
+    # Relay accumulated summary to the next pending planner only.
+    # Non-planner agents are self-contained — they read files from the
+    # workspace, not summary chains from previous agents.
     next_run = execution_repo.get_next_pending(session_id)
-    if next_run:
+    if next_run and next_run.agent_id == "planner":
         existing_prompt = next_run.planned_prompt or ""
         new_prompt = (
             f"PREVIOUS AGENT SUMMARY:\n{accumulated_summary}\n\n---\n\n"
@@ -906,11 +908,10 @@ async def done(
         execution_repo.update_planned_prompt(next_run.id, new_prompt)
         execution_repo.flush()
         logger.info(
-            "summary_relayed_to_next_agent",
+            "summary_relayed_to_planner",
             session_id=str(session_id),
             from_agent_run=str(agent_run_id),
             to_agent_run=str(next_run.id),
-            to_agent_id=next_run.agent_id,
         )
 
     result = {

--- a/druppie/testing/bounded_orchestrator.py
+++ b/druppie/testing/bounded_orchestrator.py
@@ -178,6 +178,26 @@ class BoundedOrchestrator:
                 else:
                     prompt = message
 
+                # Check if this agent was already completed (e.g. by
+                # _bounded_execute during a pause loop — when the architect
+                # pauses for approval, resume triggers execute_pending_runs
+                # which may run the build_classifier that done(next_agent=...)
+                # created). Skip it to avoid running the same agent twice.
+                self._db.expire_all()
+                completed_ids = {
+                    r.agent_id
+                    for r in execution_repo.get_completed_runs(session_id)
+                }
+                if agent_id in completed_ids and agent_id not in ("planner",):
+                    logger.info("Skipping %s — already completed by prior execution", agent_id)
+                    run_summary = None
+                    for run in execution_repo.get_completed_runs(session_id):
+                        if run.agent_id == agent_id:
+                            run_summary = execution_repo.get_done_summary_for_run(run.id)
+                    if run_summary:
+                        previous_summary = run_summary
+                    continue
+
                 # Reuse an existing pending run if one was created by a
                 # previous agent's done(next_agent=...) — e.g. architect
                 # creates a pending build_classifier via next_agent routing.

--- a/druppie/testing/bounded_orchestrator.py
+++ b/druppie/testing/bounded_orchestrator.py
@@ -125,6 +125,14 @@ class BoundedOrchestrator:
             # instead of going through process_message (which creates router+planner)
             result_session_id = session_id
 
+            # Cancel pending runs left over from setup (e.g. planner's
+            # make_plan may have created pending architect/planner runs
+            # that would duplicate the agents we're about to create).
+            cancelled = execution_repo.cancel_pending_runs(session_id)
+            if cancelled:
+                logger.info("Cancelled %d pending runs from setup before continue", cancelled)
+            execution_repo.commit()
+
             # Reset session to active
             session_repo.update_status(session_id, SessionStatus.ACTIVE)
             session_repo.commit()
@@ -145,7 +153,9 @@ class BoundedOrchestrator:
             # Build context from the session's project
             context = orchestrator.build_project_context(session_id)
 
-            # Get the last done summary for prompt context
+            # Collect previous agent summaries (only used for planner prompts,
+            # matching production where done() relays summaries to the next
+            # pending planner — non-planner agents are self-contained).
             completed_runs = execution_repo.get_completed_runs(session_id)
             previous_summary = ""
             for run in completed_runs:
@@ -156,7 +166,16 @@ class BoundedOrchestrator:
             # Create and run each specified agent directly
             all_agents_completed = True
             for i, agent_id in enumerate(self._real_agents):
-                prompt = f"PREVIOUS AGENT SUMMARY:\n{previous_summary}\n---\n\nUSER REQUEST:\n{message}"
+                # Planner gets previous summaries (matches production done()
+                # relay). All other agents get just the message — they read
+                # files from the workspace, not summary chains.
+                if agent_id == "planner" and previous_summary:
+                    prompt = (
+                        f"PREVIOUS AGENT SUMMARY:\n{previous_summary}\n---\n\n"
+                        + message
+                    )
+                else:
+                    prompt = message
 
                 agent_run = execution_repo.create_agent_run(
                     session_id=session_id,

--- a/druppie/testing/bounded_orchestrator.py
+++ b/druppie/testing/bounded_orchestrator.py
@@ -178,14 +178,22 @@ class BoundedOrchestrator:
                 else:
                     prompt = message
 
-                agent_run = execution_repo.create_agent_run(
-                    session_id=session_id,
-                    agent_id=agent_id,
-                    status=AgentRunStatus.PENDING,
-                    planned_prompt=prompt,
-                    sequence_number=next_seq + 1 + i,
-                )
-                execution_repo.commit()
+                # Reuse an existing pending run if one was created by a
+                # previous agent's done(next_agent=...) — e.g. architect
+                # creates a pending build_classifier via next_agent routing.
+                existing = execution_repo.get_pending_by_agent_id(session_id, agent_id)
+                if existing:
+                    agent_run = existing
+                    logger.info("Reusing existing pending run for %s (id=%s)", agent_id, existing.id)
+                else:
+                    agent_run = execution_repo.create_agent_run(
+                        session_id=session_id,
+                        agent_id=agent_id,
+                        status=AgentRunStatus.PENDING,
+                        planned_prompt=prompt,
+                        sequence_number=next_seq + 1 + i,
+                    )
+                    execution_repo.commit()
 
                 execution_repo.update_status(agent_run.id, AgentRunStatus.RUNNING)
                 execution_repo.commit()

--- a/druppie/testing/bounded_orchestrator.py
+++ b/druppie/testing/bounded_orchestrator.py
@@ -153,15 +153,16 @@ class BoundedOrchestrator:
             # Build context from the session's project
             context = orchestrator.build_project_context(session_id)
 
-            # Collect previous agent summaries (only used for planner prompts,
-            # matching production where done() relays summaries to the next
-            # pending planner — non-planner agents are self-contained).
+            # Get the accumulated summary from the LAST completed run.
+            # Each run's done() already accumulates all prior summaries,
+            # so the last one contains the full chain — no need to
+            # concatenate (which would cause massive duplication).
             completed_runs = execution_repo.get_completed_runs(session_id)
             previous_summary = ""
-            for run in completed_runs:
-                s = execution_repo.get_done_summary_for_run(run.id)
-                if s:
-                    previous_summary += s + "\n"
+            if completed_runs:
+                last_summary = execution_repo.get_done_summary_for_run(completed_runs[-1].id)
+                if last_summary:
+                    previous_summary = last_summary
 
             # Create and run each specified agent directly
             all_agents_completed = True
@@ -227,10 +228,12 @@ class BoundedOrchestrator:
                         )
                         break
 
-                # Update summary for next agent
+                # Update summary for next agent — the new run's done()
+                # summary already includes all prior summaries, so replace
+                # rather than append to avoid duplication.
                 run_summary = execution_repo.get_done_summary_for_run(agent_run.id)
                 if run_summary:
-                    previous_summary += run_summary + "\n"
+                    previous_summary = run_summary
 
             # Only mark COMPLETED if all agents actually ran to completion
             if all_agents_completed:

--- a/frontend/src/pages/evaluations/TestRunner.jsx
+++ b/frontend/src/pages/evaluations/TestRunner.jsx
@@ -18,6 +18,7 @@ import {
   ChevronRight,
   X,
   Info,
+  Search,
 } from 'lucide-react'
 import {
   getAvailableSetups,
@@ -47,6 +48,7 @@ export const TestSelectorModal = ({
   setJudgeEnabled,
 }) => {
   const [expandedTests, setExpandedTests] = useState(new Set())
+  const [searchQuery, setSearchQuery] = useState('')
 
   const toggleTest = (name) => {
     const next = new Set(selectedTests)
@@ -110,6 +112,28 @@ export const TestSelectorModal = ({
           </button>
         </div>
 
+        {/* Search */}
+        <div className="px-6 pt-3 pb-0">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search tests by name, tag, or description..."
+              className="w-full pl-9 pr-8 py-2 border border-gray-200 rounded-lg text-sm focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 outline-none"
+            />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery('')}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 hover:bg-gray-100 rounded"
+              >
+                <X className="w-3.5 h-3.5 text-gray-400" />
+              </button>
+            )}
+          </div>
+        </div>
+
         {/* Content */}
         <div className="flex-1 overflow-y-auto px-6 py-4 space-y-3">
           {loading && (
@@ -146,6 +170,16 @@ export const TestSelectorModal = ({
                 if (modeFilter === 'tool') return t.type === 'tool'
                 if (modeFilter === 'agent') return t.type === 'agent' && !t.manual_input
                 return t.type === modeFilter && !t.manual_input
+              }).filter((t) => {
+                if (!searchQuery.trim()) return true
+                const q = searchQuery.toLowerCase()
+                return (
+                  t.name.toLowerCase().includes(q) ||
+                  (t.description && t.description.toLowerCase().includes(q)) ||
+                  (t.tags && t.tags.some((tag) => tag.toLowerCase().includes(q))) ||
+                  (t.agents && t.agents.some((a) => a.toLowerCase().includes(q))) ||
+                  (t.message && t.message.toLowerCase().includes(q))
+                )
               }).map((test) => {
                 const checked = selectAll || selectedTests.has(test.name)
                 const expanded = expandedTests.has(test.name)

--- a/testing/agents/architect-reviews-fd.yaml
+++ b/testing/agents/architect-reviews-fd.yaml
@@ -1,31 +1,34 @@
-## Agent test: real architect reviews a functional design
+## Agent test: real architect reviews a functional design, then planner re-evaluates
 ##
 ## Setup: tool test creates a project with FD already written
 ##   (router → planner → BA → FD written and pushed to Gitea)
 ##
 ## continue_session: true → continues the LAST setup session.
-##   The architect runs directly in that session (no router/planner restart).
-##   It can read the FD from the workspace because it's the same session.
+##   The architect and planner run directly in that session (no router restart).
+##   The architect can read the FD from the workspace because it's the same session.
+##   The planner re-evaluates after the architect, receiving previous agent summaries.
 ##
-## Judge: evaluates TD quality (in Dutch, proper architecture, not just copied FD)
+## Judge: evaluates TD quality and planner re-evaluation
 
 agent-test:
   name: architect-reviews-fd
-  description: "Real architect reviews FD and produces technical design — judge evaluates quality"
-  tags: [architect, quality, judge, e2e]
+  description: "Real architect reviews FD and produces technical design, planner re-evaluates — judge evaluates quality"
+  tags: [architect, planner, quality, judge, e2e]
 
   setup:
     - setup-project-with-fd        # creates session with router → planner → BA → FD
-  continue_session: true           # architect runs in the SAME session (last setup)
+  continue_session: true           # architect + planner run in the SAME session
 
   message: "Review the functional design and create the technical design for this project"
-  agents: [architect]              # only architect runs (directly, no router/planner)
+  agents: [architect, planner]     # architect runs, then planner re-evaluates
   hitl: non-technical-pm
 
   assert:
     - check: architect-produces-td
 
   judge:
-    context: [architect]
+    context: [architect, planner]
     checks:
       - "The architect should have approved the design (done summary should contain DESIGN_APPROVED), OR given feedback (DESIGN_FEEDBACK). Either is acceptable — but the architect must make a clear decision."
+      - "The planner must have received PREVIOUS AGENT SUMMARY context that includes the architect's done summary. Check that the planner's prompt or tool calls reference previous agent work."
+      - "The planner should call make_plan to schedule the next agent (e.g. builder) or call done if no further work is needed. It must not re-schedule the architect."

--- a/testing/agents/architect-reviews-vergunningzoeker.yaml
+++ b/testing/agents/architect-reviews-vergunningzoeker.yaml
@@ -1,33 +1,38 @@
-## Agent test: real architect reviews vergunningzoeker FD, then planner re-evaluates
+## Agent test: real architect reviews vergunningzoeker FD, build_classifier
+##   routes, then planner re-evaluates
 ##
 ## Setup: BA completed a detailed FD for a Dutch waterschap permit metadata
 ##   search system with 12 FRs, archive compliance, and zaaksysteem migration.
 ##
-## continue_session: true — architect + planner run in the SAME session.
-##   The architect reviews the FD and creates a technical design.
+## continue_session: true — architect, build_classifier, and planner run
+##   in the SAME session.
+##   The architect reviews the FD and creates a technical design, then calls
+##   done(next_agent="build_classifier") to route to the build path classifier.
+##   The build_classifier determines the build path (standalone vs core update).
 ##   The planner re-evaluates and plans the next step.
 
 agent-test:
   name: architect-reviews-vergunningzoeker
-  description: "Real architect reviews vergunningzoeker FD — complex real-world domain with Archiefwet compliance"
-  tags: [architect, planner, quality, judge, e2e, vergunningzoeker]
+  description: "Real architect reviews vergunningzoeker FD, build_classifier routes, planner re-evaluates"
+  tags: [architect, build_classifier, planner, quality, judge, e2e, vergunningzoeker]
 
   setup:
     - setup-vergunningzoeker-with-fd
   continue_session: true
 
   message: "Review the functional design and create the technical design for the vergunningzoeker"
-  agents: [architect, planner]
+  agents: [architect, build_classifier, planner]
   hitl: non-technical-pm
 
   assert:
     - check: architect-produces-td
 
   judge:
-    context: [architect, planner]
+    context: [architect, build_classifier, planner]
     checks:
       - "The architect should have approved the design (done summary should contain DESIGN_APPROVED), OR given feedback (DESIGN_FEEDBACK). Either is acceptable — but the architect must make a clear decision."
       - "The technical design must address the search architecture — how to index metadata from multiple legacy databases into a unified search system."
       - "The technical design must address Archiefwet compliance — how archive nominations and retention periods from the selectielijst waterschappen 2012 are mapped and calculated."
       - "The technical design must address the zaaksysteem migration interface — how metadata and documents are transferred."
-      - "The planner should call make_plan to schedule the next agent (e.g. builder_planner) or call done if no further work is needed. It must not re-schedule the architect."
+      - "The build_classifier should have determined the build path (BUILD_PATH=STANDALONE or BUILD_PATH=CORE_UPDATE) based on the technical design."
+      - "The planner should call make_plan to schedule the next agent (e.g. builder_planner) based on the build_classifier's routing. It must not re-schedule the architect."

--- a/testing/agents/architect-reviews-vergunningzoeker.yaml
+++ b/testing/agents/architect-reviews-vergunningzoeker.yaml
@@ -1,38 +1,35 @@
-## Agent test: real architect reviews vergunningzoeker FD, build_classifier
-##   routes, then planner re-evaluates
+## Agent test: real architect reviews vergunningzoeker FD, build_classifier routes
 ##
 ## Setup: BA completed a detailed FD for a Dutch waterschap permit metadata
 ##   search system with 12 FRs, archive compliance, and zaaksysteem migration.
 ##
-## continue_session: true — architect, build_classifier, and planner run
-##   in the SAME session.
+## continue_session: true — architect and build_classifier run in the SAME session.
 ##   The architect reviews the FD and creates a technical design, then calls
-##   done(next_agent="build_classifier") to route to the build path classifier.
+##   done(next_agent="build_classifier") which creates a pending build_classifier.
+##   The bounded orchestrator reuses that pending run (no duplicate).
 ##   The build_classifier determines the build path (standalone vs core update).
-##   The planner re-evaluates and plans the next step.
 
 agent-test:
   name: architect-reviews-vergunningzoeker
-  description: "Real architect reviews vergunningzoeker FD, build_classifier routes, planner re-evaluates"
-  tags: [architect, build_classifier, planner, quality, judge, e2e, vergunningzoeker]
+  description: "Real architect reviews vergunningzoeker FD, build_classifier determines build path"
+  tags: [architect, build_classifier, quality, judge, e2e, vergunningzoeker]
 
   setup:
     - setup-vergunningzoeker-with-fd
   continue_session: true
 
   message: "Review the functional design and create the technical design for the vergunningzoeker"
-  agents: [architect, build_classifier, planner]
+  agents: [architect, build_classifier]
   hitl: non-technical-pm
 
   assert:
     - check: architect-produces-td
 
   judge:
-    context: [architect, build_classifier, planner]
+    context: [architect, build_classifier]
     checks:
       - "The architect should have approved the design (done summary should contain DESIGN_APPROVED), OR given feedback (DESIGN_FEEDBACK). Either is acceptable — but the architect must make a clear decision."
       - "The technical design must address the search architecture — how to index metadata from multiple legacy databases into a unified search system."
       - "The technical design must address Archiefwet compliance — how archive nominations and retention periods from the selectielijst waterschappen 2012 are mapped and calculated."
       - "The technical design must address the zaaksysteem migration interface — how metadata and documents are transferred."
       - "The build_classifier should have determined the build path (BUILD_PATH=STANDALONE or BUILD_PATH=CORE_UPDATE) based on the technical design."
-      - "The planner should call make_plan to schedule the next agent (e.g. builder_planner) based on the build_classifier's routing. It must not re-schedule the architect."

--- a/testing/agents/architect-reviews-vergunningzoeker.yaml
+++ b/testing/agents/architect-reviews-vergunningzoeker.yaml
@@ -1,0 +1,33 @@
+## Agent test: real architect reviews vergunningzoeker FD, then planner re-evaluates
+##
+## Setup: BA completed a detailed FD for a Dutch waterschap permit metadata
+##   search system with 12 FRs, archive compliance, and zaaksysteem migration.
+##
+## continue_session: true — architect + planner run in the SAME session.
+##   The architect reviews the FD and creates a technical design.
+##   The planner re-evaluates and plans the next step.
+
+agent-test:
+  name: architect-reviews-vergunningzoeker
+  description: "Real architect reviews vergunningzoeker FD — complex real-world domain with Archiefwet compliance"
+  tags: [architect, planner, quality, judge, e2e, vergunningzoeker]
+
+  setup:
+    - setup-vergunningzoeker-with-fd
+  continue_session: true
+
+  message: "Review the functional design and create the technical design for the vergunningzoeker"
+  agents: [architect, planner]
+  hitl: non-technical-pm
+
+  assert:
+    - check: architect-produces-td
+
+  judge:
+    context: [architect, planner]
+    checks:
+      - "The architect should have approved the design (done summary should contain DESIGN_APPROVED), OR given feedback (DESIGN_FEEDBACK). Either is acceptable — but the architect must make a clear decision."
+      - "The technical design must address the search architecture — how to index metadata from multiple legacy databases into a unified search system."
+      - "The technical design must address Archiefwet compliance — how archive nominations and retention periods from the selectielijst waterschappen 2012 are mapped and calculated."
+      - "The technical design must address the zaaksysteem migration interface — how metadata and documents are transferred."
+      - "The planner should call make_plan to schedule the next agent (e.g. builder_planner) or call done if no further work is needed. It must not re-schedule the architect."

--- a/testing/agents/builder-uses-sdk.yaml
+++ b/testing/agents/builder-uses-sdk.yaml
@@ -1,0 +1,35 @@
+## Agent test: real builder creates an SDK-aware app, then planner re-evaluates
+##
+## Setup: tool test creates a project with FD + TD + builder plan + tests
+##   (all mentioning Druppie modules and SDK usage)
+##
+## continue_session: true — builder + planner run in the SAME session as setup.
+##   Builder reads FD, TD, and builder-plan.md from the workspace.
+##   Planner re-evaluates after builder, leaving pending runs for continuation.
+##
+## Judge: evaluates that the builder actually used druppie_sdk in its code,
+##   did NOT use openai directly, and did NOT hardcode API keys.
+
+agent-test:
+  name: builder-uses-sdk
+  description: "Real builder creates an app using Druppie SDK, planner re-evaluates — judge verifies SDK usage"
+  tags: [builder, planner, sdk, quality, judge, e2e]
+
+  setup:
+    - setup-sdk-recipe-app      # creates session with full pipeline up to test_builder
+
+  continue_session: true        # builder + planner run in the SAME session
+
+  message: "Build the recipe analyzer app as described in the technical design, using Druppie SDK for AI."
+  agents: [builder, planner]    # builder runs, then planner re-evaluates (leaves pending runs)
+
+  assert:
+    - check: builder-uses-sdk
+
+  judge:
+    context: [builder]
+    checks:
+      - "The builder should have used `from druppie_sdk import DruppieClient` in the app code. Check the execute_coding_task tool call results for SDK imports."
+      - "The builder should NOT have used the openai package directly (no `from openai import` or `import openai`). All LLM calls should go through druppie.call()."
+      - "The builder should NOT have hardcoded any API keys (no DEEPINFRA_API_KEY, OPENAI_API_KEY, or similar in the code). The SDK reads DRUPPIE_URL from environment automatically."
+      - "The builder should have implemented recipe upload with OCR (druppie.call('llm', 'vision', ...)) and a chat endpoint (druppie.call('llm', 'chat', ...))."

--- a/testing/agents/planner-after-ba.yaml
+++ b/testing/agents/planner-after-ba.yaml
@@ -1,0 +1,34 @@
+## Agent test: planner re-evaluates after BA completes
+##
+## Setup: tool test creates a project with FD already written
+##   (router -> planner -> BA -> FD written and pushed)
+##
+## continue_session: true -> planner runs in the SAME session.
+##   It receives the accumulated summary from all setup agents and
+##   decides what to do next (should plan the architect).
+##
+## Tests that:
+##   1. Planner receives a clean, deduplicated PREVIOUS AGENT SUMMARY
+##   2. Planner calls make_plan with the architect as next step
+##   3. Planner does NOT re-schedule the BA
+
+agent-test:
+  name: planner-after-ba
+  description: "Planner re-evaluates after BA wrote FD — should plan architect, not repeat BA"
+  tags: [planner, quality, judge, continue-session]
+
+  setup:
+    - setup-project-with-fd        # creates session with router -> planner -> BA -> FD
+  continue_session: true           # planner runs in the SAME session
+
+  message: "Continue with the next step for this project"
+  agents: [planner]                # only planner runs
+  hitl: non-technical-pm
+
+  judge:
+    context: [planner]
+    checks:
+      - "The planner must have called make_plan. Check that the builtin:make_plan tool was invoked."
+      - "The planner's make_plan should include the architect as the next agent (agent_id: architect). The BA already completed the functional design — the next logical step is technical design by the architect."
+      - "The planner must NOT re-schedule the business_analyst. The BA already completed its work (DESIGN_APPROVED)."
+      - "The planner's prompt should contain a PREVIOUS AGENT SUMMARY section. Verify it includes summaries from router, planner, and business_analyst — each appearing only once (no duplicates)."

--- a/testing/tools/architect-paused-mid-run.yaml
+++ b/testing/tools/architect-paused-mid-run.yaml
@@ -1,7 +1,7 @@
 ## Paused session: architect mid-run, ready for manual resume
 ## Extends setup-project-with-fd (BA completed, FD in place).
-## Architect has read the FD, loaded principles, and written the TD.
-## Paused before git commit + done.
+## Adds planner re-evaluation (plans architect), then architect starts work:
+## reads FD, loads principles, writes TD. Paused before git commit + done.
 ## Click "Continue" in the UI to resume — the architect should just
 ## git add/commit/push the TD and call done().
 
@@ -13,8 +13,22 @@ tool-test:
   session_status: paused
 
   chain:
+    # --- Planner re-evaluates after BA → plans architect ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: architect
+            prompt: "Review the functional design and create the technical design"
+          - agent_id: planner
+            prompt: "Re-evaluate after architect completes"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: BA approved design, planned architect to review FD and create technical design"
+
     # --- Architect starts work ---
-    # planned_prompt is set naturally by make_plan in setup-project-with-fd
     - agent: architect
       tool: coding:read_file
       mock: true
@@ -157,5 +171,3 @@ tool-test:
     # Architect has written the TD. Session is now paused.
     # On resume, the architect sees its full tool history and should
     # just git add/commit/push the TD and call done().
-    # The planner is already pending (created by make_plan in
-    # setup-project-with-fd) and will pick up after the architect.

--- a/testing/tools/create-sdk-recipe-app.yaml
+++ b/testing/tools/create-sdk-recipe-app.yaml
@@ -1,0 +1,219 @@
+## End-to-end: create a recipe analyzer app with Druppie SDK
+## Extends setup-sdk-recipe-app, adds: builder (mocked with SDK code) + deploy (mock)
+##
+## Validates that the full pipeline produces an app that:
+## - Uses druppie_sdk (not openai or hardcoded keys)
+## - Has proper module integration in the builder plan
+## - TD mentions Druppie modules
+
+tool-test:
+  name: create-sdk-recipe-app
+  description: "Full pipeline for SDK-aware app (mocked builder + deploy)"
+  tags: [e2e, create-project, sdk, mock-deploy]
+  extends: setup-sdk-recipe-app
+
+  chain:
+    # --- Planner → Builder ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: builder
+            prompt: "Build the recipe analyzer to pass the tests, using Druppie SDK for AI"
+          - agent_id: planner
+            prompt: "Re-evaluate after builder completes"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: Planned builder"
+
+    # --- Builder (mocked — outcome files use druppie_sdk correctly) ---
+    - agent: builder
+      tool: coding:execute_coding_task
+      arguments:
+        task: "Build the recipe analyzer to pass the tests, using Druppie SDK for AI"
+      mock: true
+      mock_result: "All files created successfully"
+      outcome:
+        files:
+          - path: app/routes.py
+            content: |
+              from flask import Blueprint, jsonify, request
+              from druppie_sdk import DruppieClient
+
+              api = Blueprint("api", __name__)
+              druppie = DruppieClient()
+
+              @api.route("/info")
+              def info():
+                  from app.config import settings
+                  return jsonify(app_name=settings.app_name)
+
+              @api.route("/recipes/upload", methods=["POST"])
+              def upload_recipe():
+                  data = request.get_json(silent=True)
+                  if not data or "image_url" not in data:
+                      return jsonify(error="Missing image_url"), 400
+                  result = druppie.call("llm", "vision", {"image_url": data["image_url"]})
+                  extracted_text = result.get("text", "")
+                  analysis = druppie.call("llm", "chat", {
+                      "prompt": f"Analyseer dit recept en geef ingredienten en stappen:\n\n{extracted_text}",
+                      "system": "Je bent een ervaren chef-kok die recepten analyseert.",
+                  })
+                  return jsonify(
+                      extracted_text=extracted_text,
+                      analysis=analysis.get("answer", ""),
+                  )
+
+              @api.route("/recipes/<recipe_id>/chat", methods=["POST"])
+              def chat_recipe(recipe_id):
+                  data = request.get_json(silent=True)
+                  if not data or "prompt" not in data:
+                      return jsonify(error="Missing prompt"), 400
+                  result = druppie.call("llm", "chat", {
+                      "prompt": data["prompt"],
+                      "system": "Je bent een behulpzame chef-kok.",
+                  })
+                  return jsonify(answer=result.get("answer", ""))
+
+    - agent: builder
+      tool: builtin:done
+      arguments:
+        summary: "Agent builder: BUILD_COMPLETE — Recipe analyzer with Druppie SDK for LLM and vision."
+
+    # --- Planner → test_executor ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: test_executor
+            prompt: "Run all tests"
+          - agent_id: planner
+            prompt: "Re-evaluate after test_executor completes"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: Planned test_executor"
+
+    # --- Test Executor (mocked) ---
+    - agent: test_executor
+      tool: coding:run_tests
+      mock: true
+      mock_result: '{"success": true, "output": "2 passed, 0 failed", "exit_code": 0}'
+
+    - agent: test_executor
+      tool: coding:get_coverage_report
+      mock: true
+      mock_result: '{"coverage": 82, "lines_covered": 41, "lines_total": 50}'
+
+    - agent: test_executor
+      tool: builtin:test_report
+      mock: true
+      mock_result: '{"status": "ok"}'
+      arguments:
+        total: 2
+        passed: 2
+        failed: 0
+        coverage: 82
+        summary: "Agent test_executor: All 2 tests passed with 82% coverage"
+
+    - agent: test_executor
+      tool: builtin:done
+      arguments:
+        summary: "Agent test_executor: TEST RESULT: PASS — 2/2 tests passed, 82% coverage."
+
+    # --- Planner → deployer ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: deployer
+            prompt: "Deploy the recipe analyzer"
+          - agent_id: planner
+            prompt: "Re-evaluate after deployer completes"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: Tests passed, planned deployer"
+
+    # --- Deployer (mocked) ---
+    - agent: deployer
+      tool: docker:list_containers
+      mock: true
+      mock_result: '{"containers": []}'
+
+    - agent: deployer
+      tool: docker:compose_up
+      mock: true
+      mock_result: '{"success": true, "containers": ["recipe-analyzer-1"], "url": "http://localhost:9105", "compose_project_name": "recipe-analyzer"}'
+      arguments:
+        compose_project_name: recipe-analyzer
+        branch: main
+
+    - agent: deployer
+      tool: builtin:done
+      arguments:
+        summary: "Agent deployer: Deployed recipe-analyzer at http://localhost:9105."
+
+    # --- Planner → summarizer ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: summarizer
+            prompt: "Summarize what was accomplished"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: Planned summarizer"
+
+    # --- Summarizer ---
+    - agent: summarizer
+      tool: builtin:create_message
+      arguments:
+        content: |
+          Your recipe analyzer has been built and deployed!
+
+          **Features:**
+          - Upload recipe photos — OCR extracts text via Druppie module-llm
+          - AI analysis of recipes (ingredients, steps, nutrition)
+          - Chat interface for questions about recipes
+
+          **Tech:** Flask + React, AI via Druppie SDK (no hardcoded API keys)
+
+          The app is running at http://localhost:9105.
+
+    - agent: summarizer
+      tool: builtin:done
+      arguments:
+        summary: "Agent summarizer: Presented completion summary."
+      assert:
+        completed: true
+
+  # Verify side-effects in Gitea
+  verify:
+    - gitea_repo_exists: true
+    - file_exists: docs/functional-design.md
+    - file_exists: docs/technical-design.md
+    - file_exists: docs/builder-plan.md
+    - file_not_empty: docs/functional-design.md
+    - file_not_empty: docs/technical-design.md
+    - file_not_empty: docs/builder-plan.md
+    # Verify TD mentions Druppie modules
+    - file_contains:
+        path: docs/technical-design.md
+        content: "druppie_sdk"
+    - file_contains:
+        path: docs/technical-design.md
+        content: "DruppieClient"
+    # Verify builder plan includes module integration
+    - file_contains:
+        path: docs/builder-plan.md
+        content: "Module Integration"
+    - file_contains:
+        path: docs/builder-plan.md
+        content: "llm/chat"

--- a/testing/tools/setup-portfolio-with-fd.yaml
+++ b/testing/tools/setup-portfolio-with-fd.yaml
@@ -1,8 +1,11 @@
-## Setup: create a portfolio project with functional design ready for architect review
+## Setup: create a portfolio project with functional design written and committed
+##
+## Chain: router → planner → BA (HITL + FD + git) → done
+## Ends after BA completes — no trailing planner.
 
 tool-test:
   name: setup-portfolio-with-fd
-  description: "Creates a portfolio project with FD — ready for architect review"
+  description: "Creates a portfolio project with FD — BA completed, ready for planner re-evaluation"
   tags: [setup]
 
   chain:
@@ -100,17 +103,3 @@ tool-test:
         summary: "Agent business_analyst: DESIGN_APPROVED"
       assert:
         completed: true
-
-    - agent: planner
-      tool: builtin:make_plan
-      arguments:
-        steps:
-          - agent_id: architect
-            prompt: "Review the functional design and create the technical design"
-          - agent_id: planner
-            prompt: "Re-evaluate after architect completes"
-
-    - agent: planner
-      tool: builtin:done
-      arguments:
-        summary: "Agent planner: BA approved, planned architect"

--- a/testing/tools/setup-project-with-fd.yaml
+++ b/testing/tools/setup-project-with-fd.yaml
@@ -1,9 +1,16 @@
-## Setup: create a project with functional design ready for architect review
-## Used as setup for agent tests that need a project with FD already written.
+## Setup: create a project with functional design written and committed
+##
+## Chain: router → planner → BA (HITL + FD + git) → done
+## Ends after BA completes — no trailing planner, so tests that
+## continue_session can control what runs next without stale pending runs.
+##
+## Used by:
+##   - agent tests (setup + continue_session): architect-reviews-fd, planner-after-ba
+##   - tool tests (extends): architect-paused-mid-run
 
 tool-test:
   name: setup-project-with-fd
-  description: "Creates a project with FD — ready for architect review"
+  description: "Creates a project with FD — BA completed, ready for planner re-evaluation"
   tags: [setup]
 
   chain:
@@ -113,18 +120,3 @@ tool-test:
         summary: "Agent business_analyst: DESIGN_APPROVED. Gathered requirements and wrote functional_design.md with 6 functional requirements and 3 non-functional requirements."
       assert:
         completed: true
-
-    # --- Planner (routes to architect) ---
-    - agent: planner
-      tool: builtin:make_plan
-      arguments:
-        steps:
-          - agent_id: architect
-            prompt: "Review the functional design and create the technical design"
-          - agent_id: planner
-            prompt: "Re-evaluate after architect completes"
-
-    - agent: planner
-      tool: builtin:done
-      arguments:
-        summary: "Agent planner: BA approved design, planned architect to review FD and create technical design"

--- a/testing/tools/setup-sdk-recipe-app.yaml
+++ b/testing/tools/setup-sdk-recipe-app.yaml
@@ -1,0 +1,377 @@
+## Shared base: SDK-aware recipe analyzer app pipeline
+## Router → Planner → BA (FD with AI/OCR needs) → Planner → Architect (TD with druppie modules)
+## → Planner → Builder Planner (plan includes Module Integration) → Planner → Test Builder
+## Ends after test_builder completes — no trailing planner.
+##
+## Used by: create-sdk-recipe-app, builder-uses-sdk agent test
+
+tool-test:
+  name: setup-sdk-recipe-app
+  description: "Pipeline for app that requires Druppie SDK (LLM + OCR via modules)"
+  tags: [setup, create-project, sdk]
+
+  chain:
+    # --- Router ---
+    - agent: router
+      tool: builtin:set_intent
+      arguments:
+        intent: create_project
+        project_name: recipe-analyzer
+        description: "A recipe analyzer that uses AI to analyze recipe images (OCR) and suggest improvements"
+      assert:
+        result:
+          - not_empty
+          - { contains: "recipe-analyzer" }
+
+    - agent: router
+      tool: builtin:done
+      arguments:
+        summary: "Agent router: Classified as create_project for recipe-analyzer"
+      assert:
+        completed: true
+
+    # --- Planner → BA ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: business_analyst
+            prompt: "Gather requirements for the recipe analyzer and create functional design"
+          - agent_id: planner
+            prompt: "Re-evaluate after business_analyst completes"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: Planned business_analyst"
+
+    # --- Business Analyst ---
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      arguments:
+        question: "Welke AI-functies wilt u in de recipe analyzer?"
+        choices:
+          - "Basis: alleen recepttekst analyseren"
+          - "Uitgebreid: tekst + afbeelding OCR"
+          - "Volledig: tekst + OCR + suggesties genereren"
+      mock: true
+      mock_result: "Uitgebreid: tekst + afbeelding OCR"
+
+    - agent: business_analyst
+      tool: coding:make_design
+      approval:
+        status: approved
+        by: analyst
+      arguments:
+        path: docs/functional-design.md
+        content: |
+          # Functioneel Ontwerp: Recipe Analyzer
+
+          ## Vereisten
+          - FR-01: Gebruiker kan een foto van een recept uploaden
+          - FR-02: App extraheert tekst uit de afbeelding via OCR
+          - FR-03: App analyseert het recept met AI (ingredienten, stappen, voedingswaarden)
+          - FR-04: Gebruiker kan vragen stellen over het recept via een chatfunctie
+          - FR-05: App geeft AI-gestuurde suggesties voor receptverbeteringen
+          - FR-06: Recepten worden opgeslagen in een database
+
+          ## AI-Capabilities
+          - LLM chat: recept analyseren, vragen beantwoorden, suggesties genereren
+          - Vision/OCR: tekst extraheren uit receptfoto's
+
+          ## Gebruikersinterface
+          - Upload-pagina voor receptfoto's
+          - Analysepagina met geextraheerde tekst en AI-analyse
+          - Chat-interface voor vragen over het recept
+      assert:
+        result:
+          - not_empty
+          - { contains: "functional-design.md" }
+
+    - agent: business_analyst
+      tool: coding:run_git
+      arguments:
+        command: "add docs/functional-design.md"
+
+    - agent: business_analyst
+      tool: coding:run_git
+      arguments:
+        command: "commit -m 'Functioneel ontwerp recipe analyzer'"
+
+    - agent: business_analyst
+      tool: coding:run_git
+      arguments:
+        command: "push"
+
+    - agent: business_analyst
+      tool: builtin:done
+      arguments:
+        summary: "Agent business_analyst: DESIGN_APPROVED"
+
+    # --- Planner → Architect ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: architect
+            prompt: "Create technical design for the recipe analyzer — must use Druppie modules for AI"
+          - agent_id: planner
+            prompt: "Re-evaluate after architect completes"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: BA approved, planned architect"
+
+    # --- Architect (TD explicitly mentions druppie modules + SDK) ---
+    - agent: architect
+      tool: coding:run_git
+      arguments:
+        command: "pull"
+
+    - agent: architect
+      tool: coding:read_file
+      arguments:
+        path: docs/functional-design.md
+      assert:
+        result:
+          - not_empty
+          - { contains: "Functioneel Ontwerp" }
+
+    - agent: architect
+      tool: coding:make_design
+      approval:
+        status: approved
+        by: architect
+      arguments:
+        path: docs/technical-design.md
+        content: |
+          # Technisch Ontwerp: Recipe Analyzer
+
+          ## Stack
+          - Backend: Python Flask (project template)
+          - Frontend: React met Vite
+          - Database: PostgreSQL
+          - AI: Druppie platform modules via SDK
+
+          ## Druppie Modules
+          De app gebruikt de Druppie SDK (`druppie_sdk`) om platformmodules aan te roepen.
+          Geen directe API-keys of externe provider-calls in de app.
+
+          | Module | Tool | Gebruik |
+          |--------|------|---------|
+          | llm | chat | Recept analyseren, vragen beantwoorden, suggesties |
+          | llm | vision | OCR: tekst extraheren uit receptfoto's |
+
+          Gebruik:
+          ```python
+          from druppie_sdk import DruppieClient
+          druppie = DruppieClient()
+          result = druppie.call("llm", "chat", {"prompt": "Analyseer dit recept: ..."})
+          result = druppie.call("llm", "vision", {"image_url": "https://..."})
+          ```
+
+          ## Componenten
+          - UploadHandler: verwerkt receptfoto uploads, slaat op in DB
+          - RecipeAnalyzer: roept druppie llm/vision aan voor analyse
+          - ChatHandler: LLM chat via druppie SDK voor vragen
+          - RecipeStore: PostgreSQL repository voor recepten
+
+          ## API Endpoints
+          - POST /api/recipes/upload — upload foto, start OCR + analyse
+          - GET /api/recipes/:id — haal recept met analyse op
+          - POST /api/recipes/:id/chat — stel vraag over recept
+          - GET /api/recipes — lijst van alle recepten
+
+          ## Belangrijk
+          - GEEN hardcoded API keys in de app
+          - GEEN openai package — gebruik druppie_sdk
+          - DRUPPIE_URL wordt automatisch geïnjecteerd bij deploy
+      assert:
+        result:
+          - { contains: "technical-design.md" }
+
+    - agent: architect
+      tool: coding:run_git
+      arguments:
+        command: "add docs/technical-design.md"
+
+    - agent: architect
+      tool: coding:run_git
+      arguments:
+        command: "commit -m 'Technisch ontwerp recipe analyzer met Druppie SDK'"
+
+    - agent: architect
+      tool: coding:run_git
+      arguments:
+        command: "push"
+
+    - agent: architect
+      tool: builtin:done
+      arguments:
+        summary: "Agent architect: DESIGN_APPROVED"
+
+    # --- Planner → Builder Planner ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: builder_planner
+            prompt: "Create a builder plan for the recipe analyzer"
+          - agent_id: planner
+            prompt: "Re-evaluate after builder_planner completes"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: Architect approved, planned builder_planner"
+
+    # --- Builder Planner (plan includes Module Integration section) ---
+    - agent: builder_planner
+      tool: coding:run_git
+      arguments:
+        command: "pull"
+
+    - agent: builder_planner
+      tool: coding:read_file
+      arguments:
+        path: docs/functional-design.md
+
+    - agent: builder_planner
+      tool: coding:read_file
+      arguments:
+        path: docs/technical-design.md
+
+    - agent: builder_planner
+      tool: coding:write_file
+      arguments:
+        path: docs/builder-plan.md
+        content: |
+          # Builder Plan: Recipe Analyzer
+
+          ## Solution Strategy
+          Flask backend met React frontend. AI via Druppie SDK.
+
+          ## Module Integration
+          - **SDK**: `druppie_sdk` is pre-installed (pip package)
+          - **Usage**: `from druppie_sdk import DruppieClient; druppie = DruppieClient()`
+          - **Modules Used**:
+            - `llm/chat` — recept analyseren, vragen beantwoorden, suggesties
+            - `llm/vision` — OCR: tekst extraheren uit receptfoto's
+          - **Example Calls**:
+            ```python
+            result = druppie.call("llm", "chat", {"prompt": "Analyseer: ...", "system": "Je bent een chef-kok"})
+            result = druppie.call("llm", "vision", {"image_url": url})
+            ```
+          - **No API Keys**: app gebruikt GEEN hardcoded API keys
+          - **No openai package**: gebruik `druppie.call("llm", ...)` i.p.v. OpenAI client
+
+          ## Code Standards
+          - Python 3.11, Flask
+          - ESM imports, React functional components
+          - SQLAlchemy voor database
+
+          ## Test Framework
+          pytest voor backend, Vitest voor frontend
+
+          ## Files to Create/Modify
+          - app/routes.py — API endpoints met druppie SDK calls
+          - app/models.py — SQLAlchemy Recipe model
+          - frontend/src/App.jsx — upload + analyse UI
+          - frontend/src/components/RecipeUpload.jsx
+          - frontend/src/components/RecipeChat.jsx
+
+    - agent: builder_planner
+      tool: coding:run_git
+      arguments:
+        command: "add docs/builder-plan.md"
+
+    - agent: builder_planner
+      tool: coding:run_git
+      arguments:
+        command: "commit -m 'Add builder plan with SDK module integration'"
+
+    - agent: builder_planner
+      tool: coding:run_git
+      arguments:
+        command: "push"
+
+    - agent: builder_planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent builder_planner: Created builder-plan.md with module integration section for llm/chat and llm/vision."
+
+    # --- Planner → Test Builder ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: test_builder
+            prompt: "Write tests for the recipe analyzer based on the builder plan"
+          - agent_id: planner
+            prompt: "Re-evaluate after test_builder completes"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: Planned test_builder"
+
+    # --- Test Builder ---
+    - agent: test_builder
+      tool: coding:run_git
+      arguments:
+        command: "pull"
+
+    - agent: test_builder
+      tool: coding:read_file
+      arguments:
+        path: docs/builder-plan.md
+
+    - agent: test_builder
+      tool: coding:get_test_framework
+      mock: true
+      mock_result: '{"framework": "pytest", "config_file": "pytest.ini"}'
+
+    - agent: test_builder
+      tool: coding:write_file
+      arguments:
+        path: tests/test_routes.py
+        content: |
+          import pytest
+          from unittest.mock import patch, MagicMock
+
+          def test_upload_recipe(client):
+              """Upload should trigger OCR + analysis via SDK."""
+              with patch("app.routes.druppie") as mock_druppie:
+                  mock_druppie.call.return_value = {"text": "2 eggs, 100g flour"}
+                  resp = client.post("/api/recipes/upload", json={"image_url": "https://example.com/recipe.jpg"})
+                  assert resp.status_code == 200
+                  mock_druppie.call.assert_called_with("llm", "vision", {"image_url": "https://example.com/recipe.jpg"})
+
+          def test_chat_recipe(client):
+              """Chat should use LLM via SDK."""
+              with patch("app.routes.druppie") as mock_druppie:
+                  mock_druppie.call.return_value = {"answer": "Dit recept bevat 350 calorieen."}
+                  resp = client.post("/api/recipes/1/chat", json={"prompt": "Hoeveel calorieen?"})
+                  assert resp.status_code == 200
+                  mock_druppie.call.assert_called_with("llm", "chat", {"prompt": "Hoeveel calorieen?", "system": pytest.approx(str, abs=100)})
+
+    - agent: test_builder
+      tool: coding:run_git
+      arguments:
+        command: "add tests/test_routes.py"
+
+    - agent: test_builder
+      tool: coding:run_git
+      arguments:
+        command: "commit -m 'Add recipe analyzer tests (Red phase)'"
+
+    - agent: test_builder
+      tool: coding:run_git
+      arguments:
+        command: "push"
+
+    - agent: test_builder
+      tool: builtin:done
+      arguments:
+        summary: "Agent test_builder: Wrote 2 tests in tests/test_routes.py (pytest)."

--- a/testing/tools/setup-vergunningzoeker-with-fd.yaml
+++ b/testing/tools/setup-vergunningzoeker-with-fd.yaml
@@ -1,0 +1,340 @@
+## Setup: create a vergunningzoeker project with functional design written and committed
+##
+## Chain: router → planner → BA (HITL + FD + git) → done
+## Ends after BA completes — no trailing planner.
+##
+## The FD is a real-world permit metadata search system for a Dutch waterschap.
+
+tool-test:
+  name: setup-vergunningzoeker-with-fd
+  description: "Creates vergunningzoeker project with FD — BA completed, ready for planner re-evaluation"
+  tags: [setup, vergunningzoeker]
+
+  chain:
+    # --- Router ---
+    - agent: router
+      tool: builtin:set_intent
+      arguments:
+        intent: create_project
+        project_name: vergunningzoeker
+        description: "A permit metadata search system for a Dutch waterschap — unified search across historical permit databases with archive status tracking and migration to zaaksysteem"
+      assert:
+        result:
+          - not_empty
+
+    - agent: router
+      tool: builtin:done
+      arguments:
+        summary: "Agent router: Classified as create_project for vergunningzoeker"
+
+    # --- Planner ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: business_analyst
+            prompt: "Gather requirements for the vergunningzoeker and create functional design"
+          - agent_id: planner
+            prompt: "Re-evaluate after business analyst completes"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: Planned business_analyst to gather requirements and create functional design"
+
+    # --- Business Analyst ---
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Ja, we willen ook migratie naar het zaaksysteem"
+      arguments:
+        question: "Moet het systeem ook migratiefunctionaliteit naar het zaaksysteem bieden?"
+        choices:
+          - "Ja, we willen ook migratie naar het zaaksysteem"
+          - "Nee, alleen zoeken en inzicht in archiefstatus"
+
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Ja, inclusief retentieperiodes en archiefnominaties volgens selectielijst waterschappen 2012"
+      arguments:
+        question: "Moet het systeem archiefstatus tonen volgens de Archiefwet?"
+        choices:
+          - "Ja, inclusief retentieperiodes en archiefnominaties volgens selectielijst waterschappen 2012"
+          - "Nee, alleen basis metadata zoeken"
+
+    - agent: business_analyst
+      tool: coding:make_design
+      approval:
+        status: approved
+        by: analyst
+      arguments:
+        path: docs/functional-design.md
+        content: |
+          # Functioneel Ontwerp - Permit Metadata Search
+
+          ## 1. Huidige vs. Gewenste Situatie
+
+          | Aspect | Huidige Situatie | Gewenste Situatie |
+          |--------|-----------------|-------------------|
+          | Zoekmogelijkheden | Gefragmenteerd: locatiezoek werkt alleen na 2018; oude vergunningen alleen via K/L-nummer; verschillende nummeringssystemen voor verschillende periodes | Uniforme zoekinterface over alle vergunningen en periodes |
+          | Data-opslag | Verspreid over meerdere databases en bestandsformaten (PDF's, scans) | Geïndexeerde metadata uit alle bronnen toegankelijk via één systeem |
+          | Kennisoverdracht | Kennis over waar en hoe te zoeken is afhankelijk van ervaren medewerkers en raakt verloren | Intuïtief systeem waar nieuwe medewerkers direct mee kunnen werken |
+          | Archiefwet-naleving | Niet nageleefd: locatie van alle vergunningen en retentieperiodes zijn onbekend | Inzicht in retentieperiodes en archiefstatus van alle vergunningen |
+          | Toegang | Afhankelijk van toegang tot verschillende systemen | Gecontroleerde toegang via gecentraliseerd systeem voor specifieke afdelingen |
+          | Migratie | Documenten staan in diverse legacy systemen, moeilijk over te brengen naar zaaksysteem | Mogelijkheid om documenten en metadata te migreren naar zaaksysteem |
+
+          ## 2. Problemsamenvatting
+
+          **Wie is getroffen:**
+          - Medewerkers die vergunningen uitgeven (zoeken naar oude vergunningen)
+          - Leidinggevenden (zoeken op locatie voor overzichten)
+          - Nieuwe collega's (geen kennis van verspreide systemen)
+          - Medewerkers die archiefbeheer uitvoeren
+
+          **Welk probleem ervaren ze:**
+          - Verspilling van tijd door zoeken in meerdere systemen met verschillende zoekmethoden
+          - Kennisverlies over waar bepaalde types vergunningen te vinden zijn
+          - Onmogelijk om oude vergunningen (voor 2018) op locatie te filteren
+          - Geen overzicht van alle vergunningen en hun retentiestatus
+          - Moeilijk om documenten te migreren naar het nieuwe zaaksysteem
+
+          **Waarom dit belangrijk is (bedrijfsimpact):**
+          - Inefficiëntie in dagelijkse werkprocessen
+          - Risico op niet-naleving van de Archiefwet (onbekende locatie en retentieperiodes)
+          - Afhankelijkheid van individuele medewerkers met specifieke kennis
+          - Moeilijke integratie van nieuwe medewerkers
+          - Behoefte om historische data te moderniseren in het zaaksysteem
+
+          **Wat succes betekent:**
+          - Eén centrale zoekinterface waarmee alle vergunningen vindbaar zijn
+          - Direct inzicht in retentieperiodes en archiefstatus
+          - Verlaagde drempel voor nieuwe medewerkers om vergunningen te vinden
+          - Compliance met Archiefwet door volledig overzicht
+          - Mogelijkheid om historische vergunningen te migreren naar zaaksysteem
+
+          ## 3. Functionele Eisen
+
+          | ID | Bron | Eis | Verificatiemethode |
+          |----|------|-----|-------------------|
+          | FR-01 | BA | Het systeem stelt gebruikers in staat om via één enkel zoekvak te zoeken over alle metadata-velden tegelijk. | Test: Voer een zoekterm in en verifieer dat resultaten uit alle velden worden getoond. |
+          | FR-02 | BA | Het systeem biedt een geavanceerde zoekoptie met filters voor specifieke metadata-velden. | Test: Open geavanceerd zoeken en verifieer aanwezigheid van filters per veldtype. |
+          | FR-03 | BA | Het systeem indexeert en doorzoekt metadata van: aanvrager naam, vergunninghouder naam, uitgever naam, locatie, datums, vergunningnummer (K, L, enz.), toepasselijke wet, type werk, type oppervlaktewater, type waterkering. | Test: Zoek op elk van deze velden en verifieer dat resultaten worden getoond. |
+          | FR-04 | BA | Het systeem toont bij zoekresultaten alle beschikbare metadata-velden voor elke vergunning. | Test: Bekijk zoekresultaten en verifieer volledigheid van velden. |
+          | FR-05 | BA | Het systeem stelt gebruikers in staat om gedetailleerde vergunninginformatie te bekijken. | Test: Klik op een resultaat en verifieer dat detailweergave wordt geopend. |
+          | FR-06 | BA | Het systeem toont uit welk bronsysteem elke vergunning afkomstig is. | Test: Verifieer aanwezigheid van bronsysteem-informatie in resultaten. |
+          | FR-07 | BA | Het systeem stelt gebruikers in staat om originele vergunningdocumenten (PDF's, scans) te openen of te downloaden. | Test: Klik op documentlink en verifieer dat document wordt geopend/downloaded. |
+          | FR-08 | BA | Het systeem voorziet in toegangsbeperking zodat alleen gebruikers van specifieke afdelingen (bv. vergunningen, planning) toegang hebben. | Test: Probeer toegang met niet-geautoriseerde gebruiker en verifieer weigering. |
+          | FR-09 | BA | Het systeem toont de archiefnominatie (bewaren of vernietigen) voor elke vergunning gebaseerd op het type document volgens de selectielijst voor waterschappen (2012). | Test: Bekijk detailweergave en verifieer dat archiefnominatie wordt getoond. |
+          | FR-10 | BA | Het systeem toont de retentieperiode voor elke vergunning indien de archiefnominatie is "vernietigen" (volgens selectielijst waterschappen 2012). | Test: Bekijk detailweergave en verifieer dat retentieperiode wordt getoond indien van toepassing. |
+          | FR-11 | BA | Het systeem toont de huidige archiefstatus van elke vergunning (te bewaren oneindig, of retentieperiode verstreken/niet verstreken). | Test: Bekijk detailweergave en verifieer dat archiefstatus duidelijk wordt getoond. |
+          | FR-12 | BA | Het systeem stelt gebruikers in staat om vergunningdocumenten en hun metadata te migreren naar het zaaksysteem. | Test: Selecteer vergunning(en), kies migratie-optie en verifieer dat metadata en documenten naar zaaksysteem worden overgebracht. |
+
+          ## 4. Bedrijfsregels & Logica
+
+          | Regel ID | Beschrijving | Conditie | Uitkomst |
+          |----------|-------------|----------|----------|
+          | BR-01 | Archiefnominatie wordt bepaald op basis van type document volgens de selectielijst voor waterschappen uit 2012 | Vergunning beschikbaar in index | Toon archiefnominatie (bewaren of vernietigen) |
+          | BR-02 | Retentieperiode wordt bepaald op basis van type document volgens de selectielijst voor waterschappen uit 2012 | Archiefnominatie = vernietigen | Toon bijbehorende retentieperiode |
+          | BR-03 | Geen retentieperiode van toepassing | Archiefnominatie = bewaren | Oneindig bewaren, geen retentieperiode tonen |
+          | BR-04 | Archiefstatus wordt bepaald op basis van uitgiftedatum en retentieperiode | Archiefnominatie = vernietigen én retentieperiode verstreken | Status = "te vernietigen" |
+          | BR-05 | Archiefnominatie = bewaren | | Status = "te bewaren (oneindig)" |
+          | BR-06 | Archiefnominatie = vernietigen én retentieperiode nog niet verstreken | | Status = "te bewaren tot [datum]" |
+          | BR-07 | Zoekresultaten bevatten alle vergunningen waar de zoekterm overeenkomt met ten minste één metadata-veld | Zoekterm ingevoerd | Toon alle overeenkomende resultaten |
+          | BR-08 | Geavanceerd zoeken past alle geselecteerde filters toe | Meerdere filters geselecteerd | Toon alleen resultaten die aan alle filters voldoen |
+
+          ## 5. Informatievereisten
+
+          | Informatie | Beschrijving | Bron | Gebruikt door |
+          |-----------|-------------|------|---------------|
+          | Vergunningnummer | Unieke identificatie (K, L, of andere nummeringssystemen) | Brondatabases | Zoekfunctie, resultaatweergave, migratie |
+          | Aanvrager naam | Naam van de persoon/organisatie die de vergunning aanvroeg | Brondatabases | Zoekfunctie, resultaatweergave, migratie |
+          | Vergunninghouder naam | Naam van de houder van de vergunning | Brondatabases | Zoekfunctie, resultaatweergave, migratie |
+          | Uitgever naam | Naam van de persoon die de vergunning verstrekte | Brondatabases | Zoekfunctie, resultaatweergave, migratie |
+          | Locatie | Locatie/adres waar de vergunning betrekking op heeft | Brondatabases | Zoekfunctie, resultaatweergave, migratie |
+          | Datums | Uitgiftedatum, geldigheidsdatum, en andere relevante datums | Brondatabases | Zoekfunctie, resultaatweergave, migratie |
+          | Toepasselijke wet | Wet of regelgeving waarop de vergunning gebaseerd is | Brondatabases | Zoekfunctie, resultaatweergave, retentiebepaling, migratie |
+          | Type werk | Beschrijving van het type werk/activiteit | Brondatabases | Zoekfunctie, resultaatweergave, retentiebepaling, migratie |
+          | Type oppervlaktewater | Type oppervlaktewater gerelateerd aan de vergunning | Brondatabases | Zoekfunctie, resultaatweergave, migratie |
+          | Type waterkering | Type waterkering gerelateerd aan de vergunning | Brondatabases | Zoekfunctie, resultaatweergave, migratie |
+          | Archiefnominatie | Bewaren of vernietigen volgens selectielijst waterschappen 2012 | Organisatiereferentie (selectielijst) | Archiefstatusweergave, migratie |
+          | Retentieperiode | Bewaartermijn volgens selectielijst waterschappen 2012 (indien van toepassing) | Organisatiereferentie (selectielijst) | Archiefstatusweergave, migratie |
+          | Archiefstatus | Huidige archiefstatus (te bewaren/te vernietigen) | Berekend op basis van datum, nominatie en retentieperiode | Resultaatweergave |
+          | Bronsysteem | Systeem waaruit de vergunning afkomstig is | Metadata | Resultaatweergave, migratie |
+          | Documentlocatie | Verwijzing naar origineel document (PDF, scan) | Documentopslag | Documenttoegang, migratie |
+
+          ## 6. User Journeys
+
+          ### User Journey 1: Eenvoudig zoeken naar oude vergunning
+
+          **Actor:** Medewerker vergunningverlening
+          **Doel:** Een oude vergunning vinden met beperkte informatie
+
+          **Stappen:**
+          1. Gebruiker opent zoekinterface
+          2. Systeem presenteert enkel zoekvak
+          3. Gebruiker voert zoekterm in (bv. deel van locatie of aanvrager naam)
+          4. Gebruiker klikt op zoekknop of drukt op Enter
+          5. Systeem doorzoekt alle geïndexeerde metadata
+          6. Systeem toont resultatenlijst met alle metadata-velden voor elke vergunning
+          7. Gebruiker identificeert relevante vergunning aan resultaten
+          8. Gebruiker klikt op vergunning voor detailweergave
+          9. Systeem toont volledige details inclusief archiefnominatie, retentieperiode en bronsysteem
+          10. Gebruiker klikt op documentlink
+          11. Systeem opent of downloadt origineel document
+
+          ### User Journey 2: Geavanceerd zoeken op specifieke criteria
+
+          **Actor:** Gebruiker (medewerker vergunningverlening, planning, of archief)
+          **Doel:** Vergunningen zoeken binnen specifiek gebied en periode
+
+          **Stappen:**
+          1. Gebruiker opent zoekinterface
+          2. Gebruiker klikt op "Geavanceerd zoeken"
+          3. Systeem toont filteropties voor alle metadata-velden
+          4. Gebruiker selecteert locatiefilter en voert gebied in
+          5. Gebruiker selecteert datumbereik
+          6. Gebruiker voert eventueel aanvullende filters in (bv. type werk, type oppervlaktewater, type waterkering)
+          7. Gebruiker klikt op zoekknop
+          8. Systeem past alle filters toe en doorzoekt index
+          9. Systeem toont resultaten die aan alle criteria voldoen
+          10. Gebruiker bekijkt resultaten en filtert indien nodig verder
+          11. Gebruiker selecteert relevante vergunningen voor overzicht
+
+          ### User Journey 3: Controleren van archiefstatus
+
+          **Actor:** Medewerker vergunningverlening
+          **Doel:** Controleren of vergunningen voldoen aan Archiefwet
+
+          **Stappen:**
+          1. Gebruiker opent zoekinterface
+          2. Gebruiker zoekt op vergunningnummer of andere identifier
+          3. Systeem toont resultaat met alle metadata
+          4. Gebruiker bekijkt archiefnominatie en -status in resultaat
+          5. Gebruiker opent detailweergave indien nodig
+          6. Systeem toont archiefnominatie, retentieperiode (indien van toepassing) en huidige status duidelijk
+          7. Gebruiker kan beoordelen of actie nodig is (vernietigen wanneer retentieperiode verstreken)
+
+          ### User Journey 4: Migreren van vergunning naar zaaksysteem
+
+          **Actor:** Medewerker vergunningverlening
+          **Doel:** Een historische vergunning migreren naar het zaaksysteem
+
+          **Stappen:**
+          1. Gebruiker opent zoekinterface
+          2. Gebruiker zoekt naar de te migreren vergunning
+          3. Systeem toont resultaat met alle metadata
+          4. Gebruiker selecteert de vergunning
+          5. Gebruiker klikt op "Migreren naar zaaksysteem"
+          6. Systeem toont overzicht van metadata en documenten die gemigreerd worden
+          7. Gebruiker bevestigt migratie
+          8. Systeem transporteert metadata en origineel document naar zaaksysteem
+          9. Systeem bevestigt succesvolle migratie en toont nieuwe locatie in zaaksysteem
+
+          ## 7. Integratiepunten
+
+          | Systeem/Dienst | Interactietype | Doel |
+          |---------------|----------------|------|
+          | Brondatabases (meerdere) | Lezen - Metadata extraheren | Vergunningmetadata ophalen en indexeren |
+          | Documentopslag (PDF's, scans) | Lezen - Documenten ophalen | Originele vergunningdocumenten beschikbaar stellen voor weergave/download |
+          | Zaaksysteem | Lezen/Schrijven - Migratie | Metadata en documenten overbrengen naar zaaksysteem |
+          | Organisatiereferentie (selectielijst waterschappen 2012) | Lezen - Referentiegegevens | Archiefnominaties en retentieperiodes ophalen op basis van documenttype |
+          | Authenticatiesysteem | Verifiëren - Toegangscontrole | Valideren van gebruikers en afdelingstoegang |
+
+          ## 8. Niet-Functionele Eisen
+
+          | ID | Bron | Eis | Verificatiemethode |
+          |----|------|-----|-------------------|
+          | NFR-01 | BA | Het systeem moet zoekresultaten binnen 5 seconden retourneren. | Performancetest: Voer zoekopdrachten uit en meet responstijd. |
+          | NFR-02 | BA | Het systeem moet toegankelijk zijn voor 20+ gelijktijdige gebruikers. | Loadtest: Simuleer gelijktijdig gebruik door 25 gebruikers. |
+          | NFR-03 | BA | Het systeem moet beschikbaar zijn tijdens reguliere kantooruren. | Monitoring: Verifieer uptime tijdens bedrijfsdagen. |
+          | NFR-04 | BA | De gebruikersinterface moet intuïtief zijn en vereist geen training voor nieuwe medewerkers. | Usabilitytest: Laat nieuwe gebruiker een zoekopdracht uitvoeren zonder instructies. |
+          | NFR-05 | BA | Het systeem moet persoonsgegevens (namen, adressen, contactgegevens) beschermen tegen ongeautoriseerde toegang. | Beveiligingstest: Verifieer dat niet-geautoriseerde gebruikers geen toegang hebben. |
+          | NFR-06 | BA | Het systeem moet auditlogs bijhouden van wie welke zoekopdrachten en migraties uitvoert. | Test: Voer zoekopdrachten en migraties uit en verifieer aanwezigheid in logs. |
+          | NFR-07 | BA | Migraties moeten data-integriteit garanderen: metadata en documenten moeten volledig en correct worden overgebracht. | Test: Voer migratie uit en vergelijk bron- en doeldata. |
+
+          ## 9. Security & Compliance Eisen
+
+          **Persoonsgegevens betrokken:** Ja — namen (aanvrager, vergunninghouder, uitgever), adressen (locatie), contactgegevens
+
+          **Vertrouwelijke bedrijfsgegevens betrokken:** Nee — voornamelijk publieke archief-informatie
+
+          **Authenticatie vereist:** Ja — toegangsbeperking tot specifieke afdelingen (vergunningen, planning)
+
+          **Toegangsbeperkingen:** Alleen gebruikers van specifieke afdelingen hebben toegang. Andere afdelingen en publiek hebben geen toegang.
+
+          **Dataretentie:** Het systeem zelf slaat geen vergunninggegevens op; deze blijven in bronsystemen. Search index verwijst naar brongegevens. Migraties verplaatsen data naar zaaksysteem; brondata blijft in bronsysteem.
+
+          ## 10. Aannames & Open Vragen
+
+          | ID | Type | Beschrijving | Standaard/Fallback |
+          |----|------|-------------|-------------------|
+          | A-01 | Aanname | Organisatie heeft de selectielijst voor waterschappen (2012) beschikbaar als referentie voor archiefnominaties en retentieperiodes | Wordt gebruikt voor FR-09, FR-10 en FR-11 |
+          | A-02 | Aanname | Brondatabases en documentopslag zijn toegankelijk voor het nieuwe systeem via bekende interfaces | Architect moet interfaces specificeren |
+          | A-03 | Aanname | Authenticatiesysteem is beschikbaar om afdelingstoegang te valideren | Architect moet integratie specificeren |
+          | A-04 | Aanname | Zaaksysteem heeft beschikbare interfaces om metadata en documenten te ontvangen via migratie | Architect moet migratie-interface specificeren |
+          | O-01 | Open vraag | Hoe vaak moeten de bronsystemen opnieuw geïndexeerd worden? | Te bepalen door Architect op basis van datawijzigingfrequentie |
+          | O-02 | Open vraag | Moet het systeem in staat zijn om zoeken terwijl een indexering bezig is? | Te bepalen door Architect |
+          | O-03 | Open vraag | Moet een gemigreerde vergunning in de bronsysteem-index worden gemarkeerd als "gemigreerd"? | Te bepalen door Architect en gebruiker |
+
+          ## 11. Out of Scope
+
+          Dit ontwerp omvat NIET:
+          - Het aanmaken of wijzigen van vergunningen
+          - Integratie met systemen buiten de vergunningdatabases, documentopslag en zaaksysteem
+          - Publieke toegang tot vergunninggegevens
+          - Vernietiging of archivering van fysieke documenten (slechts statusweergave)
+          - Workflow voor goedkeuring of archivering (slechts informatieweergave)
+          - Automatische bulk-migratie van alle vergunningen (individuele migratie op initiatief van gebruiker)
+
+          ## 12. Proces Flow Diagram
+
+          ```mermaid
+          flowchart TD
+            start(["Gebruiker opent zoekinterface"]) --> choice{"Zoektype"}
+            choice -->|"Eenvoudig zoeken"| simple["Gebruiker voert zoekterm in"]
+            choice -->|"Geavanceerd zoeken"| advanced["Gebruiker selecteert filters"]
+            simple --> search["Systeem doorzoekt alle geïndexeerde metadata"]
+            advanced --> search
+            search --> results["Systeem toont resultaten met alle metadata-velden"]
+            results --> action{"Gebruikersactie"}
+            action -->|"Resultaat bekijken"| detail["Gebruiker klikt op resultaat"]
+            action -->|"Migreren naar zaaksysteem"| migrate["Gebruiker selecteert vergunning"]
+            action -->|"Nieuwe zoekopdracht"| simple
+            detail --> status["Systeem toont details incl. archiefnominatie, retentieperiode"]
+            status --> doc{"Gebruiker opent document?"}
+            doc -->|"Ja"| download["Systeem opent/downloadt origineel document"]
+            doc -->|"Nee"| finish(["Klaar"])
+            download --> finish
+            migrate --> confirm["Systeem toont overzicht van metadata en documenten"]
+            confirm --> decision{"Gebruiker bevestigt?"}
+            decision -->|"Nee"| results
+            decision -->|"Ja"| transfer["Systeem transporteert metadata en document"]
+            transfer --> success["Systeem bevestigt succesvolle migratie"]
+            success --> finish
+          ```
+      assert:
+        result:
+          - { contains: "functional-design.md" }
+
+    - agent: business_analyst
+      tool: coding:run_git
+      arguments:
+        command: "add docs/functional-design.md"
+
+    - agent: business_analyst
+      tool: coding:run_git
+      arguments:
+        command: "commit -m 'Functioneel ontwerp vergunningzoeker'"
+
+    - agent: business_analyst
+      tool: coding:run_git
+      arguments:
+        command: "push"
+
+    - agent: business_analyst
+      tool: builtin:done
+      arguments:
+        summary: "Agent business_analyst: DESIGN_APPROVED. Gathered requirements and wrote functional_design.md for vergunningzoeker with 12 functional requirements, 7 non-functional requirements, 8 business rules, 4 user journeys, and 5 integration points. Covers unified permit search, archive status tracking (Archiefwet compliance), and migration to zaaksysteem."
+      assert:
+        completed: true

--- a/testing/tools/setup-vergunningzoeker-with-fd.yaml
+++ b/testing/tools/setup-vergunningzoeker-with-fd.yaml
@@ -1,20 +1,13 @@
 ## Setup: create a vergunningzoeker project with functional design written and committed
 ##
-## Chain: router → planner → BA (context gathering, HITL elicitation, summary
-##   validation, FD writing, FD confirmation, git) → done
+## Chain: router → planner → BA (HITL + FD + git) → done
 ## Ends after BA completes — no trailing planner.
 ##
-## The BA flow follows the real operational phases:
-##   Phase 1: Intake & context exploration (registry + project calls)
-##   Phase 4: Elicitation (multiple clarifying questions)
-##   Phase 9: User validation (present summary, user confirms)
-##   Phase 7: Write FD via make_design
-##   Phase 10: FD confirmation (present full FD, user approves)
-##   Git add/commit/push → done()
+## The FD is a real-world permit metadata search system for a Dutch waterschap.
 
 tool-test:
   name: setup-vergunningzoeker-with-fd
-  description: "Creates vergunningzoeker project with FD — realistic BA elicitation flow"
+  description: "Creates vergunningzoeker project with FD — BA completed, ready for planner re-evaluation"
   tags: [setup, vergunningzoeker]
 
   chain:
@@ -49,154 +42,26 @@ tool-test:
       arguments:
         summary: "Agent planner: Planned business_analyst to gather requirements and create functional design"
 
-    # =========================================================================
-    # Business Analyst — realistic elicitation flow
-    # =========================================================================
-
-    # --- Phase 1: Context gathering (registry + project discovery) ---
-    - agent: business_analyst
-      tool: registry:list_modules
-      mock: true
-      mock_result: '[{"id": "llm", "tools": ["chat"]}, {"id": "vision", "tools": ["ocr", "analyze"]}, {"id": "web", "tools": ["search_web"]}, {"id": "filesearch", "tools": ["search"]}]'
-
-    - agent: business_analyst
-      tool: registry:search_modules
-      mock: true
-      mock_result: '[]'
-      arguments:
-        query: "vergunning permit search"
-
-    - agent: business_analyst
-      tool: coding:list_projects
-      mock: true
-      mock_result: '[]'
-
-    # --- Phase 4: Elicitation — clarifying questions ---
-
-    # Question 1: Context & current situation
+    # --- Business Analyst ---
     - agent: business_analyst
       tool: builtin:hitl_ask_multiple_choice_question
       mock: true
-      mock_result: "We zoeken in meerdere oude systemen — sommige alleen op K/L-nummer, sommige op locatie maar alleen na 2018. Nieuwe medewerkers weten niet waar ze moeten zoeken."
+      mock_result: "Ja, we willen ook migratie naar het zaaksysteem"
       arguments:
-        question: "Kunt u vertellen hoe u op dit moment vergunningen zoekt? Wat is het huidige proces?"
+        question: "Moet het systeem ook migratiefunctionaliteit naar het zaaksysteem bieden?"
         choices:
-          - "We zoeken in meerdere oude systemen — sommige alleen op K/L-nummer, sommige op locatie maar alleen na 2018. Nieuwe medewerkers weten niet waar ze moeten zoeken."
-          - "We hebben één systeem maar het is traag en onvolledig"
-          - "We zoeken vooral in papieren archieven en gescande PDF's"
+          - "Ja, we willen ook migratie naar het zaaksysteem"
+          - "Nee, alleen zoeken en inzicht in archiefstatus"
 
-    # Question 2: Who is affected
-    - agent: business_analyst
-      tool: builtin:hitl_ask_multiple_choice_question
-      mock: true
-      mock_result: "Medewerkers vergunningverlening, leidinggevenden die overzichten nodig hebben, en nieuwe collega's die het systeem niet kennen"
-      arguments:
-        question: "Wie ondervindt dit probleem het meest? Wie zoekt er dagelijks naar vergunningen?"
-        choices:
-          - "Medewerkers vergunningverlening, leidinggevenden die overzichten nodig hebben, en nieuwe collega's die het systeem niet kennen"
-          - "Alleen de afdeling vergunningen"
-          - "Iedereen binnen het waterschap"
-
-    # Question 3: What metadata to search
-    - agent: business_analyst
-      tool: builtin:hitl_ask_multiple_choice_question
-      mock: true
-      mock_result: "Aanvrager, vergunninghouder, uitgever, locatie, datums, vergunningnummer (K/L), toepasselijke wet, type werk, type oppervlaktewater, type waterkering"
-      arguments:
-        question: "Welke gegevens moeten doorzoekbaar zijn? Welke metadata-velden zijn belangrijk?"
-        choices:
-          - "Aanvrager, vergunninghouder, uitgever, locatie, datums, vergunningnummer (K/L), toepasselijke wet, type werk, type oppervlaktewater, type waterkering"
-          - "Alleen vergunningnummer en locatie"
-          - "Alle beschikbare velden, maar ik weet niet precies welke dat zijn"
-
-    # Question 4: Archive compliance
     - agent: business_analyst
       tool: builtin:hitl_ask_multiple_choice_question
       mock: true
       mock_result: "Ja, inclusief retentieperiodes en archiefnominaties volgens selectielijst waterschappen 2012"
       arguments:
-        question: "Moet het systeem inzicht geven in de archiefstatus van vergunningen? Denk aan de Archiefwet en bewaar-/vernietigingstermijnen."
+        question: "Moet het systeem archiefstatus tonen volgens de Archiefwet?"
         choices:
           - "Ja, inclusief retentieperiodes en archiefnominaties volgens selectielijst waterschappen 2012"
-          - "Ja, maar alleen basale statusweergave"
-          - "Nee, dat is niet nodig"
-
-    # Question 5: Migration to zaaksysteem
-    - agent: business_analyst
-      tool: builtin:hitl_ask_multiple_choice_question
-      mock: true
-      mock_result: "Ja, we willen individuele vergunningen met metadata en documenten kunnen migreren naar het zaaksysteem"
-      arguments:
-        question: "Moet het systeem ook vergunningen kunnen migreren naar het zaaksysteem? Of is het puur zoeken en inzicht?"
-        choices:
-          - "Ja, we willen individuele vergunningen met metadata en documenten kunnen migreren naar het zaaksysteem"
-          - "Nee, alleen zoeken en inzicht"
-          - "Misschien later, maar niet in de eerste versie"
-
-    # Question 6: Access control
-    - agent: business_analyst
-      tool: builtin:hitl_ask_multiple_choice_question
-      mock: true
-      mock_result: "Alleen medewerkers van vergunningen en planning — andere afdelingen mogen niet zoeken"
-      arguments:
-        question: "Wie mag toegang hebben tot het zoeksysteem? Moet er toegangsbeperking zijn?"
-        choices:
-          - "Alleen medewerkers van vergunningen en planning — andere afdelingen mogen niet zoeken"
-          - "Alle medewerkers van het waterschap"
-          - "Openbaar toegankelijk"
-
-    # Question 7: Personal data
-    - agent: business_analyst
-      tool: builtin:hitl_ask_question
-      mock: true
-      mock_result: "Ja, namen van aanvragers, vergunninghouders en uitgevers staan in de metadata. Adressen en locaties ook. Geen bijzondere persoonsgegevens."
-      arguments:
-        question: "Bevatten de vergunninggegevens persoonsgegevens? Denk aan namen, adressen of contactgegevens van aanvragers of vergunninghouders."
-
-    # --- Phase 9: User validation — present summary ---
-    - agent: business_analyst
-      tool: builtin:hitl_ask_multiple_choice_question
-      mock: true
-      mock_result: "Ja, dit beschrijft precies wat we nodig hebben"
-      arguments:
-        question: |
-          **Problemomschrijving**
-          Medewerkers verliezen tijd door in meerdere gefragmenteerde systemen te zoeken naar vergunningen. Oude vergunningen (voor 2018) zijn niet op locatie doorzoekbaar. Kennis over waar te zoeken raakt verloren bij personeelswisselingen. De Archiefwet wordt niet nageleefd omdat retentieperiodes en locatie van alle vergunningen onbekend zijn.
-
-          **Kernprobleem**
-          Vergunningmetadata is verspreid over meerdere legacy databases met verschillende zoekmethoden en nummeringssystemen, waardoor er geen uniform overzicht is.
-
-          **Functionele Eisen**
-          1. FR-01: Eenvoudig zoeken via één zoekvak over alle metadata-velden
-          2. FR-02: Geavanceerd zoeken met filters per veldtype
-          3. FR-03: Indexering van alle metadata (aanvrager, locatie, datums, vergunningnummer, wet, type werk, etc.)
-          4. FR-04: Zoekresultaten tonen alle metadata-velden
-          5. FR-05: Detailweergave van vergunninginformatie
-          6. FR-06: Bronsysteem zichtbaar per vergunning
-          7. FR-07: Originele documenten openen/downloaden
-          8. FR-08: Toegangsbeperking per afdeling
-          9. FR-09: Archiefnominatie tonen (bewaren/vernietigen)
-          10. FR-10: Retentieperiode tonen indien van toepassing
-          11. FR-11: Archiefstatus berekenen en tonen
-          12. FR-12: Migratie van vergunningen naar zaaksysteem
-
-          **Buiten Scope**
-          - Aanmaken of wijzigen van vergunningen
-          - Publieke toegang
-          - Automatische bulk-migratie
-          - Fysieke archivering/vernietiging
-        choices:
-          - "Ja, dit beschrijft precies wat we nodig hebben"
-          - "Gedeeltelijk, er missen nog een paar dingen"
-          - "Nee, er zijn belangrijke punten die niet kloppen"
-
-    # --- Phase 7: Write functional design via make_design ---
-    - agent: business_analyst
-      tool: builtin:invoke_skill
-      mock: true
-      mock_result: "Mermaid diagram syntax rules loaded successfully"
-      arguments:
-        skill_name: making-mermaid-diagrams
+          - "Nee, alleen basis metadata zoeken"
 
     - agent: business_analyst
       tool: coding:make_design
@@ -301,91 +166,126 @@ tool-test:
           ## 6. User Journeys
 
           ### User Journey 1: Eenvoudig zoeken naar oude vergunning
+
           **Actor:** Medewerker vergunningverlening
           **Doel:** Een oude vergunning vinden met beperkte informatie
+
+          **Stappen:**
           1. Gebruiker opent zoekinterface
           2. Systeem presenteert enkel zoekvak
           3. Gebruiker voert zoekterm in (bv. deel van locatie of aanvrager naam)
-          4. Systeem doorzoekt alle geïndexeerde metadata
-          5. Systeem toont resultatenlijst met alle metadata-velden
-          6. Gebruiker klikt op vergunning voor detailweergave
-          7. Systeem toont volledige details inclusief archiefnominatie en bronsysteem
-          8. Gebruiker klikt op documentlink om origineel te openen
+          4. Gebruiker klikt op zoekknop of drukt op Enter
+          5. Systeem doorzoekt alle geïndexeerde metadata
+          6. Systeem toont resultatenlijst met alle metadata-velden voor elke vergunning
+          7. Gebruiker identificeert relevante vergunning aan resultaten
+          8. Gebruiker klikt op vergunning voor detailweergave
+          9. Systeem toont volledige details inclusief archiefnominatie, retentieperiode en bronsysteem
+          10. Gebruiker klikt op documentlink
+          11. Systeem opent of downloadt origineel document
 
           ### User Journey 2: Geavanceerd zoeken op specifieke criteria
-          **Actor:** Medewerker vergunningverlening, planning, of archief
+
+          **Actor:** Gebruiker (medewerker vergunningverlening, planning, of archief)
           **Doel:** Vergunningen zoeken binnen specifiek gebied en periode
-          1. Gebruiker opent zoekinterface en klikt op "Geavanceerd zoeken"
-          2. Systeem toont filteropties voor alle metadata-velden
-          3. Gebruiker selecteert locatiefilter, datumbereik en eventueel type werk
-          4. Systeem past alle filters toe en toont resultaten
-          5. Gebruiker selecteert relevante vergunningen voor overzicht
+
+          **Stappen:**
+          1. Gebruiker opent zoekinterface
+          2. Gebruiker klikt op "Geavanceerd zoeken"
+          3. Systeem toont filteropties voor alle metadata-velden
+          4. Gebruiker selecteert locatiefilter en voert gebied in
+          5. Gebruiker selecteert datumbereik
+          6. Gebruiker voert eventueel aanvullende filters in (bv. type werk, type oppervlaktewater, type waterkering)
+          7. Gebruiker klikt op zoekknop
+          8. Systeem past alle filters toe en doorzoekt index
+          9. Systeem toont resultaten die aan alle criteria voldoen
+          10. Gebruiker bekijkt resultaten en filtert indien nodig verder
+          11. Gebruiker selecteert relevante vergunningen voor overzicht
 
           ### User Journey 3: Controleren van archiefstatus
-          **Actor:** Medewerker archiefbeheer
+
+          **Actor:** Medewerker vergunningverlening
           **Doel:** Controleren of vergunningen voldoen aan Archiefwet
-          1. Gebruiker zoekt op vergunningnummer of andere identifier
-          2. Systeem toont resultaat met archiefnominatie en -status
-          3. Gebruiker bekijkt of retentieperiode verstreken is
-          4. Gebruiker beoordeelt of actie nodig is (vernietigen of bewaren)
+
+          **Stappen:**
+          1. Gebruiker opent zoekinterface
+          2. Gebruiker zoekt op vergunningnummer of andere identifier
+          3. Systeem toont resultaat met alle metadata
+          4. Gebruiker bekijkt archiefnominatie en -status in resultaat
+          5. Gebruiker opent detailweergave indien nodig
+          6. Systeem toont archiefnominatie, retentieperiode (indien van toepassing) en huidige status duidelijk
+          7. Gebruiker kan beoordelen of actie nodig is (vernietigen wanneer retentieperiode verstreken)
 
           ### User Journey 4: Migreren van vergunning naar zaaksysteem
+
           **Actor:** Medewerker vergunningverlening
           **Doel:** Een historische vergunning migreren naar het zaaksysteem
-          1. Gebruiker zoekt naar de te migreren vergunning
-          2. Gebruiker selecteert de vergunning en klikt "Migreren naar zaaksysteem"
-          3. Systeem toont overzicht van metadata en documenten die gemigreerd worden
-          4. Gebruiker bevestigt migratie
-          5. Systeem transporteert metadata en document naar zaaksysteem
-          6. Systeem bevestigt succesvolle migratie
+
+          **Stappen:**
+          1. Gebruiker opent zoekinterface
+          2. Gebruiker zoekt naar de te migreren vergunning
+          3. Systeem toont resultaat met alle metadata
+          4. Gebruiker selecteert de vergunning
+          5. Gebruiker klikt op "Migreren naar zaaksysteem"
+          6. Systeem toont overzicht van metadata en documenten die gemigreerd worden
+          7. Gebruiker bevestigt migratie
+          8. Systeem transporteert metadata en origineel document naar zaaksysteem
+          9. Systeem bevestigt succesvolle migratie en toont nieuwe locatie in zaaksysteem
 
           ## 7. Integratiepunten
 
           | Systeem/Dienst | Interactietype | Doel |
           |---------------|----------------|------|
           | Brondatabases (meerdere) | Lezen - Metadata extraheren | Vergunningmetadata ophalen en indexeren |
-          | Documentopslag (PDF's, scans) | Lezen - Documenten ophalen | Originele vergunningdocumenten beschikbaar stellen |
-          | Zaaksysteem | Lezen/Schrijven - Migratie | Metadata en documenten overbrengen |
-          | Selectielijst waterschappen 2012 | Lezen - Referentie | Archiefnominaties en retentieperiodes bepalen |
-          | Authenticatiesysteem | Verifiëren | Afdelingstoegang valideren |
+          | Documentopslag (PDF's, scans) | Lezen - Documenten ophalen | Originele vergunningdocumenten beschikbaar stellen voor weergave/download |
+          | Zaaksysteem | Lezen/Schrijven - Migratie | Metadata en documenten overbrengen naar zaaksysteem |
+          | Organisatiereferentie (selectielijst waterschappen 2012) | Lezen - Referentiegegevens | Archiefnominaties en retentieperiodes ophalen op basis van documenttype |
+          | Authenticatiesysteem | Verifiëren - Toegangscontrole | Valideren van gebruikers en afdelingstoegang |
 
           ## 8. Niet-Functionele Eisen
 
           | ID | Bron | Eis | Verificatiemethode |
           |----|------|-----|-------------------|
-          | NFR-01 | BA | Zoekresultaten binnen 5 seconden retourneren | Performancetest |
-          | NFR-02 | BA | Toegankelijk voor 20+ gelijktijdige gebruikers | Loadtest met 25 gebruikers |
-          | NFR-03 | BA | Beschikbaar tijdens reguliere kantooruren | Uptime monitoring |
-          | NFR-04 | BA | Intuïtieve interface — geen training nodig | Usabilitytest met nieuwe gebruiker |
-          | NFR-05 | BA | Persoonsgegevens beschermen tegen ongeautoriseerde toegang | Beveiligingstest |
-          | NFR-06 | BA | Auditlogs van zoekopdrachten en migraties | Logverificatie |
-          | NFR-07 | BA | Data-integriteit bij migraties garanderen | Vergelijking bron- en doeldata |
+          | NFR-01 | BA | Het systeem moet zoekresultaten binnen 5 seconden retourneren. | Performancetest: Voer zoekopdrachten uit en meet responstijd. |
+          | NFR-02 | BA | Het systeem moet toegankelijk zijn voor 20+ gelijktijdige gebruikers. | Loadtest: Simuleer gelijktijdig gebruik door 25 gebruikers. |
+          | NFR-03 | BA | Het systeem moet beschikbaar zijn tijdens reguliere kantooruren. | Monitoring: Verifieer uptime tijdens bedrijfsdagen. |
+          | NFR-04 | BA | De gebruikersinterface moet intuïtief zijn en vereist geen training voor nieuwe medewerkers. | Usabilitytest: Laat nieuwe gebruiker een zoekopdracht uitvoeren zonder instructies. |
+          | NFR-05 | BA | Het systeem moet persoonsgegevens (namen, adressen, contactgegevens) beschermen tegen ongeautoriseerde toegang. | Beveiligingstest: Verifieer dat niet-geautoriseerde gebruikers geen toegang hebben. |
+          | NFR-06 | BA | Het systeem moet auditlogs bijhouden van wie welke zoekopdrachten en migraties uitvoert. | Test: Voer zoekopdrachten en migraties uit en verifieer aanwezigheid in logs. |
+          | NFR-07 | BA | Migraties moeten data-integriteit garanderen: metadata en documenten moeten volledig en correct worden overgebracht. | Test: Voer migratie uit en vergelijk bron- en doeldata. |
 
-          ## 9. Security & Compliance
+          ## 9. Security & Compliance Eisen
 
-          **Persoonsgegevens:** Ja — namen (aanvrager, vergunninghouder, uitgever), adressen, locaties
-          **Authenticatie:** Ja — toegangsbeperking tot afdelingen vergunningen en planning
-          **Dataretentie:** Systeem slaat geen vergunninggegevens op; index verwijst naar bronsystemen
+          **Persoonsgegevens betrokken:** Ja — namen (aanvrager, vergunninghouder, uitgever), adressen (locatie), contactgegevens
+
+          **Vertrouwelijke bedrijfsgegevens betrokken:** Nee — voornamelijk publieke archief-informatie
+
+          **Authenticatie vereist:** Ja — toegangsbeperking tot specifieke afdelingen (vergunningen, planning)
+
+          **Toegangsbeperkingen:** Alleen gebruikers van specifieke afdelingen hebben toegang. Andere afdelingen en publiek hebben geen toegang.
+
+          **Dataretentie:** Het systeem zelf slaat geen vergunninggegevens op; deze blijven in bronsystemen. Search index verwijst naar brongegevens. Migraties verplaatsen data naar zaaksysteem; brondata blijft in bronsysteem.
 
           ## 10. Aannames & Open Vragen
 
-          | ID | Type | Beschrijving |
-          |----|------|-------------|
-          | A-01 | Aanname | Selectielijst waterschappen (2012) is beschikbaar als referentie |
-          | A-02 | Aanname | Brondatabases zijn toegankelijk via bekende interfaces |
-          | A-03 | Aanname | Authenticatiesysteem is beschikbaar voor afdelingsvalidatie |
-          | A-04 | Aanname | Zaaksysteem heeft interfaces voor metadata- en documentontvangst |
-          | O-01 | Open vraag | Hoe vaak moeten bronsystemen opnieuw geïndexeerd worden? |
-          | O-02 | Open vraag | Moet zoeken mogelijk zijn tijdens indexering? |
-          | O-03 | Open vraag | Moet gemigreerde vergunning in bronindex als "gemigreerd" worden gemarkeerd? |
+          | ID | Type | Beschrijving | Standaard/Fallback |
+          |----|------|-------------|-------------------|
+          | A-01 | Aanname | Organisatie heeft de selectielijst voor waterschappen (2012) beschikbaar als referentie voor archiefnominaties en retentieperiodes | Wordt gebruikt voor FR-09, FR-10 en FR-11 |
+          | A-02 | Aanname | Brondatabases en documentopslag zijn toegankelijk voor het nieuwe systeem via bekende interfaces | Architect moet interfaces specificeren |
+          | A-03 | Aanname | Authenticatiesysteem is beschikbaar om afdelingstoegang te valideren | Architect moet integratie specificeren |
+          | A-04 | Aanname | Zaaksysteem heeft beschikbare interfaces om metadata en documenten te ontvangen via migratie | Architect moet migratie-interface specificeren |
+          | O-01 | Open vraag | Hoe vaak moeten de bronsystemen opnieuw geïndexeerd worden? | Te bepalen door Architect op basis van datawijzigingfrequentie |
+          | O-02 | Open vraag | Moet het systeem in staat zijn om zoeken terwijl een indexering bezig is? | Te bepalen door Architect |
+          | O-03 | Open vraag | Moet een gemigreerde vergunning in de bronsysteem-index worden gemarkeerd als "gemigreerd"? | Te bepalen door Architect en gebruiker |
 
           ## 11. Out of Scope
 
-          - Aanmaken of wijzigen van vergunningen
+          Dit ontwerp omvat NIET:
+          - Het aanmaken of wijzigen van vergunningen
+          - Integratie met systemen buiten de vergunningdatabases, documentopslag en zaaksysteem
           - Publieke toegang tot vergunninggegevens
-          - Automatische bulk-migratie
-          - Fysieke archivering/vernietiging (slechts statusweergave)
-          - Workflow voor goedkeuring of archivering
+          - Vernietiging of archivering van fysieke documenten (slechts statusweergave)
+          - Workflow voor goedkeuring of archivering (slechts informatieweergave)
+          - Automatische bulk-migratie van alle vergunningen (individuele migratie op initiatief van gebruiker)
 
           ## 12. Proces Flow Diagram
 
@@ -398,36 +298,25 @@ tool-test:
             advanced --> search
             search --> results["Systeem toont resultaten met alle metadata-velden"]
             results --> action{"Gebruikersactie"}
-            action -->|"Resultaat bekijken"| detail["Detailweergave met archiefstatus"]
-            action -->|"Migreren"| migrate["Selecteer vergunning voor migratie"]
+            action -->|"Resultaat bekijken"| detail["Gebruiker klikt op resultaat"]
+            action -->|"Migreren naar zaaksysteem"| migrate["Gebruiker selecteert vergunning"]
             action -->|"Nieuwe zoekopdracht"| simple
-            detail --> doc{"Document openen?"}
-            doc -->|"Ja"| download["Systeem opent/downloadt document"]
+            detail --> status["Systeem toont details incl. archiefnominatie, retentieperiode"]
+            status --> doc{"Gebruiker opent document?"}
+            doc -->|"Ja"| download["Systeem opent/downloadt origineel document"]
             doc -->|"Nee"| finish(["Klaar"])
             download --> finish
-            migrate --> confirm["Overzicht metadata en documenten"]
-            confirm --> decision{"Bevestigen?"}
+            migrate --> confirm["Systeem toont overzicht van metadata en documenten"]
+            confirm --> decision{"Gebruiker bevestigt?"}
             decision -->|"Nee"| results
-            decision -->|"Ja"| transfer["Migratie naar zaaksysteem"]
-            transfer --> success["Bevestiging succesvolle migratie"]
+            decision -->|"Ja"| transfer["Systeem transporteert metadata en document"]
+            transfer --> success["Systeem bevestigt succesvolle migratie"]
             success --> finish
           ```
       assert:
         result:
           - { contains: "functional-design.md" }
 
-    # --- Phase 10: FD confirmation — user approves the written FD ---
-    - agent: business_analyst
-      tool: builtin:hitl_ask_multiple_choice_question
-      mock: true
-      mock_result: "Ja, goedkeuren en doorsturen naar de Architect"
-      arguments:
-        question: "Het functioneel ontwerp is geschreven met 12 functionele eisen, 7 niet-functionele eisen, 8 bedrijfsregels en 4 user journeys. Wilt u het goedkeuren en doorsturen naar de Architect voor technisch ontwerp?"
-        choices:
-          - "Ja, goedkeuren en doorsturen naar de Architect"
-          - "Nee, ik heb nog feedback"
-
-    # --- Git add/commit/push ---
     - agent: business_analyst
       tool: coding:run_git
       arguments:
@@ -443,10 +332,9 @@ tool-test:
       arguments:
         command: "push"
 
-    # --- done() with DESIGN_APPROVED ---
     - agent: business_analyst
       tool: builtin:done
       arguments:
-        summary: "Agent business_analyst: DESIGN_APPROVED. Gathered requirements through 7 elicitation questions covering current process, stakeholders, metadata fields, Archiefwet compliance, zaaksysteem migration, access control, and personal data. User validated summary and approved written FD. Wrote functional_design.md with 12 functional requirements, 7 non-functional requirements, 8 business rules, 4 user journeys, and 5 integration points."
+        summary: "Agent business_analyst: DESIGN_APPROVED. Gathered requirements and wrote functional_design.md for vergunningzoeker with 12 functional requirements, 7 non-functional requirements, 8 business rules, 4 user journeys, and 5 integration points. Covers unified permit search, archive status tracking (Archiefwet compliance), and migration to zaaksysteem."
       assert:
         completed: true

--- a/testing/tools/setup-vergunningzoeker-with-fd.yaml
+++ b/testing/tools/setup-vergunningzoeker-with-fd.yaml
@@ -1,13 +1,20 @@
 ## Setup: create a vergunningzoeker project with functional design written and committed
 ##
-## Chain: router → planner → BA (HITL + FD + git) → done
+## Chain: router → planner → BA (context gathering, HITL elicitation, summary
+##   validation, FD writing, FD confirmation, git) → done
 ## Ends after BA completes — no trailing planner.
 ##
-## The FD is a real-world permit metadata search system for a Dutch waterschap.
+## The BA flow follows the real operational phases:
+##   Phase 1: Intake & context exploration (registry + project calls)
+##   Phase 4: Elicitation (multiple clarifying questions)
+##   Phase 9: User validation (present summary, user confirms)
+##   Phase 7: Write FD via make_design
+##   Phase 10: FD confirmation (present full FD, user approves)
+##   Git add/commit/push → done()
 
 tool-test:
   name: setup-vergunningzoeker-with-fd
-  description: "Creates vergunningzoeker project with FD — BA completed, ready for planner re-evaluation"
+  description: "Creates vergunningzoeker project with FD — realistic BA elicitation flow"
   tags: [setup, vergunningzoeker]
 
   chain:
@@ -42,26 +49,154 @@ tool-test:
       arguments:
         summary: "Agent planner: Planned business_analyst to gather requirements and create functional design"
 
-    # --- Business Analyst ---
+    # =========================================================================
+    # Business Analyst — realistic elicitation flow
+    # =========================================================================
+
+    # --- Phase 1: Context gathering (registry + project discovery) ---
+    - agent: business_analyst
+      tool: registry:list_modules
+      mock: true
+      mock_result: '[{"id": "llm", "tools": ["chat"]}, {"id": "vision", "tools": ["ocr", "analyze"]}, {"id": "web", "tools": ["search_web"]}, {"id": "filesearch", "tools": ["search"]}]'
+
+    - agent: business_analyst
+      tool: registry:search_modules
+      mock: true
+      mock_result: '[]'
+      arguments:
+        query: "vergunning permit search"
+
+    - agent: business_analyst
+      tool: coding:list_projects
+      mock: true
+      mock_result: '[]'
+
+    # --- Phase 4: Elicitation — clarifying questions ---
+
+    # Question 1: Context & current situation
     - agent: business_analyst
       tool: builtin:hitl_ask_multiple_choice_question
       mock: true
-      mock_result: "Ja, we willen ook migratie naar het zaaksysteem"
+      mock_result: "We zoeken in meerdere oude systemen — sommige alleen op K/L-nummer, sommige op locatie maar alleen na 2018. Nieuwe medewerkers weten niet waar ze moeten zoeken."
       arguments:
-        question: "Moet het systeem ook migratiefunctionaliteit naar het zaaksysteem bieden?"
+        question: "Kunt u vertellen hoe u op dit moment vergunningen zoekt? Wat is het huidige proces?"
         choices:
-          - "Ja, we willen ook migratie naar het zaaksysteem"
-          - "Nee, alleen zoeken en inzicht in archiefstatus"
+          - "We zoeken in meerdere oude systemen — sommige alleen op K/L-nummer, sommige op locatie maar alleen na 2018. Nieuwe medewerkers weten niet waar ze moeten zoeken."
+          - "We hebben één systeem maar het is traag en onvolledig"
+          - "We zoeken vooral in papieren archieven en gescande PDF's"
 
+    # Question 2: Who is affected
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Medewerkers vergunningverlening, leidinggevenden die overzichten nodig hebben, en nieuwe collega's die het systeem niet kennen"
+      arguments:
+        question: "Wie ondervindt dit probleem het meest? Wie zoekt er dagelijks naar vergunningen?"
+        choices:
+          - "Medewerkers vergunningverlening, leidinggevenden die overzichten nodig hebben, en nieuwe collega's die het systeem niet kennen"
+          - "Alleen de afdeling vergunningen"
+          - "Iedereen binnen het waterschap"
+
+    # Question 3: What metadata to search
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Aanvrager, vergunninghouder, uitgever, locatie, datums, vergunningnummer (K/L), toepasselijke wet, type werk, type oppervlaktewater, type waterkering"
+      arguments:
+        question: "Welke gegevens moeten doorzoekbaar zijn? Welke metadata-velden zijn belangrijk?"
+        choices:
+          - "Aanvrager, vergunninghouder, uitgever, locatie, datums, vergunningnummer (K/L), toepasselijke wet, type werk, type oppervlaktewater, type waterkering"
+          - "Alleen vergunningnummer en locatie"
+          - "Alle beschikbare velden, maar ik weet niet precies welke dat zijn"
+
+    # Question 4: Archive compliance
     - agent: business_analyst
       tool: builtin:hitl_ask_multiple_choice_question
       mock: true
       mock_result: "Ja, inclusief retentieperiodes en archiefnominaties volgens selectielijst waterschappen 2012"
       arguments:
-        question: "Moet het systeem archiefstatus tonen volgens de Archiefwet?"
+        question: "Moet het systeem inzicht geven in de archiefstatus van vergunningen? Denk aan de Archiefwet en bewaar-/vernietigingstermijnen."
         choices:
           - "Ja, inclusief retentieperiodes en archiefnominaties volgens selectielijst waterschappen 2012"
-          - "Nee, alleen basis metadata zoeken"
+          - "Ja, maar alleen basale statusweergave"
+          - "Nee, dat is niet nodig"
+
+    # Question 5: Migration to zaaksysteem
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Ja, we willen individuele vergunningen met metadata en documenten kunnen migreren naar het zaaksysteem"
+      arguments:
+        question: "Moet het systeem ook vergunningen kunnen migreren naar het zaaksysteem? Of is het puur zoeken en inzicht?"
+        choices:
+          - "Ja, we willen individuele vergunningen met metadata en documenten kunnen migreren naar het zaaksysteem"
+          - "Nee, alleen zoeken en inzicht"
+          - "Misschien later, maar niet in de eerste versie"
+
+    # Question 6: Access control
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Alleen medewerkers van vergunningen en planning — andere afdelingen mogen niet zoeken"
+      arguments:
+        question: "Wie mag toegang hebben tot het zoeksysteem? Moet er toegangsbeperking zijn?"
+        choices:
+          - "Alleen medewerkers van vergunningen en planning — andere afdelingen mogen niet zoeken"
+          - "Alle medewerkers van het waterschap"
+          - "Openbaar toegankelijk"
+
+    # Question 7: Personal data
+    - agent: business_analyst
+      tool: builtin:hitl_ask_question
+      mock: true
+      mock_result: "Ja, namen van aanvragers, vergunninghouders en uitgevers staan in de metadata. Adressen en locaties ook. Geen bijzondere persoonsgegevens."
+      arguments:
+        question: "Bevatten de vergunninggegevens persoonsgegevens? Denk aan namen, adressen of contactgegevens van aanvragers of vergunninghouders."
+
+    # --- Phase 9: User validation — present summary ---
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Ja, dit beschrijft precies wat we nodig hebben"
+      arguments:
+        question: |
+          **Problemomschrijving**
+          Medewerkers verliezen tijd door in meerdere gefragmenteerde systemen te zoeken naar vergunningen. Oude vergunningen (voor 2018) zijn niet op locatie doorzoekbaar. Kennis over waar te zoeken raakt verloren bij personeelswisselingen. De Archiefwet wordt niet nageleefd omdat retentieperiodes en locatie van alle vergunningen onbekend zijn.
+
+          **Kernprobleem**
+          Vergunningmetadata is verspreid over meerdere legacy databases met verschillende zoekmethoden en nummeringssystemen, waardoor er geen uniform overzicht is.
+
+          **Functionele Eisen**
+          1. FR-01: Eenvoudig zoeken via één zoekvak over alle metadata-velden
+          2. FR-02: Geavanceerd zoeken met filters per veldtype
+          3. FR-03: Indexering van alle metadata (aanvrager, locatie, datums, vergunningnummer, wet, type werk, etc.)
+          4. FR-04: Zoekresultaten tonen alle metadata-velden
+          5. FR-05: Detailweergave van vergunninginformatie
+          6. FR-06: Bronsysteem zichtbaar per vergunning
+          7. FR-07: Originele documenten openen/downloaden
+          8. FR-08: Toegangsbeperking per afdeling
+          9. FR-09: Archiefnominatie tonen (bewaren/vernietigen)
+          10. FR-10: Retentieperiode tonen indien van toepassing
+          11. FR-11: Archiefstatus berekenen en tonen
+          12. FR-12: Migratie van vergunningen naar zaaksysteem
+
+          **Buiten Scope**
+          - Aanmaken of wijzigen van vergunningen
+          - Publieke toegang
+          - Automatische bulk-migratie
+          - Fysieke archivering/vernietiging
+        choices:
+          - "Ja, dit beschrijft precies wat we nodig hebben"
+          - "Gedeeltelijk, er missen nog een paar dingen"
+          - "Nee, er zijn belangrijke punten die niet kloppen"
+
+    # --- Phase 7: Write functional design via make_design ---
+    - agent: business_analyst
+      tool: builtin:invoke_skill
+      mock: true
+      mock_result: "Mermaid diagram syntax rules loaded successfully"
+      arguments:
+        skill_name: making-mermaid-diagrams
 
     - agent: business_analyst
       tool: coding:make_design
@@ -166,126 +301,91 @@ tool-test:
           ## 6. User Journeys
 
           ### User Journey 1: Eenvoudig zoeken naar oude vergunning
-
           **Actor:** Medewerker vergunningverlening
           **Doel:** Een oude vergunning vinden met beperkte informatie
-
-          **Stappen:**
           1. Gebruiker opent zoekinterface
           2. Systeem presenteert enkel zoekvak
           3. Gebruiker voert zoekterm in (bv. deel van locatie of aanvrager naam)
-          4. Gebruiker klikt op zoekknop of drukt op Enter
-          5. Systeem doorzoekt alle geïndexeerde metadata
-          6. Systeem toont resultatenlijst met alle metadata-velden voor elke vergunning
-          7. Gebruiker identificeert relevante vergunning aan resultaten
-          8. Gebruiker klikt op vergunning voor detailweergave
-          9. Systeem toont volledige details inclusief archiefnominatie, retentieperiode en bronsysteem
-          10. Gebruiker klikt op documentlink
-          11. Systeem opent of downloadt origineel document
+          4. Systeem doorzoekt alle geïndexeerde metadata
+          5. Systeem toont resultatenlijst met alle metadata-velden
+          6. Gebruiker klikt op vergunning voor detailweergave
+          7. Systeem toont volledige details inclusief archiefnominatie en bronsysteem
+          8. Gebruiker klikt op documentlink om origineel te openen
 
           ### User Journey 2: Geavanceerd zoeken op specifieke criteria
-
-          **Actor:** Gebruiker (medewerker vergunningverlening, planning, of archief)
+          **Actor:** Medewerker vergunningverlening, planning, of archief
           **Doel:** Vergunningen zoeken binnen specifiek gebied en periode
-
-          **Stappen:**
-          1. Gebruiker opent zoekinterface
-          2. Gebruiker klikt op "Geavanceerd zoeken"
-          3. Systeem toont filteropties voor alle metadata-velden
-          4. Gebruiker selecteert locatiefilter en voert gebied in
-          5. Gebruiker selecteert datumbereik
-          6. Gebruiker voert eventueel aanvullende filters in (bv. type werk, type oppervlaktewater, type waterkering)
-          7. Gebruiker klikt op zoekknop
-          8. Systeem past alle filters toe en doorzoekt index
-          9. Systeem toont resultaten die aan alle criteria voldoen
-          10. Gebruiker bekijkt resultaten en filtert indien nodig verder
-          11. Gebruiker selecteert relevante vergunningen voor overzicht
+          1. Gebruiker opent zoekinterface en klikt op "Geavanceerd zoeken"
+          2. Systeem toont filteropties voor alle metadata-velden
+          3. Gebruiker selecteert locatiefilter, datumbereik en eventueel type werk
+          4. Systeem past alle filters toe en toont resultaten
+          5. Gebruiker selecteert relevante vergunningen voor overzicht
 
           ### User Journey 3: Controleren van archiefstatus
-
-          **Actor:** Medewerker vergunningverlening
+          **Actor:** Medewerker archiefbeheer
           **Doel:** Controleren of vergunningen voldoen aan Archiefwet
-
-          **Stappen:**
-          1. Gebruiker opent zoekinterface
-          2. Gebruiker zoekt op vergunningnummer of andere identifier
-          3. Systeem toont resultaat met alle metadata
-          4. Gebruiker bekijkt archiefnominatie en -status in resultaat
-          5. Gebruiker opent detailweergave indien nodig
-          6. Systeem toont archiefnominatie, retentieperiode (indien van toepassing) en huidige status duidelijk
-          7. Gebruiker kan beoordelen of actie nodig is (vernietigen wanneer retentieperiode verstreken)
+          1. Gebruiker zoekt op vergunningnummer of andere identifier
+          2. Systeem toont resultaat met archiefnominatie en -status
+          3. Gebruiker bekijkt of retentieperiode verstreken is
+          4. Gebruiker beoordeelt of actie nodig is (vernietigen of bewaren)
 
           ### User Journey 4: Migreren van vergunning naar zaaksysteem
-
           **Actor:** Medewerker vergunningverlening
           **Doel:** Een historische vergunning migreren naar het zaaksysteem
-
-          **Stappen:**
-          1. Gebruiker opent zoekinterface
-          2. Gebruiker zoekt naar de te migreren vergunning
-          3. Systeem toont resultaat met alle metadata
-          4. Gebruiker selecteert de vergunning
-          5. Gebruiker klikt op "Migreren naar zaaksysteem"
-          6. Systeem toont overzicht van metadata en documenten die gemigreerd worden
-          7. Gebruiker bevestigt migratie
-          8. Systeem transporteert metadata en origineel document naar zaaksysteem
-          9. Systeem bevestigt succesvolle migratie en toont nieuwe locatie in zaaksysteem
+          1. Gebruiker zoekt naar de te migreren vergunning
+          2. Gebruiker selecteert de vergunning en klikt "Migreren naar zaaksysteem"
+          3. Systeem toont overzicht van metadata en documenten die gemigreerd worden
+          4. Gebruiker bevestigt migratie
+          5. Systeem transporteert metadata en document naar zaaksysteem
+          6. Systeem bevestigt succesvolle migratie
 
           ## 7. Integratiepunten
 
           | Systeem/Dienst | Interactietype | Doel |
           |---------------|----------------|------|
           | Brondatabases (meerdere) | Lezen - Metadata extraheren | Vergunningmetadata ophalen en indexeren |
-          | Documentopslag (PDF's, scans) | Lezen - Documenten ophalen | Originele vergunningdocumenten beschikbaar stellen voor weergave/download |
-          | Zaaksysteem | Lezen/Schrijven - Migratie | Metadata en documenten overbrengen naar zaaksysteem |
-          | Organisatiereferentie (selectielijst waterschappen 2012) | Lezen - Referentiegegevens | Archiefnominaties en retentieperiodes ophalen op basis van documenttype |
-          | Authenticatiesysteem | Verifiëren - Toegangscontrole | Valideren van gebruikers en afdelingstoegang |
+          | Documentopslag (PDF's, scans) | Lezen - Documenten ophalen | Originele vergunningdocumenten beschikbaar stellen |
+          | Zaaksysteem | Lezen/Schrijven - Migratie | Metadata en documenten overbrengen |
+          | Selectielijst waterschappen 2012 | Lezen - Referentie | Archiefnominaties en retentieperiodes bepalen |
+          | Authenticatiesysteem | Verifiëren | Afdelingstoegang valideren |
 
           ## 8. Niet-Functionele Eisen
 
           | ID | Bron | Eis | Verificatiemethode |
           |----|------|-----|-------------------|
-          | NFR-01 | BA | Het systeem moet zoekresultaten binnen 5 seconden retourneren. | Performancetest: Voer zoekopdrachten uit en meet responstijd. |
-          | NFR-02 | BA | Het systeem moet toegankelijk zijn voor 20+ gelijktijdige gebruikers. | Loadtest: Simuleer gelijktijdig gebruik door 25 gebruikers. |
-          | NFR-03 | BA | Het systeem moet beschikbaar zijn tijdens reguliere kantooruren. | Monitoring: Verifieer uptime tijdens bedrijfsdagen. |
-          | NFR-04 | BA | De gebruikersinterface moet intuïtief zijn en vereist geen training voor nieuwe medewerkers. | Usabilitytest: Laat nieuwe gebruiker een zoekopdracht uitvoeren zonder instructies. |
-          | NFR-05 | BA | Het systeem moet persoonsgegevens (namen, adressen, contactgegevens) beschermen tegen ongeautoriseerde toegang. | Beveiligingstest: Verifieer dat niet-geautoriseerde gebruikers geen toegang hebben. |
-          | NFR-06 | BA | Het systeem moet auditlogs bijhouden van wie welke zoekopdrachten en migraties uitvoert. | Test: Voer zoekopdrachten en migraties uit en verifieer aanwezigheid in logs. |
-          | NFR-07 | BA | Migraties moeten data-integriteit garanderen: metadata en documenten moeten volledig en correct worden overgebracht. | Test: Voer migratie uit en vergelijk bron- en doeldata. |
+          | NFR-01 | BA | Zoekresultaten binnen 5 seconden retourneren | Performancetest |
+          | NFR-02 | BA | Toegankelijk voor 20+ gelijktijdige gebruikers | Loadtest met 25 gebruikers |
+          | NFR-03 | BA | Beschikbaar tijdens reguliere kantooruren | Uptime monitoring |
+          | NFR-04 | BA | Intuïtieve interface — geen training nodig | Usabilitytest met nieuwe gebruiker |
+          | NFR-05 | BA | Persoonsgegevens beschermen tegen ongeautoriseerde toegang | Beveiligingstest |
+          | NFR-06 | BA | Auditlogs van zoekopdrachten en migraties | Logverificatie |
+          | NFR-07 | BA | Data-integriteit bij migraties garanderen | Vergelijking bron- en doeldata |
 
-          ## 9. Security & Compliance Eisen
+          ## 9. Security & Compliance
 
-          **Persoonsgegevens betrokken:** Ja — namen (aanvrager, vergunninghouder, uitgever), adressen (locatie), contactgegevens
-
-          **Vertrouwelijke bedrijfsgegevens betrokken:** Nee — voornamelijk publieke archief-informatie
-
-          **Authenticatie vereist:** Ja — toegangsbeperking tot specifieke afdelingen (vergunningen, planning)
-
-          **Toegangsbeperkingen:** Alleen gebruikers van specifieke afdelingen hebben toegang. Andere afdelingen en publiek hebben geen toegang.
-
-          **Dataretentie:** Het systeem zelf slaat geen vergunninggegevens op; deze blijven in bronsystemen. Search index verwijst naar brongegevens. Migraties verplaatsen data naar zaaksysteem; brondata blijft in bronsysteem.
+          **Persoonsgegevens:** Ja — namen (aanvrager, vergunninghouder, uitgever), adressen, locaties
+          **Authenticatie:** Ja — toegangsbeperking tot afdelingen vergunningen en planning
+          **Dataretentie:** Systeem slaat geen vergunninggegevens op; index verwijst naar bronsystemen
 
           ## 10. Aannames & Open Vragen
 
-          | ID | Type | Beschrijving | Standaard/Fallback |
-          |----|------|-------------|-------------------|
-          | A-01 | Aanname | Organisatie heeft de selectielijst voor waterschappen (2012) beschikbaar als referentie voor archiefnominaties en retentieperiodes | Wordt gebruikt voor FR-09, FR-10 en FR-11 |
-          | A-02 | Aanname | Brondatabases en documentopslag zijn toegankelijk voor het nieuwe systeem via bekende interfaces | Architect moet interfaces specificeren |
-          | A-03 | Aanname | Authenticatiesysteem is beschikbaar om afdelingstoegang te valideren | Architect moet integratie specificeren |
-          | A-04 | Aanname | Zaaksysteem heeft beschikbare interfaces om metadata en documenten te ontvangen via migratie | Architect moet migratie-interface specificeren |
-          | O-01 | Open vraag | Hoe vaak moeten de bronsystemen opnieuw geïndexeerd worden? | Te bepalen door Architect op basis van datawijzigingfrequentie |
-          | O-02 | Open vraag | Moet het systeem in staat zijn om zoeken terwijl een indexering bezig is? | Te bepalen door Architect |
-          | O-03 | Open vraag | Moet een gemigreerde vergunning in de bronsysteem-index worden gemarkeerd als "gemigreerd"? | Te bepalen door Architect en gebruiker |
+          | ID | Type | Beschrijving |
+          |----|------|-------------|
+          | A-01 | Aanname | Selectielijst waterschappen (2012) is beschikbaar als referentie |
+          | A-02 | Aanname | Brondatabases zijn toegankelijk via bekende interfaces |
+          | A-03 | Aanname | Authenticatiesysteem is beschikbaar voor afdelingsvalidatie |
+          | A-04 | Aanname | Zaaksysteem heeft interfaces voor metadata- en documentontvangst |
+          | O-01 | Open vraag | Hoe vaak moeten bronsystemen opnieuw geïndexeerd worden? |
+          | O-02 | Open vraag | Moet zoeken mogelijk zijn tijdens indexering? |
+          | O-03 | Open vraag | Moet gemigreerde vergunning in bronindex als "gemigreerd" worden gemarkeerd? |
 
           ## 11. Out of Scope
 
-          Dit ontwerp omvat NIET:
-          - Het aanmaken of wijzigen van vergunningen
-          - Integratie met systemen buiten de vergunningdatabases, documentopslag en zaaksysteem
+          - Aanmaken of wijzigen van vergunningen
           - Publieke toegang tot vergunninggegevens
-          - Vernietiging of archivering van fysieke documenten (slechts statusweergave)
-          - Workflow voor goedkeuring of archivering (slechts informatieweergave)
-          - Automatische bulk-migratie van alle vergunningen (individuele migratie op initiatief van gebruiker)
+          - Automatische bulk-migratie
+          - Fysieke archivering/vernietiging (slechts statusweergave)
+          - Workflow voor goedkeuring of archivering
 
           ## 12. Proces Flow Diagram
 
@@ -298,25 +398,36 @@ tool-test:
             advanced --> search
             search --> results["Systeem toont resultaten met alle metadata-velden"]
             results --> action{"Gebruikersactie"}
-            action -->|"Resultaat bekijken"| detail["Gebruiker klikt op resultaat"]
-            action -->|"Migreren naar zaaksysteem"| migrate["Gebruiker selecteert vergunning"]
+            action -->|"Resultaat bekijken"| detail["Detailweergave met archiefstatus"]
+            action -->|"Migreren"| migrate["Selecteer vergunning voor migratie"]
             action -->|"Nieuwe zoekopdracht"| simple
-            detail --> status["Systeem toont details incl. archiefnominatie, retentieperiode"]
-            status --> doc{"Gebruiker opent document?"}
-            doc -->|"Ja"| download["Systeem opent/downloadt origineel document"]
+            detail --> doc{"Document openen?"}
+            doc -->|"Ja"| download["Systeem opent/downloadt document"]
             doc -->|"Nee"| finish(["Klaar"])
             download --> finish
-            migrate --> confirm["Systeem toont overzicht van metadata en documenten"]
-            confirm --> decision{"Gebruiker bevestigt?"}
+            migrate --> confirm["Overzicht metadata en documenten"]
+            confirm --> decision{"Bevestigen?"}
             decision -->|"Nee"| results
-            decision -->|"Ja"| transfer["Systeem transporteert metadata en document"]
-            transfer --> success["Systeem bevestigt succesvolle migratie"]
+            decision -->|"Ja"| transfer["Migratie naar zaaksysteem"]
+            transfer --> success["Bevestiging succesvolle migratie"]
             success --> finish
           ```
       assert:
         result:
           - { contains: "functional-design.md" }
 
+    # --- Phase 10: FD confirmation — user approves the written FD ---
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Ja, goedkeuren en doorsturen naar de Architect"
+      arguments:
+        question: "Het functioneel ontwerp is geschreven met 12 functionele eisen, 7 niet-functionele eisen, 8 bedrijfsregels en 4 user journeys. Wilt u het goedkeuren en doorsturen naar de Architect voor technisch ontwerp?"
+        choices:
+          - "Ja, goedkeuren en doorsturen naar de Architect"
+          - "Nee, ik heb nog feedback"
+
+    # --- Git add/commit/push ---
     - agent: business_analyst
       tool: coding:run_git
       arguments:
@@ -332,9 +443,10 @@ tool-test:
       arguments:
         command: "push"
 
+    # --- done() with DESIGN_APPROVED ---
     - agent: business_analyst
       tool: builtin:done
       arguments:
-        summary: "Agent business_analyst: DESIGN_APPROVED. Gathered requirements and wrote functional_design.md for vergunningzoeker with 12 functional requirements, 7 non-functional requirements, 8 business rules, 4 user journeys, and 5 integration points. Covers unified permit search, archive status tracking (Archiefwet compliance), and migration to zaaksysteem."
+        summary: "Agent business_analyst: DESIGN_APPROVED. Gathered requirements through 7 elicitation questions covering current process, stakeholders, metadata fields, Archiefwet compliance, zaaksysteem migration, access control, and personal data. User validated summary and approved written FD. Wrote functional_design.md with 12 functional requirements, 7 non-functional requirements, 8 business rules, 4 user journeys, and 5 integration points."
       assert:
         completed: true

--- a/testing/tools/setup-vergunningzoeker-with-fd.yaml
+++ b/testing/tools/setup-vergunningzoeker-with-fd.yaml
@@ -1,13 +1,20 @@
 ## Setup: create a vergunningzoeker project with functional design written and committed
 ##
-## Chain: router → planner → BA (HITL + FD + git) → done
+## Chain: router → planner → BA (context gathering, HITL elicitation, summary
+##   validation, FD writing, FD confirmation, git) → done
 ## Ends after BA completes — no trailing planner.
 ##
-## The FD is a real-world permit metadata search system for a Dutch waterschap.
+## The BA flow follows the real operational phases:
+##   Phase 1: Intake & context exploration (registry + project calls)
+##   Phase 4: Elicitation (multiple clarifying questions)
+##   Phase 9: User validation (present summary, user confirms)
+##   Phase 7: Write FD via make_design
+##   Phase 10: FD confirmation (present full FD, user approves)
+##   Git add/commit/push → done()
 
 tool-test:
   name: setup-vergunningzoeker-with-fd
-  description: "Creates vergunningzoeker project with FD — BA completed, ready for planner re-evaluation"
+  description: "Creates vergunningzoeker project with FD — realistic BA elicitation flow"
   tags: [setup, vergunningzoeker]
 
   chain:
@@ -42,26 +49,154 @@ tool-test:
       arguments:
         summary: "Agent planner: Planned business_analyst to gather requirements and create functional design"
 
-    # --- Business Analyst ---
+    # =========================================================================
+    # Business Analyst — realistic elicitation flow
+    # =========================================================================
+
+    # --- Phase 1: Context gathering (registry + project discovery) ---
+    - agent: business_analyst
+      tool: registry:list_modules
+      mock: true
+      mock_result: '[{"id": "llm", "tools": ["chat"]}, {"id": "vision", "tools": ["ocr", "analyze"]}, {"id": "web", "tools": ["search_web"]}, {"id": "filesearch", "tools": ["search"]}]'
+
+    - agent: business_analyst
+      tool: registry:search_modules
+      mock: true
+      mock_result: '[]'
+      arguments:
+        query: "vergunning permit search"
+
+    - agent: business_analyst
+      tool: coding:list_projects
+      mock: true
+      mock_result: '[]'
+
+    # --- Phase 4: Elicitation — clarifying questions ---
+
+    # Question 1: Context & current situation
     - agent: business_analyst
       tool: builtin:hitl_ask_multiple_choice_question
       mock: true
-      mock_result: "Ja, we willen ook migratie naar het zaaksysteem"
+      mock_result: "We zoeken in meerdere oude systemen — sommige alleen op K/L-nummer, sommige op locatie maar alleen na 2018. Nieuwe medewerkers weten niet waar ze moeten zoeken."
       arguments:
-        question: "Moet het systeem ook migratiefunctionaliteit naar het zaaksysteem bieden?"
+        question: "Kunt u vertellen hoe u op dit moment vergunningen zoekt? Wat is het huidige proces?"
         choices:
-          - "Ja, we willen ook migratie naar het zaaksysteem"
-          - "Nee, alleen zoeken en inzicht in archiefstatus"
+          - "We zoeken in meerdere oude systemen — sommige alleen op K/L-nummer, sommige op locatie maar alleen na 2018. Nieuwe medewerkers weten niet waar ze moeten zoeken."
+          - "We hebben één systeem maar het is traag en onvolledig"
+          - "We zoeken vooral in papieren archieven en gescande PDF's"
 
+    # Question 2: Who is affected
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Medewerkers vergunningverlening, leidinggevenden die overzichten nodig hebben, en nieuwe collega's die het systeem niet kennen"
+      arguments:
+        question: "Wie ondervindt dit probleem het meest? Wie zoekt er dagelijks naar vergunningen?"
+        choices:
+          - "Medewerkers vergunningverlening, leidinggevenden die overzichten nodig hebben, en nieuwe collega's die het systeem niet kennen"
+          - "Alleen de afdeling vergunningen"
+          - "Iedereen binnen het waterschap"
+
+    # Question 3: What metadata to search
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Aanvrager, vergunninghouder, uitgever, locatie, datums, vergunningnummer (K/L), toepasselijke wet, type werk, type oppervlaktewater, type waterkering"
+      arguments:
+        question: "Welke gegevens moeten doorzoekbaar zijn? Welke metadata-velden zijn belangrijk?"
+        choices:
+          - "Aanvrager, vergunninghouder, uitgever, locatie, datums, vergunningnummer (K/L), toepasselijke wet, type werk, type oppervlaktewater, type waterkering"
+          - "Alleen vergunningnummer en locatie"
+          - "Alle beschikbare velden, maar ik weet niet precies welke dat zijn"
+
+    # Question 4: Archive compliance
     - agent: business_analyst
       tool: builtin:hitl_ask_multiple_choice_question
       mock: true
       mock_result: "Ja, inclusief retentieperiodes en archiefnominaties volgens selectielijst waterschappen 2012"
       arguments:
-        question: "Moet het systeem archiefstatus tonen volgens de Archiefwet?"
+        question: "Moet het systeem inzicht geven in de archiefstatus van vergunningen? Denk aan de Archiefwet en bewaar-/vernietigingstermijnen."
         choices:
           - "Ja, inclusief retentieperiodes en archiefnominaties volgens selectielijst waterschappen 2012"
-          - "Nee, alleen basis metadata zoeken"
+          - "Ja, maar alleen basale statusweergave"
+          - "Nee, dat is niet nodig"
+
+    # Question 5: Migration to zaaksysteem
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Ja, we willen individuele vergunningen met metadata en documenten kunnen migreren naar het zaaksysteem"
+      arguments:
+        question: "Moet het systeem ook vergunningen kunnen migreren naar het zaaksysteem? Of is het puur zoeken en inzicht?"
+        choices:
+          - "Ja, we willen individuele vergunningen met metadata en documenten kunnen migreren naar het zaaksysteem"
+          - "Nee, alleen zoeken en inzicht"
+          - "Misschien later, maar niet in de eerste versie"
+
+    # Question 6: Access control
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Alleen medewerkers van vergunningen en planning — andere afdelingen mogen niet zoeken"
+      arguments:
+        question: "Wie mag toegang hebben tot het zoeksysteem? Moet er toegangsbeperking zijn?"
+        choices:
+          - "Alleen medewerkers van vergunningen en planning — andere afdelingen mogen niet zoeken"
+          - "Alle medewerkers van het waterschap"
+          - "Openbaar toegankelijk"
+
+    # Question 7: Personal data
+    - agent: business_analyst
+      tool: builtin:hitl_ask_question
+      mock: true
+      mock_result: "Ja, namen van aanvragers, vergunninghouders en uitgevers staan in de metadata. Adressen en locaties ook. Geen bijzondere persoonsgegevens."
+      arguments:
+        question: "Bevatten de vergunninggegevens persoonsgegevens? Denk aan namen, adressen of contactgegevens van aanvragers of vergunninghouders."
+
+    # --- Phase 9: User validation — present summary ---
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Ja, dit beschrijft precies wat we nodig hebben"
+      arguments:
+        question: |
+          **Problemomschrijving**
+          Medewerkers verliezen tijd door in meerdere gefragmenteerde systemen te zoeken naar vergunningen. Oude vergunningen (voor 2018) zijn niet op locatie doorzoekbaar. Kennis over waar te zoeken raakt verloren bij personeelswisselingen. De Archiefwet wordt niet nageleefd omdat retentieperiodes en locatie van alle vergunningen onbekend zijn.
+
+          **Kernprobleem**
+          Vergunningmetadata is verspreid over meerdere legacy databases met verschillende zoekmethoden en nummeringssystemen, waardoor er geen uniform overzicht is.
+
+          **Functionele Eisen**
+          1. FR-01: Eenvoudig zoeken via één zoekvak over alle metadata-velden
+          2. FR-02: Geavanceerd zoeken met filters per veldtype
+          3. FR-03: Indexering van alle metadata (aanvrager, locatie, datums, vergunningnummer, wet, type werk, etc.)
+          4. FR-04: Zoekresultaten tonen alle metadata-velden
+          5. FR-05: Detailweergave van vergunninginformatie
+          6. FR-06: Bronsysteem zichtbaar per vergunning
+          7. FR-07: Originele documenten openen/downloaden
+          8. FR-08: Toegangsbeperking per afdeling
+          9. FR-09: Archiefnominatie tonen (bewaren/vernietigen)
+          10. FR-10: Retentieperiode tonen indien van toepassing
+          11. FR-11: Archiefstatus berekenen en tonen
+          12. FR-12: Migratie van vergunningen naar zaaksysteem
+
+          **Buiten Scope**
+          - Aanmaken of wijzigen van vergunningen
+          - Publieke toegang
+          - Automatische bulk-migratie
+          - Fysieke archivering/vernietiging
+        choices:
+          - "Ja, dit beschrijft precies wat we nodig hebben"
+          - "Gedeeltelijk, er missen nog een paar dingen"
+          - "Nee, er zijn belangrijke punten die niet kloppen"
+
+    # --- Phase 7: Write functional design via make_design ---
+    - agent: business_analyst
+      tool: builtin:invoke_skill
+      mock: true
+      mock_result: "Mermaid diagram syntax rules loaded successfully"
+      arguments:
+        skill_name: making-mermaid-diagrams
 
     - agent: business_analyst
       tool: coding:make_design
@@ -168,6 +303,7 @@ tool-test:
           ### User Journey 1: Eenvoudig zoeken naar oude vergunning
 
           **Actor:** Medewerker vergunningverlening
+
           **Doel:** Een oude vergunning vinden met beperkte informatie
 
           **Stappen:**
@@ -186,6 +322,7 @@ tool-test:
           ### User Journey 2: Geavanceerd zoeken op specifieke criteria
 
           **Actor:** Gebruiker (medewerker vergunningverlening, planning, of archief)
+
           **Doel:** Vergunningen zoeken binnen specifiek gebied en periode
 
           **Stappen:**
@@ -204,6 +341,7 @@ tool-test:
           ### User Journey 3: Controleren van archiefstatus
 
           **Actor:** Medewerker vergunningverlening
+
           **Doel:** Controleren of vergunningen voldoen aan Archiefwet
 
           **Stappen:**
@@ -218,6 +356,7 @@ tool-test:
           ### User Journey 4: Migreren van vergunning naar zaaksysteem
 
           **Actor:** Medewerker vergunningverlening
+
           **Doel:** Een historische vergunning migreren naar het zaaksysteem
 
           **Stappen:**
@@ -253,17 +392,28 @@ tool-test:
           | NFR-06 | BA | Het systeem moet auditlogs bijhouden van wie welke zoekopdrachten en migraties uitvoert. | Test: Voer zoekopdrachten en migraties uit en verifieer aanwezigheid in logs. |
           | NFR-07 | BA | Migraties moeten data-integriteit garanderen: metadata en documenten moeten volledig en correct worden overgebracht. | Test: Voer migratie uit en vergelijk bron- en doeldata. |
 
-          ## 9. Security & Compliance Eisen
+          ## 9. Security & Compliance Eisen (van gebruikersinvoer)
 
-          **Persoonsgegevens betrokken:** Ja — namen (aanvrager, vergunninghouder, uitgever), adressen (locatie), contactgegevens
+          **Persoonsgegevens betrokken:**
+          Ja: Namen (aanvrager, vergunninghouder, uitgever), adressen (locatie), contactgegevens
 
-          **Vertrouwelijke bedrijfsgegevens betrokken:** Nee — voornamelijk publieke archief-informatie
+          **Vertrouwelijke bedrijfsgegevens betrokken:**
+          Nee: Voornamelijk publieke archief-informatie
 
-          **Authenticatie vereist:** Ja — toegangsbeperking tot specifieke afdelingen (vergunningen, planning)
+          **Authenticatie vereist:**
+          Ja: Toegangsbeperking tot specifieke afdelingen (vergunningen, planning)
 
-          **Toegangsbeperkingen:** Alleen gebruikers van specifieke afdelingen hebben toegang. Andere afdelingen en publiek hebben geen toegang.
+          **Toegangsbeperkingen:**
+          Alleen gebruikers van specifieke afdelingen hebben toegang
+          Andere afdelingen en publiek hebben geen toegang
 
-          **Dataretentie:** Het systeem zelf slaat geen vergunninggegevens op; deze blijven in bronsystemen. Search index verwijst naar brongegevens. Migraties verplaatsen data naar zaaksysteem; brondata blijft in bronsysteem.
+          **Failover-voorkeur:**
+          Niet gespecificeerd door gebruiker
+
+          **Dataretentie:**
+          Het systeem zelf slaat geen vergunninggegevens op; deze blijven in bronsystemen
+          Search index verwijst naar brongegevens
+          Migraties verplaatsen data naar zaaksysteem; brondata blijft in bronsysteem
 
           ## 10. Aannames & Open Vragen
 
@@ -292,24 +442,24 @@ tool-test:
           ```mermaid
           flowchart TD
             start(["Gebruiker opent zoekinterface"]) --> choice{"Zoektype"}
-            choice -->|"Eenvoudig zoeken"| simple["Gebruiker voert zoekterm in"]
-            choice -->|"Geavanceerd zoeken"| advanced["Gebruiker selecteert filters"]
+            choice -->|"Eenvoudig zoeken"| simple["Gebruiker voert zoekterm in en drukt op Enter"]
+            choice -->|"Geavanceerd zoeken"| advanced["Gebruiker selecteert filters en voert criteria in"]
             simple --> search["Systeem doorzoekt alle geïndexeerde metadata"]
             advanced --> search
             search --> results["Systeem toont resultaten met alle metadata-velden"]
             results --> action{"Gebruikersactie"}
-            action -->|"Resultaat bekijken"| detail["Gebruiker klikt op resultaat"]
-            action -->|"Migreren naar zaaksysteem"| migrate["Gebruiker selecteert vergunning"]
+            action -->|"Resultaat bekijken"| detail["Gebruiker klikt op resultaat voor detailweergave"]
+            action -->|"Migreren naar zaaksysteem"| migrate["Gebruiker selecteert vergunning voor migratie"]
             action -->|"Nieuwe zoekopdracht"| simple
-            detail --> status["Systeem toont details incl. archiefnominatie, retentieperiode"]
+            detail --> status["Systeem toont details incl. archiefnominatie, retentieperiode en bronsysteem"]
             status --> doc{"Gebruiker opent document?"}
             doc -->|"Ja"| download["Systeem opent/downloadt origineel document"]
             doc -->|"Nee"| finish(["Klaar"])
             download --> finish
-            migrate --> confirm["Systeem toont overzicht van metadata en documenten"]
+            migrate --> confirm["Systeem toont overzicht van metadata en documenten die gemigreerd worden"]
             confirm --> decision{"Gebruiker bevestigt?"}
             decision -->|"Nee"| results
-            decision -->|"Ja"| transfer["Systeem transporteert metadata en document"]
+            decision -->|"Ja"| transfer["Systeem transporteert metadata en document naar zaaksysteem"]
             transfer --> success["Systeem bevestigt succesvolle migratie"]
             success --> finish
           ```
@@ -317,6 +467,18 @@ tool-test:
         result:
           - { contains: "functional-design.md" }
 
+    # --- Phase 10: FD confirmation — user approves the written FD ---
+    - agent: business_analyst
+      tool: builtin:hitl_ask_multiple_choice_question
+      mock: true
+      mock_result: "Ja, goedkeuren en doorsturen naar de Architect"
+      arguments:
+        question: "Het functioneel ontwerp is geschreven met 12 functionele eisen, 7 niet-functionele eisen, 8 bedrijfsregels en 4 user journeys. Wilt u het goedkeuren en doorsturen naar de Architect voor technisch ontwerp?"
+        choices:
+          - "Ja, goedkeuren en doorsturen naar de Architect"
+          - "Nee, ik heb nog feedback"
+
+    # --- Git add/commit/push ---
     - agent: business_analyst
       tool: coding:run_git
       arguments:
@@ -332,9 +494,10 @@ tool-test:
       arguments:
         command: "push"
 
+    # --- done() with DESIGN_APPROVED ---
     - agent: business_analyst
       tool: builtin:done
       arguments:
-        summary: "Agent business_analyst: DESIGN_APPROVED. Gathered requirements and wrote functional_design.md for vergunningzoeker with 12 functional requirements, 7 non-functional requirements, 8 business rules, 4 user journeys, and 5 integration points. Covers unified permit search, archive status tracking (Archiefwet compliance), and migration to zaaksysteem."
+        summary: "Agent business_analyst: DESIGN_APPROVED. Gathered requirements through 7 elicitation questions covering current process, stakeholders, metadata fields, Archiefwet compliance, zaaksysteem migration, access control, and personal data. User validated summary and approved written FD. Wrote functional_design.md with 12 functional requirements, 7 non-functional requirements, 8 business rules, 4 user journeys, and 5 integration points."
       assert:
         completed: true


### PR DESCRIPTION
## Summary

### Bug fixes (continue_session orchestrator)
- **Fix duplicate agents**: When a setup tool test ends with a planner `make_plan` call, pending agent runs (e.g. architect, planner) were left in the session. The `continue_session` path then created additional runs for the same agents. Now cancels leftover pending runs before creating continue agent runs.
- **Fix summary duplication**: Each run's `done()` stores an accumulated summary containing all prior summaries. The continue path was concatenating ALL completed runs' summaries, causing exponential duplication. Now uses only the last completed run's summary (which already contains the full chain) and replaces rather than appends.
- **Fix summary leaking to non-planner agents**: Only planner agents receive the `PREVIOUS AGENT SUMMARY` prefix, matching production's `done()` relay behavior. Non-planner agents get just the message since they are self-contained.

### New test scenarios

- **`architect-reviews-vergunningzoeker`** — End-to-end agent test for a realistic Dutch waterschap permit metadata search system (vergunningzoeker). Setup creates a detailed FD with 12 functional requirements covering archive compliance (Archiefwet/selectielijst waterschappen 2012), zaaksysteem migration, and unified metadata search across legacy databases. The architect reviews this FD, produces a TD, then `build_classifier` determines the build path (standalone vs core update). Judge checks validate that the TD addresses search architecture, Archiefwet compliance, and zaaksysteem migration — not just a generic rubber-stamp.
- **`setup-vergunningzoeker-with-fd`** — New setup tool test (503 lines) providing the full BA pipeline for the vergunningzoeker scenario: router → planner → BA (HITL mocked with Dutch waterschap domain answers) → FD with 12 FRs committed to Gitea.
- **`planner-after-ba`** — Verifies the planner receives a clean, deduplicated summary when running via `continue_session` after BA setup, and plans the architect (not a repeat BA).
- **`builder-uses-sdk`** — Agent test where a real builder creates an app using Druppie SDK. Judge verifies SDK imports (`from druppie_sdk import DruppieClient`), no direct openai usage, and no hardcoded API keys.
- **`setup-sdk-recipe-app`** / **`create-sdk-recipe-app`** — Full pipeline setup and end-to-end test for an SDK-aware recipe analyzer app (BA → architect → builder planner → test builder → builder → deployer).

### Other changes
- **`architect-reviews-fd`** extended to include planner re-evaluation after architect completes, with judge checks for summary relay and correct next-agent scheduling.
- **`setup-project-with-fd`** and **`setup-portfolio-with-fd`** trimmed: trailing planner step removed so `continue_session` tests control what runs next without stale pending runs.
- **`architect-paused-mid-run`** updated to include planner re-evaluation step before architect starts.
- **Search in test selector**: Added a search input to the test selector modal that filters by name, description, tags, agents, and message.

Partially addresses #148

## Test plan

- [x] Unit tests pass (39 passed, 2 skipped)
- [x] Run `architect-reviews-vergunningzoeker` — architect reviews waterschap FD, produces TD addressing search/archive/migration, build_classifier determines build path
- [x] Run `architect-reviews-fd` — should produce exactly one architect run, then one planner re-evaluation
- [x] Run `planner-after-ba` — planner should receive deduplicated summary and plan the architect
- [x] Run `builder-uses-sdk` — builder uses DruppieClient, no openai, no hardcoded keys
- [x] Verify planner prompt contains `PREVIOUS AGENT SUMMARY` with no duplicate lines
- [x] Verify architect prompt contains only the message (no summary chain)
- [x] Verify search filter works in the test selector modal