### PR TITLE
feat: BA completion guardrails and MCP server retry

### DIFF
--- a/druppie/agents/builtin_tools.py
+++ b/druppie/agents/builtin_tools.py
@@ -774,7 +774,17 @@ def _check_completion_preconditions(
         loader = AgentDefinitionLoader()
         definition = loader.load(agent_run.agent_id)
     except Exception:
-        return None
+        # Fail closed: if we can't load the definition, block completion.
+        # A guardrail that can be bypassed by an error isn't a guardrail.
+        logger.error(
+            "completion_precondition_definition_load_failed",
+            agent_run_id=str(agent_run_id),
+            agent_id=agent_run.agent_id,
+        )
+        return (
+            f"Internal error: could not load agent definition for '{agent_run.agent_id}'. "
+            "Cannot verify completion preconditions. Please retry or contact support."
+        )
 
     # Check required summary status keywords
     if definition.required_summary_status:

--- a/druppie/agents/builtin_tools.py
+++ b/druppie/agents/builtin_tools.py
@@ -754,6 +754,59 @@ async def create_message(
 # COMPLETION TOOL IMPLEMENTATION
 # =============================================================================
 
+
+def _check_completion_preconditions(
+    summary: str,
+    agent_run_id: UUID,
+    execution_repo: "ExecutionRepository",
+) -> str | None:
+    """Check if done() preconditions are met for this agent run.
+
+    Returns error message string if a precondition is violated, None if all OK.
+    """
+    from druppie.agents.definition_loader import AgentDefinitionLoader
+
+    agent_run = execution_repo.get_by_id(agent_run_id)
+    if not agent_run or not agent_run.agent_id:
+        return None
+
+    try:
+        loader = AgentDefinitionLoader()
+        definition = loader.load(agent_run.agent_id)
+    except Exception:
+        return None
+
+    # Check required summary status keywords
+    if definition.required_summary_status:
+        req = definition.required_summary_status
+        if not any(keyword in summary for keyword in req.one_of):
+            return req.error_message
+
+    if not definition.completion_preconditions:
+        return None
+
+    for precondition in definition.completion_preconditions:
+        if (
+            precondition.summary_contains is not None
+            and precondition.summary_contains not in summary
+        ):
+            continue
+
+        # Rule matches — check required tools
+        tool_calls = execution_repo.get_tool_calls_for_run(agent_run_id)
+
+        for required in precondition.required_tools:
+            completed_count = sum(
+                1
+                for tc in tool_calls
+                if tc.tool_name == required.tool_name and tc.status == "completed"
+            )
+            if completed_count < required.min_calls:
+                return precondition.error_message
+
+    return None
+
+
 async def done(
     summary: str,
     session_id: UUID,
@@ -781,6 +834,21 @@ async def done(
     Returns:
         Completion status with accumulated summary
     """
+    # Check completion preconditions before proceeding
+    precondition_error = _check_completion_preconditions(
+        summary=summary,
+        agent_run_id=agent_run_id,
+        execution_repo=execution_repo,
+    )
+    if precondition_error:
+        logger.warning(
+            "completion_precondition_failed",
+            agent_run_id=str(agent_run_id),
+            summary=summary[:200] if summary else "",
+            error=precondition_error,
+        )
+        return {"success": False, "error": precondition_error}
+
     logger.info(
         "agent_done",
         session_id=str(session_id),

--- a/druppie/agents/definitions/business_analyst.yaml
+++ b/druppie/agents/definitions/business_analyst.yaml
@@ -971,6 +971,40 @@ mcps:
 # When business_analyst calls make_design (to create functional_design.md),
 # it requires approval from someone with the "business_analyst" role.
 
+required_summary_status:
+  one_of:
+    - "DESIGN_APPROVED"
+    - "DESIGN_REJECTED"
+    - "NO_FD_CHANGE"
+    - "CHAT_COMPLETE"
+    - "CHAT_ROUTE_AGENT"
+    - "CHAT_ROUTE_CREATE_PROJECT"
+    - "CHAT_ROUTE_UPDATE_PROJECT"
+  error_message: >
+    PRECONDITION FAILED: Your done() summary MUST contain one of the required
+    status keywords: DESIGN_APPROVED, DESIGN_REJECTED, NO_FD_CHANGE,
+    CHAT_COMPLETE, CHAT_ROUTE_AGENT, CHAT_ROUTE_CREATE_PROJECT, or
+    CHAT_ROUTE_UPDATE_PROJECT. These are mandatory protocol keywords that must
+    appear exactly as written (in English, uppercase). Review your completion
+    instructions and call done() again with the correct status in your summary.
+
+completion_preconditions:
+  - summary_contains: "DESIGN_APPROVED"
+    required_tools:
+      - tool_name: "make_design"
+        min_calls: 1
+      - tool_name: "run_git"
+        min_calls: 1
+    error_message: >
+      PRECONDITION FAILED: You cannot call done() with DESIGN_APPROVED without
+      first writing functional_design.md AND committing it to git. You MUST
+      call these tools before calling done():
+      1. Call coding_make_design(path="functional_design.md", content="...") to write the file
+      2. Call hitl_ask_multiple_choice_question to present the FD to the user
+      3. Call run_git to add, commit, and push functional_design.md to git
+      Do NOT output markdown text — you must use the coding_make_design TOOL.
+      Do NOT call done() again until you have completed all 3 steps.
+
 llm_profile: cheap
 temperature: 0.2
 max_tokens: 100000

--- a/druppie/agents/definitions/business_analyst.yaml
+++ b/druppie/agents/definitions/business_analyst.yaml
@@ -757,11 +757,12 @@ system_prompt: |
      that will be sent to the Architect.
   2. Ask for explicit confirmation with options:
      → Yes, approve and send to Architect / No, I have feedback (please explain below)
-  3. If user approves the FD → call done() with DESIGN_APPROVED.
+  3. If user approves the FD → use run_git to add, commit, and push
+     functional_design.md to git → then call done() with DESIGN_APPROVED.
   4. If user has feedback → Update functional_design.md accordingly → present
      the updated version again for confirmation (repeat this phase).
 
-  **Output:** User-approved functional_design.md confirmed + done() called.
+  **Output:** User-approved functional_design.md committed to git + done() called.
 
   =============================================================================
   functional_design.md FORMAT

--- a/druppie/api/main.py
+++ b/druppie/api/main.py
@@ -107,13 +107,22 @@ async def lifespan(app: FastAPI):
     await cleanup_orphaned_sandbox_users()
 
     # Initialize tool registry (discovers MCP tools from servers via tools/list)
-    from druppie.core.tool_registry import initialize_tool_registry
+    from druppie.core.tool_registry import initialize_tool_registry, get_tool_registry
     try:
         await initialize_tool_registry()
         logger.info("tool_registry_initialized")
     except Exception as e:
         logger.warning("tool_registry_init_failed", error=str(e),
                        hint="MCP servers may not be ready yet. Registry will load builtin tools only.")
+
+    # Retry any MCP servers that failed during startup
+    registry = get_tool_registry()
+    failed = getattr(registry, "_failed_servers", [])
+    if failed:
+        create_tracked_task(
+            registry._retry_failed_servers(failed),
+            name="mcp-registry-retry",
+        )
 
     # Start sandbox watchdog (detects stuck WAITING_SANDBOX tool calls)
     from druppie.api.routes.sandbox import sandbox_watchdog_loop

--- a/druppie/api/main.py
+++ b/druppie/api/main.py
@@ -117,7 +117,7 @@ async def lifespan(app: FastAPI):
 
     # Retry any MCP servers that failed during startup
     registry = get_tool_registry()
-    failed = getattr(registry, "_failed_servers", [])
+    failed = registry._failed_servers
     if failed:
         create_tracked_task(
             registry._retry_failed_servers(failed),

--- a/druppie/core/tool_registry.py
+++ b/druppie/core/tool_registry.py
@@ -115,7 +115,38 @@ class ToolRegistry:
             logger.error(
                 "tool_registry_partial_init",
                 failed_servers=failed_servers,
-                impact=f"{len(failed_servers)} MCP server(s) unreachable — their tools will not work",
+                impact=f"{len(failed_servers)} MCP server(s) unreachable — will retry",
+            )
+            self._failed_servers = failed_servers
+
+    async def _retry_failed_servers(
+        self, servers: list[str], max_retries: int = 5, base_delay: float = 5.0
+    ) -> None:
+        """Retry loading tools from MCP servers that failed during startup."""
+        remaining = list(servers)
+        for attempt in range(1, max_retries + 1):
+            delay = base_delay * attempt
+            await asyncio.sleep(delay)
+            still_failing = []
+            for server in remaining:
+                try:
+                    await self._load_mcp_tools_from_server(server)
+                    logger.info(
+                        "mcp_server_retry_success",
+                        server=server,
+                        attempt=attempt,
+                    )
+                except Exception:
+                    still_failing.append(server)
+            remaining = still_failing
+            if not remaining:
+                logger.info("all_mcp_servers_recovered")
+                return
+        if remaining:
+            logger.error(
+                "mcp_servers_permanently_failed",
+                servers=remaining,
+                impact="These MCP server tools will NOT be available to agents",
             )
 
     def _load_builtin_tools(self) -> None:
@@ -154,7 +185,7 @@ class ToolRegistry:
                 url=url,
                 error=str(e),
             )
-            return
+            raise
 
         # Get approval config from mcp_config.yaml
         tool_configs = {t["name"]: t for t in self._mcp_config.get_tools(server)}

--- a/druppie/core/tool_registry.py
+++ b/druppie/core/tool_registry.py
@@ -48,6 +48,7 @@ class ToolRegistry:
         """
         self._mcp_config = mcp_config or get_mcp_config()
         self._tools: dict[str, ToolDefinition] = {}
+        self._failed_servers: list[str] = []
         self._initialized = False
 
     async def initialize(self) -> None:
@@ -111,13 +112,13 @@ class ToolRegistry:
                     impact=f"All tools from '{server}' are unavailable",
                 )
 
+        self._failed_servers = failed_servers
         if failed_servers:
             logger.error(
                 "tool_registry_partial_init",
                 failed_servers=failed_servers,
                 impact=f"{len(failed_servers)} MCP server(s) unreachable — will retry",
             )
-            self._failed_servers = failed_servers
 
     async def _retry_failed_servers(
         self, servers: list[str], max_retries: int = 5, base_delay: float = 5.0
@@ -141,7 +142,10 @@ class ToolRegistry:
             remaining = still_failing
             if not remaining:
                 logger.info("all_mcp_servers_recovered")
+                self._failed_servers = []
                 return
+        # Update to reflect only servers that never recovered
+        self._failed_servers = remaining
         if remaining:
             logger.error(
                 "mcp_servers_permanently_failed",

--- a/druppie/domain/agent_definition.py
+++ b/druppie/domain/agent_definition.py
@@ -5,6 +5,36 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 
+class RequiredToolCall(BaseModel):
+    """A tool that must have been called before completion is allowed."""
+
+    tool_name: str
+    min_calls: int = 1
+
+
+class CompletionPrecondition(BaseModel):
+    """Rule: require certain prior tool calls before done() succeeds.
+
+    If summary_contains is set, the rule only applies when the summary matches.
+    If summary_contains is omitted (None), the rule always applies.
+    """
+
+    summary_contains: str | None = None
+    required_tools: list[RequiredToolCall]
+    error_message: str = "Completion precondition not met."
+
+
+class CompletionSummaryRequirement(BaseModel):
+    """Require that done() summary contains one of the allowed status keywords.
+
+    This enforces the agent's status protocol (e.g. DESIGN_APPROVED,
+    DESIGN_REJECTED, NO_FD_CHANGE) regardless of what language the LLM uses.
+    """
+
+    one_of: list[str]
+    error_message: str = "Summary must contain a required status keyword."
+
+
 class ApprovalOverride(BaseModel):
     """Override for tool approval requirements.
 
@@ -53,6 +83,15 @@ class AgentDefinition(BaseModel):
     # Direct routing: which agents this agent can route to via done(next_agent=...)
     # Empty list means no direct routing allowed (default — planner decides)
     allowed_next_agents: list[str] = Field(default_factory=list)
+
+    # Completion preconditions: rules that must be satisfied before done() succeeds
+    # If done()'s summary matches a rule's summary_contains, the required tools
+    # must have been called (with status=completed) during this agent run.
+    completion_preconditions: list[CompletionPrecondition] = Field(default_factory=list)
+
+    # Require done() summary to contain one of the allowed status keywords.
+    # Enforces the agent's status protocol regardless of LLM language drift.
+    required_summary_status: CompletionSummaryRequirement | None = None
 
     # LLM settings
     llm_profile: str = "standard"


### PR DESCRIPTION
## Summary

- **Completion preconditions guardrail** — Adds a YAML-configurable validation layer on the agent `done()` tool. Before an agent can complete, the system checks that required tools were actually called (with `status=completed`) and that the summary contains a valid status keyword. This prevents the BA from claiming `DESIGN_APPROVED` without having written `functional_design.md` via `make_design` or committed it via `run_git`.
- **MCP server startup retry** — Fixes a race condition where the coding MCP server isn't ready when the backend starts, causing its tools (`make_design`, `run_git`, etc.) to never be registered. Failed servers are now retried in a background task with linear backoff (5 attempts).
- **BA Phase 10 ordering fix** — Moves the `run_git` instruction to *after* user approval (Phase 10) instead of before it (Phase 9), so the BA commits the design only once the user has confirmed it.

## Changes

### New domain models (`domain/agent_definition.py`)
- `RequiredToolCall` — tool name + minimum call count
- `CompletionPrecondition` — conditional rule: if summary matches, require certain tools
- `CompletionSummaryRequirement` — enforce status keywords in `done()` summary
- New fields on `AgentDefinition`: `completion_preconditions`, `required_summary_status`

### Completion validation (`agents/builtin_tools.py`)
- `_check_completion_preconditions()` — loads the agent definition, checks summary keywords and tool call history against configured rules
- Wired into `done()` — returns `{"success": False, "error": ...}` on violation, forcing the agent to retry
- Fails closed: if the agent definition can't be loaded, completion is blocked (not silently skipped)

### MCP retry logic (`core/tool_registry.py`, `api/main.py`)
- `_load_mcp_tools_from_server` now raises on failure (instead of silently returning)
- `_retry_failed_servers()` retries with linear backoff (`5s * attempt`, up to 5 retries)
- `_failed_servers` declared in `__init__` with proper cleanup after retry
- `main.py` launches retry as a background task after initial registry init

### BA agent config (`agents/definitions/business_analyst.yaml`)
- Added `required_summary_status` with all valid BA status keywords
- Added `completion_preconditions` rule: `DESIGN_APPROVED` requires prior `make_design` + `run_git`
- Updated Phase 10 instructions: commit *after* user approval, not before

## Test plan

- [ ] **Completion guardrail — happy path**: Run a BA session end-to-end. Create an FD with `make_design`, get user approval, commit with `run_git`, then call `done(DESIGN_APPROVED)`. Should succeed.
- [ ] **Completion guardrail — missing tool calls**: Manually (or via prompt) trigger `done()` with `DESIGN_APPROVED` without having called `make_design` or `run_git`. The agent should receive an error and be forced to retry.
- [ ] **Completion guardrail — bad status keyword**: Call `done()` with a summary that doesn't contain any of the required keywords. Should return an error with the expected keyword list.
- [ ] **Completion guardrail — non-DESIGN_APPROVED paths**: Call `done()` with `CHAT_COMPLETE` or `NO_FD_CHANGE` (no precondition rules match). Should succeed without requiring tool calls.
- [ ] **Fail-closed guardrail — definition load error**: Temporarily break an agent YAML (e.g., rename `business_analyst.yaml`), then trigger `done()` for that agent. Should return an error blocking completion, not silently pass.
- [ ] **MCP retry**: Start the stack and observe logs. If the coding server starts slowly, you should see `mcp_server_retry_success` log entries. Verify coding tools are available to agents after retry.
- [ ] **MCP retry — all retries fail**: Stop the coding MCP server entirely, start the backend. After 5 retries, confirm `mcp_servers_permanently_failed` is logged.
- [ ] **MCP retry — `_failed_servers` cleanup (all recover)**: Start backend with one MCP server down, let it retry and recover. Verify `registry._failed_servers` is `[]` afterward.
- [ ] **MCP retry — `_failed_servers` cleanup (partial recovery)**: Start backend with two MCP servers down, let only one recover. Verify `registry._failed_servers` contains only the still-failing server.
- [ ] **Phase 10 ordering**: Run a BA session that produces an FD. Verify the BA presents the FD for approval *before* committing to git (not the other way around).
- [ ] **Existing tests**: `cd druppie && pytest` — confirm no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)