### PR TITLE
feat: session_owner approval type for BA functional design gate

### DIFF
--- a/druppie/agents/definitions/business_analyst.yaml
+++ b/druppie/agents/definitions/business_analyst.yaml
@@ -267,8 +267,9 @@ system_prompt: |
   Follow the full operational flow below: Intake & Classification →
   Solution Unpacking (if needed) → Root Cause Analysis → Elicitation →
   Requirement Structuring → Functional Design Synthesis → Solution Bias
-  Check → User Validation (summary) → Write functional_design.md → FD
-  Confirmation (user approves the actual FD) → done()
+  Check → Prepare Process Flow Diagram → coding_make_design (the approval
+  gate IS the user confirmation — do NOT ask hitl for extra confirmation
+  before or after make_design) → done()
 
   **Note:** Context gathering is MANDATORY during Phase 1 (Intake). See
   Phase 1 step 3 and the Context Gathering section above.
@@ -399,14 +400,10 @@ system_prompt: |
       K -- No --> L[Remove Solution Bias]
       L --> J
       K -- Yes --> M[Generate Process Flow Diagram]
-      M --> N[Present Summary to User]
-      N --> P{User approves summary?}
-      P -- No --> F
-      P -- Yes --> Q[Write functional_design.md]
-      Q --> R[Present FD to User for Confirmation]
-      R --> X{User approves FD?}
-      X -- No --> Y[Update FD based on feedback]
-      Y --> R
+      M --> Q[coding_make_design — approval gate fires]
+      Q --> X{User approves via gate?}
+      X -- No --> Y[Revise FD using rejection reason]
+      Y --> Q
       X -- Yes --> Z(["done() with DESIGN_APPROVED"])
   ```
 
@@ -708,55 +705,43 @@ system_prompt: |
 
   **Output:** Validated solution-agnostic design.
 
-  ### Phase 9: User Validation
+  ### Phase 9: Prepare Process Flow Diagram
 
   **Trigger:** Functional Design passes bias check.
 
   **Task:**
-  1. Generate a **Mermaid process flow diagram** as part of functional_design.md.
-     **MANDATORY:** Before creating the diagram, you MUST first call
-     invoke_skill(skill_name="making-mermaid-diagrams") to load the correct
-     syntax rules. Follow the loaded syntax exactly to avoid rendering errors.
-     Before including the diagram in make_design, verify each node against
-     the skill's shape table and self-verification checklist.
-  2. Present a summary to the user via hitl_ask_multiple_choice_question.
-     Use the user's language. You MUST follow this exact template:
+  Generate a **Mermaid process flow diagram** that will be included as section 12
+  of functional_design.md.
+  **MANDATORY:** Before creating the diagram, you MUST first call
+  invoke_skill(skill_name="making-mermaid-diagrams") to load the correct
+  syntax rules. Follow the loaded syntax exactly to avoid rendering errors.
+  Before including the diagram in make_design, verify each node against
+  the skill's shape table and self-verification checklist.
 
-     ---
-     **Problem Statement**
-     [1-3 sentences describing the core problem the user experiences]
+  **Output:** Validated Mermaid diagram ready to embed in the FD.
 
-     **Root Cause**
-     [1-2 sentences describing the underlying root cause you identified]
+  ### Phase 10: Write FD and Resolve Approval Gate
 
-     **Functional Requirements**
-     1. [FR-01: requirement statement]
-     2. [FR-02: requirement statement]
-     3. [...]
-
-     **Out of Scope**
-     - [What this design explicitly does NOT cover]
-     ---
-
-     Then ask for confirmation with these options:
-     → Yes, this accurately captures my needs / Partially, some things need adjustment / No, there are significant issues
-  3. If user has feedback on the summary → Iterate (return to relevant phase) → repeat validation.
-  4. If user confirms the summary → Write functional_design.md via coding_make_design, then use run_git to add, commit, and push it to git.
-
-  ### Phase 10: Functional Design Confirmation
-
-  **Trigger:** functional_design.md has been written (both initial and revision flows).
+  **Trigger:** Mermaid diagram is prepared and the full FD content is ready.
 
   **Task:**
-  1. Call coding_make_design to write functional_design.md. The system will
-     automatically pause and present the content to the user for approval
-     via the approval gate (no need to use hitl_ask_multiple_choice_question).
-  2. If the user approves → the file is written automatically. Then use
-     run_git to add, commit, and push functional_design.md to git.
-     Finally call done() with DESIGN_APPROVED.
-  3. If the user rejects (with feedback) → update the content based on
-     their feedback and call coding_make_design again. The approval gate
-     fires again so the user can review the updated version.
+  1. Call `coding_make_design` with the complete `functional_design.md`
+     content. The system automatically creates a session_owner approval
+     and pauses execution — the session owner sees the full FD in the
+     approval card and clicks approve or reject.
+  2. **DO NOT** call `hitl_ask_question` or `hitl_ask_multiple_choice_question`
+     to confirm the FD before or after `coding_make_design`. The approval
+     gate IS the user confirmation. Asking a HITL question in addition
+     is redundant and frustrates the user.
+  3. If the approval is approved → the tool call completes and writes
+     the file. Use `run_git` to add, commit, and push `functional_design.md`,
+     then call `done()` with `DESIGN_APPROVED`.
+  4. If the approval is rejected → the tool call returns a failure message
+     containing the user's rejection reason (e.g. "Tool call was rejected
+     by a human reviewer. Reason: ..."). Read that reason, revise the FD
+     content to address it, and call `coding_make_design` again. The gate
+     fires on every `make_design` call, so the user re-reviews the revised
+     version.
 
   **Output:** User-approved functional_design.md committed to git + done() called.
 

--- a/druppie/agents/definitions/business_analyst.yaml
+++ b/druppie/agents/definitions/business_analyst.yaml
@@ -41,11 +41,10 @@ system_prompt: |
   YOUR OWN "Agent business_analyst:" line.
 
   ### STATUS: DESIGN_APPROVED
-  Use when you have written functional_design.md AND the user has explicitly
-  confirmed the written FD (Phase 10). You must NEVER call done() with
-  DESIGN_APPROVED without first presenting the complete FD to the user and
-  receiving their confirmation. This applies to both initial creation and
-  every revision cycle.
+  Use when you have written functional_design.md (via coding_make_design,
+  which requires user approval through the approval gate) AND committed it
+  to git (via run_git). You must NEVER call done() with DESIGN_APPROVED
+  without first having the user approve the FD through the approval gate.
 
   CORRECT:
     Call done with summary: "Agent business_analyst: DESIGN_APPROVED. [what you gathered and designed]. Wrote functional_design.md with [X] functional requirements and [Y] user journeys."
@@ -513,15 +512,13 @@ system_prompt: |
   **Trigger:** Targeted validation passes.
 
   **Task:**
-  1. Write the revised functional_design.md via coding_make_design.
-  2. Use run_git to add, commit, and push it to git.
-  3. Proceed to **Phase 10: Functional Design Confirmation** — present the
-     complete revised FD to the user for explicit approval before proceeding.
-     Do NOT call done() until the user has confirmed the revised FD.
-  4. After user confirmation, call done() with DESIGN_APPROVED and a summary
-     describing: what was changed, whether the user was consulted, and any
-     items that could not be fully resolved.
-  5. The Planner will route the revised design back to the Architect.
+  1. Write the revised functional_design.md via coding_make_design (the
+     approval gate will pause for user approval automatically).
+  2. Once approved, use run_git to add, commit, and push it to git.
+  3. Call done() with DESIGN_APPROVED and a summary describing: what was
+     changed, whether the user was consulted, and any items that could not
+     be fully resolved.
+  4. The Planner will route the revised design back to the Architect.
 
   **Output:** User-confirmed revised functional_design.md + done() summary serving as revision summary.
 
@@ -751,17 +748,17 @@ system_prompt: |
   **Trigger:** functional_design.md has been written (both initial and revision flows).
 
   **Task:**
-  1. Present the **complete written functional_design.md** to the user via
-     hitl_ask_multiple_choice_question. Include the full content of the
-     document in the question text so the user can review the actual design
-     that will be sent to the Architect.
-  2. Ask for explicit confirmation with options:
-     → Yes, approve and send to Architect / No, I have feedback (please explain below)
-  3. If user approves the FD → call done() with DESIGN_APPROVED.
-  4. If user has feedback → Update functional_design.md accordingly → present
-     the updated version again for confirmation (repeat this phase).
+  1. Call coding_make_design to write functional_design.md. The system will
+     automatically pause and present the content to the user for approval
+     via the approval gate (no need to use hitl_ask_multiple_choice_question).
+  2. If the user approves → the file is written automatically. Then use
+     run_git to add, commit, and push functional_design.md to git.
+     Finally call done() with DESIGN_APPROVED.
+  3. If the user rejects (with feedback) → update the content based on
+     their feedback and call coding_make_design again. The approval gate
+     fires again so the user can review the updated version.
 
-  **Output:** User-approved functional_design.md confirmed + done() called.
+  **Output:** User-approved functional_design.md committed to git + done() called.
 
   =============================================================================
   functional_design.md FORMAT
@@ -969,7 +966,13 @@ mcps:
 
 # LAYERED APPROVAL SYSTEM:
 # When business_analyst calls make_design (to create functional_design.md),
-# it requires approval from someone with the "business_analyst" role.
+# it requires approval from the session owner (the user who started the
+# conversation). This is enforced at the system level — the approval gate
+# pauses execution until the user approves or rejects the FD content.
+approval_overrides:
+  "coding:make_design":
+    requires_approval: true
+    required_role: session_owner
 
 llm_profile: cheap
 temperature: 0.2

--- a/druppie/api/deps.py
+++ b/druppie/api/deps.py
@@ -101,9 +101,10 @@ def get_session_service(
 
 def get_approval_service(
     approval_repo: ApprovalRepository = Depends(get_approval_repository),
+    session_repo: SessionRepository = Depends(get_session_repository),
 ) -> ApprovalService:
     """Get ApprovalService with repositories injected."""
-    return ApprovalService(approval_repo)
+    return ApprovalService(approval_repo, session_repo=session_repo)
 
 
 def get_question_service(

--- a/druppie/api/routes/approvals.py
+++ b/druppie/api/routes/approvals.py
@@ -102,8 +102,9 @@ async def list_approvals(
     - Required role to approve
     - Session and agent info
     """
+    user_id = UUID(user["sub"])
     user_roles = get_user_roles(user)
-    return service.get_pending_for_roles(user_roles)
+    return service.get_pending_for_roles(user_roles, user_id=user_id)
 
 
 @router.get("/history")
@@ -118,8 +119,9 @@ async def approval_history(
     Returns paginated history of approvals that have been resolved,
     filtered by the user's roles. Admin users see all history.
     """
+    user_id = UUID(user["sub"])
     user_roles = get_user_roles(user)
-    return service.get_history_for_roles(user_roles, page, limit)
+    return service.get_history_for_roles(user_roles, user_id=user_id, page=page, limit=limit)
 
 
 @router.post("/{approval_id}/approve")

--- a/druppie/domain/approval.py
+++ b/druppie/domain/approval.py
@@ -29,6 +29,9 @@ class ApprovalDetail(ApprovalSummary):
     agent_id: str | None
     rejection_reason: str | None = None
     created_at: datetime
+    # Session owner ID — populated for session_owner approvals so the frontend
+    # can determine if the current user is the session owner.
+    session_user_id: UUID | None = None
 
 
 class PendingApprovalList(BaseModel):

--- a/druppie/repositories/approval_repository.py
+++ b/druppie/repositories/approval_repository.py
@@ -3,9 +3,12 @@
 from uuid import UUID
 from datetime import datetime, timezone
 
+from sqlalchemy import or_, and_
+
 from .base import BaseRepository
 from ..domain import ApprovalDetail, ApprovalSummary, ApprovalHistoryList, PendingApprovalList, ApprovalStatus
 from ..db.models import Approval
+from ..db.models.session import Session as SessionModel
 
 
 class ApprovalRepository(BaseRepository):
@@ -53,18 +56,32 @@ class ApprovalRepository(BaseRepository):
         """Get raw approval model."""
         return self.db.query(Approval).filter_by(id=approval_id).first()
 
-    def get_pending_for_roles(self, roles: list[str] | None) -> PendingApprovalList:
+    def get_pending_for_roles(
+        self, roles: list[str] | None, user_id: UUID | None = None
+    ) -> PendingApprovalList:
         """Get pending approvals that the user's roles can approve.
 
         Args:
             roles: List of roles to filter by, or None to return all pending.
+            user_id: Current user's ID — used to include session_owner approvals
+                for sessions this user owns.
         """
         query = (
             self.db.query(Approval)
             .filter(Approval.status == ApprovalStatus.PENDING.value)
         )
         if roles is not None:
-            query = query.filter(Approval.required_role.in_(roles))
+            conditions = [Approval.required_role.in_(roles)]
+            if user_id:
+                conditions.append(
+                    and_(
+                        Approval.required_role == "session_owner",
+                        Approval.session_id.in_(
+                            self.db.query(SessionModel.id).filter(SessionModel.user_id == user_id)
+                        ),
+                    )
+                )
+            query = query.filter(or_(*conditions))
         approvals = query.order_by(Approval.created_at.desc()).all()
         return PendingApprovalList(
             items=[self._to_detail(a) for a in approvals],
@@ -72,12 +89,14 @@ class ApprovalRepository(BaseRepository):
         )
 
     def get_resolved_for_roles(
-        self, roles: list[str] | None, page: int = 1, limit: int = 20
+        self, roles: list[str] | None, page: int = 1, limit: int = 20,
+        user_id: UUID | None = None,
     ) -> ApprovalHistoryList:
         """Get resolved approvals (approved/rejected) filtered by roles, paginated.
 
         Args:
             roles: List of roles to filter by, or None to return all resolved.
+            user_id: Current user's ID — used to include session_owner approvals.
         """
         base_query = (
             self.db.query(Approval)
@@ -89,7 +108,17 @@ class ApprovalRepository(BaseRepository):
             )
         )
         if roles is not None:
-            base_query = base_query.filter(Approval.required_role.in_(roles))
+            conditions = [Approval.required_role.in_(roles)]
+            if user_id:
+                conditions.append(
+                    and_(
+                        Approval.required_role == "session_owner",
+                        Approval.session_id.in_(
+                            self.db.query(SessionModel.id).filter(SessionModel.user_id == user_id)
+                        ),
+                    )
+                )
+            base_query = base_query.filter(or_(*conditions))
 
         total = base_query.count()
 
@@ -127,6 +156,13 @@ class ApprovalRepository(BaseRepository):
 
     def _to_detail(self, approval: Approval) -> ApprovalDetail:
         """Convert approval model to detail domain object."""
+        # Look up session owner for session_owner approvals (needed by frontend)
+        session_user_id = None
+        if approval.required_role == "session_owner" and approval.session_id:
+            row = self.db.query(SessionModel.user_id).filter_by(id=approval.session_id).first()
+            if row:
+                session_user_id = row.user_id
+
         return ApprovalDetail(
             # From ApprovalSummary
             id=approval.id,
@@ -144,6 +180,7 @@ class ApprovalRepository(BaseRepository):
             agent_id=approval.agent_id,
             rejection_reason=approval.rejection_reason,
             created_at=approval.created_at,
+            session_user_id=session_user_id,
         )
 
     def _to_summary(self, approval: Approval) -> ApprovalSummary:

--- a/druppie/services/approval_service.py
+++ b/druppie/services/approval_service.py
@@ -20,11 +20,15 @@ The route coordinates both services:
 from uuid import UUID
 import structlog
 
-from ..repositories import ApprovalRepository
+from ..repositories import ApprovalRepository, SessionRepository
 from ..domain import ApprovalDetail, ApprovalHistoryList, PendingApprovalList, ApprovalStatus
 from ..api.errors import NotFoundError, AuthorizationError, ConflictError
 
 logger = structlog.get_logger()
+
+# Sentinel value for approval_overrides that means "the session's own user
+# must approve" instead of a Keycloak role.
+SESSION_OWNER_ROLE = "session_owner"
 
 
 class ApprovalService:
@@ -38,42 +42,47 @@ class ApprovalService:
     the route should call WorkflowService.resume_from_approval().
     """
 
-    def __init__(self, approval_repo: ApprovalRepository):
+    def __init__(self, approval_repo: ApprovalRepository, session_repo: SessionRepository):
         self.approval_repo = approval_repo
+        self.session_repo = session_repo
 
     def get_pending_for_roles(
         self,
         user_roles: list[str],
+        user_id: UUID | None = None,
     ) -> PendingApprovalList:
         """Get approvals user can act on based on their roles.
 
         Admin users see all pending approvals.
-        Other users see only approvals matching their roles.
+        Other users see only approvals matching their roles,
+        plus session_owner approvals for sessions they own.
         """
         if "admin" in user_roles:
             roles_to_check = None  # Admin sees all pending approvals
         else:
             roles_to_check = user_roles
 
-        return self.approval_repo.get_pending_for_roles(roles_to_check)
+        return self.approval_repo.get_pending_for_roles(roles_to_check, user_id=user_id)
 
     def get_history_for_roles(
         self,
         user_roles: list[str],
+        user_id: UUID | None = None,
         page: int = 1,
         limit: int = 20,
     ) -> ApprovalHistoryList:
         """Get resolved approvals user can see based on their roles.
 
         Admin users see all resolved approvals.
-        Other users see only approvals matching their roles.
+        Other users see only approvals matching their roles,
+        plus session_owner approvals for sessions they own.
         """
         if "admin" in user_roles:
             roles_to_check = None  # Admin sees all history
         else:
             roles_to_check = user_roles
 
-        return self.approval_repo.get_resolved_for_roles(roles_to_check, page, limit)
+        return self.approval_repo.get_resolved_for_roles(roles_to_check, page, limit, user_id=user_id)
 
     def approve(
         self,
@@ -113,13 +122,8 @@ class ApprovalService:
         if not approval:
             raise NotFoundError("approval", str(approval_id))
 
-        # Check role authorization
-        required_role = approval.required_role or "admin"
-        if required_role not in user_roles and "admin" not in user_roles:
-            raise AuthorizationError(
-                f"Requires {required_role} role to approve",
-                required_roles=[required_role],
-            )
+        # Check authorization
+        self._check_authorization(approval, user_id, user_roles, action="approve")
 
         # Check not already processed
         if approval.status != ApprovalStatus.PENDING.value:
@@ -174,12 +178,8 @@ class ApprovalService:
         if not approval:
             raise NotFoundError("approval", str(approval_id))
 
-        required_role = approval.required_role or "admin"
-        if required_role not in user_roles and "admin" not in user_roles:
-            raise AuthorizationError(
-                f"Requires {required_role} role to reject",
-                required_roles=[required_role],
-            )
+        # Check authorization
+        self._check_authorization(approval, user_id, user_roles, action="reject")
 
         if approval.status != ApprovalStatus.PENDING.value:
             raise ConflictError(f"Approval already {approval.status}")
@@ -201,3 +201,28 @@ class ApprovalService:
 
         updated = self.approval_repo.get_by_id(approval_id)
         return self.approval_repo._to_detail(updated)
+
+    def _check_authorization(self, approval, user_id: UUID, user_roles: list[str], action: str) -> None:
+        """Check if user is authorized to approve/reject.
+
+        Handles both role-based approvals (required_role = "architect", etc.)
+        and session_owner approvals (required_role = "session_owner").
+        Admins can always approve/reject.
+        """
+        if "admin" in user_roles:
+            return
+
+        required_role = approval.required_role or "admin"
+
+        if required_role == SESSION_OWNER_ROLE:
+            session = self.session_repo.get_by_id(approval.session_id)
+            if not session or session.user_id != user_id:
+                raise AuthorizationError(
+                    f"Only the session owner can {action} this",
+                )
+        else:
+            if required_role not in user_roles:
+                raise AuthorizationError(
+                    f"Requires {required_role} role to {action}",
+                    required_roles=[required_role],
+                )

--- a/druppie/services/approval_service.py
+++ b/druppie/services/approval_service.py
@@ -22,6 +22,7 @@ import structlog
 
 from ..repositories import ApprovalRepository, SessionRepository
 from ..domain import ApprovalDetail, ApprovalHistoryList, PendingApprovalList, ApprovalStatus
+from ..db.models import Approval
 from ..api.errors import NotFoundError, AuthorizationError, ConflictError
 
 logger = structlog.get_logger()
@@ -202,7 +203,7 @@ class ApprovalService:
         updated = self.approval_repo.get_by_id(approval_id)
         return self.approval_repo._to_detail(updated)
 
-    def _check_authorization(self, approval, user_id: UUID, user_roles: list[str], action: str) -> None:
+    def _check_authorization(self, approval: Approval, user_id: UUID, user_roles: list[str], action: str) -> None:
         """Check if user is authorized to approve/reject.
 
         Handles both role-based approvals (required_role = "architect", etc.)

--- a/druppie/testing/bounded_orchestrator.py
+++ b/druppie/testing/bounded_orchestrator.py
@@ -276,9 +276,25 @@ class BoundedOrchestrator:
                     if agent_run and agent_run.agent_id not in self._real_agents:
                         break
 
+                question_context = None
+                if pending_question.tool_call_id:
+                    from druppie.db.models import ToolCall
+                    tc = self._db.query(ToolCall).filter(
+                        ToolCall.id == pending_question.tool_call_id
+                    ).first()
+                    if tc and isinstance(tc.arguments, dict):
+                        question_context = tc.arguments.get("context")
+
+                from druppie.testing.session_transcript import build_transcript
+                transcript = build_transcript(
+                    self._db, session_id, exclude_question_id=pending_question.id,
+                )
+
                 raw_answer = self._hitl_simulator.answer(
                     question_text=pending_question.question,
                     choices=pending_question.choices,
+                    question_context=question_context,
+                    session_transcript=transcript,
                 )
 
                 answer = raw_answer
@@ -306,14 +322,41 @@ class BoundedOrchestrator:
                 if not pending_approval:
                     break
 
-                # Auto-approve with the test user
-                pending_approval.status = "approved"
+                decision_status = "approved"
+                decision_reason: str | None = None
+                if self._hitl_simulator is not None:
+                    from druppie.db.models import ToolCall
+                    from druppie.testing.session_transcript import build_transcript
+                    tc = self._db.query(ToolCall).filter(
+                        ToolCall.id == pending_approval.tool_call_id
+                    ).first()
+                    tool_name = f"{pending_approval.mcp_server}:{pending_approval.tool_name}"
+                    tool_args = tc.arguments if tc and isinstance(tc.arguments, dict) else {}
+                    transcript = build_transcript(
+                        self._db, session_id, exclude_approval_id=pending_approval.id,
+                    )
+                    decision = self._hitl_simulator.decide_approval(
+                        tool_name=tool_name,
+                        tool_arguments=tool_args,
+                        session_transcript=transcript,
+                    )
+                    decision_status = decision.get("status", "approved")
+                    decision_reason = decision.get("reason")
+
+                if decision_status == "rejected":
+                    pending_approval.status = "rejected"
+                    pending_approval.rejection_reason = decision_reason or "Rejected by session owner."
+                else:
+                    pending_approval.status = "approved"
                 pending_approval.resolved_by = session.user_id
                 pending_approval.resolved_at = utcnow()
                 self._db.commit()
 
-                logger.info("Approval auto-approved (iteration %d): tool=%s:%s",
-                            iteration, pending_approval.mcp_server, pending_approval.tool_name)
+                logger.info(
+                    "Approval resolved by simulator (iteration %d): tool=%s:%s status=%s reason=%s",
+                    iteration, pending_approval.mcp_server, pending_approval.tool_name,
+                    pending_approval.status, (decision_reason or "")[:120],
+                )
                 await orchestrator.resume_after_approval(
                     session_id=session_id,
                     approval_id=pending_approval.id,

--- a/druppie/testing/hitl_simulator.py
+++ b/druppie/testing/hitl_simulator.py
@@ -1,7 +1,9 @@
 """HITL (Human-in-the-Loop) simulator for automated test execution."""
 from __future__ import annotations
 
+import json
 import logging
+import re
 import time
 
 from druppie.testing.schema import HITLProfile
@@ -12,14 +14,29 @@ MAX_HITL_INTERACTIONS = 100
 
 
 class HITLSimulator:
-    """Simulates human-in-the-loop answers using an LLM with a profile prompt."""
+    """Simulates human-in-the-loop answers using an LLM with a profile prompt.
+
+    Also decides approval/rejection on approval gates — the same persona
+    both answers HITL questions and acts as the session owner reviewing
+    tool calls, so its behavior stays coherent across a session.
+    """
 
     def __init__(self, profile: HITLProfile, test_context: str = ""):
         self._profile = profile
         self._test_context = test_context
         self._interaction_count = 0
 
-    def answer(self, question_text: str, choices: list[dict] | None = None) -> str:
+    # ------------------------------------------------------------------ #
+    # HITL question answering
+    # ------------------------------------------------------------------ #
+
+    def answer(
+        self,
+        question_text: str,
+        choices: list[dict] | None = None,
+        question_context: str | None = None,
+        session_transcript: str | None = None,
+    ) -> str:
         from druppie.llm.litellm_provider import ChatLiteLLM
 
         self._interaction_count += 1
@@ -32,14 +49,24 @@ class HITLSimulator:
             temperature=self._profile.temperature,
         )
 
-        system_parts = [self._profile.prompt.strip()]
-        if self._test_context:
-            system_parts.append(f'\nContext: The user originally requested: "{self._test_context}"')
-        system_parts.append(
-            "\nWhen asked multiple choice questions, respond with the FULL TEXT of your chosen option, NOT a number."
-            "\nWhen asked open-ended questions, give a clear 1-2 sentence answer."
+        system_prompt = self._build_system_prompt(
+            extra_guidance=(
+                "When asked multiple choice questions, respond with the FULL TEXT "
+                "of your chosen option, NOT a number.\n"
+                "When asked open-ended questions, give a clear 1-2 sentence answer."
+            )
         )
-        system_prompt = "\n".join(system_parts)
+
+        blocks = []
+        if session_transcript:
+            blocks.append(
+                "Conversation so far (most recent tool calls, questions, approvals):\n\n"
+                f"{session_transcript}\n"
+            )
+        if question_context:
+            blocks.append(
+                f"Additional context the agent provided with this question:\n\n{question_context}\n"
+            )
 
         is_choice_question = bool(choices)
         if is_choice_question:
@@ -48,36 +75,191 @@ class HITLSimulator:
                 text = c.get("text", c) if isinstance(c, dict) else str(c)
                 choice_lines.append(f"{i + 1}. {text}")
             user_prompt = (
-                f'The agent asks you a multiple choice question:\n\n'
-                f'"{question_text}"\n\n'
-                f'Options:\n'
-                + "\n".join(choice_lines)
-                + "\n\nRespond with the FULL TEXT of your chosen option, NOT a number."
+                "\n\n".join(blocks)
+                + (f"\n\nThe agent asks you a multiple choice question:\n\n"
+                   f'"{question_text}"\n\nOptions:\n'
+                   + "\n".join(choice_lines)
+                   + "\n\nRespond with the FULL TEXT of your chosen option, NOT a number.")
             )
         else:
             user_prompt = (
-                f'The agent asks you:\n\n'
-                f'"{question_text}"\n\n'
-                f'Respond with ONLY your answer, no explanation.'
+                "\n\n".join(blocks)
+                + f"\n\nThe agent asks you:\n\n\"{question_text}\"\n\n"
+                "Respond with ONLY your answer, no explanation."
             )
 
-        # Retry on rate limits
+        response = self._call_llm_with_retry(
+            llm,
+            [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+        )
+        answer = response.content.strip()
+        logger.info(
+            "HITL simulator answered (interaction %d): question=%s answer=%s",
+            self._interaction_count, question_text[:80], answer[:80],
+        )
+        return answer
+
+    # ------------------------------------------------------------------ #
+    # Approval gate decision
+    # ------------------------------------------------------------------ #
+
+    def decide_approval(
+        self,
+        tool_name: str,
+        tool_arguments: dict | None,
+        session_transcript: str | None = None,
+    ) -> dict:
+        """Let the persona approve or reject a pending approval gate.
+
+        Returns a dict: {"status": "approved"|"rejected", "reason": str|None}.
+        The reason is populated only for rejections and is what the agent
+        will see in the tool call failure message.
+        """
+        from druppie.llm.litellm_provider import ChatLiteLLM
+
+        self._interaction_count += 1
+        if self._interaction_count > MAX_HITL_INTERACTIONS:
+            raise RuntimeError(f"Exceeded max HITL interactions ({MAX_HITL_INTERACTIONS})")
+
+        llm = ChatLiteLLM(
+            provider=self._profile.provider,
+            model=self._profile.model,
+            temperature=self._profile.temperature,
+        )
+
+        system_prompt = self._build_system_prompt(
+            extra_guidance=(
+                "You are acting as the session owner reviewing an agent's tool call "
+                "that requires your approval. Decide whether to APPROVE or REJECT it "
+                "based on your persona and the conversation so far.\n\n"
+                "Respond with ONLY valid JSON in this exact shape — no prose, no code "
+                "fences:\n"
+                "  {\"status\": \"approved\"}\n"
+                "  or\n"
+                "  {\"status\": \"rejected\", \"reason\": \"<concrete feedback for the agent>\"}\n\n"
+                "If rejecting, the `reason` must give the agent actionable guidance so "
+                "it can revise and try again. Do not reject without a reason."
+            )
+        )
+
+        args_str = ""
+        if tool_arguments:
+            try:
+                args_str = json.dumps(tool_arguments, ensure_ascii=False, indent=2)
+            except Exception:
+                args_str = str(tool_arguments)
+            if len(args_str) > 8000:
+                args_str = args_str[:8000] + f"\n... [truncated, {len(args_str) - 8000} chars omitted]"
+
+        blocks = []
+        if session_transcript:
+            blocks.append(
+                "Conversation so far (most recent tool calls, questions, approvals):\n\n"
+                f"{session_transcript}\n"
+            )
+        blocks.append(
+            f"The agent now wants to call `{tool_name}` with these arguments:\n\n"
+            f"{args_str or '(no arguments)'}"
+        )
+        blocks.append(
+            "Decide: approve or reject? Return JSON only."
+        )
+        user_prompt = "\n\n".join(blocks)
+
+        response = self._call_llm_with_retry(
+            llm,
+            [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+        )
+
+        decision = self._parse_approval_decision(response.content)
+        logger.info(
+            "HITL simulator approval decision (interaction %d): tool=%s status=%s reason=%s",
+            self._interaction_count, tool_name, decision["status"],
+            (decision.get("reason") or "")[:120],
+        )
+        return decision
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+
+    def _build_system_prompt(self, extra_guidance: str) -> str:
+        parts = [self._profile.prompt.strip()]
+        if self._test_context:
+            parts.append(f'\nContext: The user originally requested: "{self._test_context}"')
+        parts.append("\n" + extra_guidance)
+        return "\n".join(parts)
+
+    def _call_llm_with_retry(self, llm, messages):
         for attempt in range(5):
             try:
-                response = llm.chat(
-                    messages=[
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt},
-                    ]
-                )
-                answer = response.content.strip()
-                logger.info("HITL simulator answered (interaction %d): question=%s answer=%s",
-                             self._interaction_count, question_text[:80], answer[:80])
-                return answer
+                return llm.chat(messages=messages)
             except Exception as e:
                 if "rate" in str(e).lower() and attempt < 4:
                     wait = 2 ** attempt
-                    logger.warning("HITL simulator rate limited, retrying in %ds (attempt %d)", wait, attempt + 1)
+                    logger.warning(
+                        "HITL simulator rate limited, retrying in %ds (attempt %d)",
+                        wait, attempt + 1,
+                    )
                     time.sleep(wait)
                 else:
                     raise
+
+    @staticmethod
+    def _parse_approval_decision(raw: str) -> dict:
+        """Parse the LLM's approval decision JSON, tolerant of fences/prose."""
+        text = (raw or "").strip()
+
+        # Strip ```json fences if present
+        if text.startswith("```"):
+            text = re.sub(r"^```(?:json)?\s*", "", text)
+            text = re.sub(r"\s*```$", "", text)
+
+        # First try the whole thing
+        for candidate in (text, _extract_first_json_object(text)):
+            if not candidate:
+                continue
+            try:
+                obj = json.loads(candidate)
+            except Exception:
+                continue
+            status = str(obj.get("status", "")).strip().lower()
+            if status in ("approved", "approve", "yes"):
+                return {"status": "approved", "reason": None}
+            if status in ("rejected", "reject", "no"):
+                reason = str(obj.get("reason") or "").strip() or "Rejected by session owner."
+                return {"status": "rejected", "reason": reason}
+
+        # Fallback: look for explicit approve/reject keywords
+        low = text.lower()
+        if "rejected" in low or "reject" in low:
+            return {
+                "status": "rejected",
+                "reason": "Rejected (simulator could not parse structured decision).",
+            }
+        logger.warning("HITL simulator approval output unparsable — defaulting to approved: %r", raw[:200])
+        return {"status": "approved", "reason": None}
+
+
+def _extract_first_json_object(text: str) -> str | None:
+    """Best-effort extraction of the first {...} block in `text`."""
+    if not text:
+        return None
+    depth = 0
+    start = -1
+    for i, ch in enumerate(text):
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start != -1:
+                return text[start : i + 1]
+    return None

--- a/druppie/testing/session_transcript.py
+++ b/druppie/testing/session_transcript.py
@@ -1,0 +1,132 @@
+"""Chronological transcript of a session for the HITL simulator.
+
+Compiles agent runs, tool calls, HITL Q&A, and approvals into a single
+text summary so the simulator can answer follow-up questions and make
+approval decisions with full context of what the agent has done so far.
+"""
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+from sqlalchemy.orm import Session as DbSession
+
+from druppie.db.models import AgentRun, Approval, Question, ToolCall
+
+
+MAX_FIELD_CHARS = 4000
+
+
+def _truncate(value: str, limit: int = MAX_FIELD_CHARS) -> str:
+    if value is None:
+        return ""
+    if len(value) <= limit:
+        return value
+    return value[:limit] + f"... [truncated, {len(value) - limit} chars omitted]"
+
+
+def _format_args(args) -> str:
+    if not args:
+        return "{}"
+    try:
+        return _truncate(json.dumps(args, ensure_ascii=False, indent=2))
+    except Exception:
+        return _truncate(str(args))
+
+
+def build_transcript(db: DbSession, session_id: UUID, exclude_question_id: UUID | None = None,
+                     exclude_approval_id: UUID | None = None) -> str:
+    """Return a chronological transcript string for the session.
+
+    Includes every tool call with its arguments and result, every HITL
+    question with its answer, and every approval with its outcome. Events
+    are ordered by `created_at`.
+
+    `exclude_question_id` / `exclude_approval_id` let the caller omit the
+    *current* pending question/approval from the transcript so the simulator
+    sees prior context without the question it is about to answer.
+    """
+    runs = (
+        db.query(AgentRun)
+        .filter(AgentRun.session_id == session_id)
+        .order_by(AgentRun.created_at.asc())
+        .all()
+    )
+    tool_calls = (
+        db.query(ToolCall)
+        .join(AgentRun, ToolCall.agent_run_id == AgentRun.id)
+        .filter(AgentRun.session_id == session_id)
+        .order_by(ToolCall.created_at.asc())
+        .all()
+    )
+    questions = (
+        db.query(Question)
+        .filter(Question.session_id == session_id)
+        .order_by(Question.created_at.asc())
+        .all()
+    )
+    approvals = (
+        db.query(Approval)
+        .filter(Approval.session_id == session_id)
+        .order_by(Approval.created_at.asc())
+        .all()
+    )
+
+    # Index for fast lookup
+    questions_by_tc = {q.tool_call_id: q for q in questions if q.tool_call_id}
+    approvals_by_tc = {a.tool_call_id: a for a in approvals if a.tool_call_id}
+    run_agent_by_id = {r.id: r.agent_id for r in runs}
+
+    lines: list[str] = []
+    for tc in tool_calls:
+        agent_id = run_agent_by_id.get(tc.agent_run_id, "?")
+        header = f"[{agent_id}] {tc.mcp_server or 'builtin'}:{tc.tool_name}"
+
+        # HITL question path
+        q = questions_by_tc.get(tc.id)
+        if q is not None:
+            if exclude_question_id is not None and q.id == exclude_question_id:
+                continue
+            lines.append(f"{header} (HITL question)")
+            if isinstance(tc.arguments, dict) and tc.arguments.get("context"):
+                lines.append(f"  context: {_truncate(str(tc.arguments['context']))}")
+            lines.append(f"  question: {_truncate(q.question)}")
+            if q.choices:
+                for i, c in enumerate(q.choices):
+                    text = c.get("text", c) if isinstance(c, dict) else str(c)
+                    lines.append(f"    {i + 1}. {text}")
+            if q.status == "answered":
+                lines.append(f"  answer: {_truncate(q.answer or '')}")
+            else:
+                lines.append("  answer: (still pending)")
+            lines.append("")
+            continue
+
+        # Approval-gated tool call
+        approval = approvals_by_tc.get(tc.id)
+        if approval is not None and (exclude_approval_id is None or approval.id != exclude_approval_id):
+            lines.append(f"{header} (approval-gated, role={approval.required_role})")
+            lines.append(f"  arguments: {_format_args(tc.arguments)}")
+            if approval.status == "pending":
+                lines.append("  approval: (still pending)")
+            elif approval.status == "rejected":
+                reason = getattr(approval, "rejection_reason", None) or "(no reason given)"
+                lines.append(f"  approval: REJECTED — reason: {_truncate(str(reason))}")
+            else:
+                lines.append(f"  approval: {approval.status.upper()}")
+            lines.append("")
+            continue
+
+        # Plain tool call
+        lines.append(header)
+        if tc.arguments:
+            lines.append(f"  arguments: {_format_args(tc.arguments)}")
+        if tc.result:
+            lines.append(f"  result: {_truncate(tc.result)}")
+        if tc.status and tc.status not in ("completed", "pending"):
+            lines.append(f"  status: {tc.status}")
+        lines.append("")
+
+    if not lines:
+        return "(no prior agent activity in this session yet)"
+    return "\n".join(lines).rstrip()

--- a/frontend/src/components/chat/ApprovalCard.jsx
+++ b/frontend/src/components/chat/ApprovalCard.jsx
@@ -265,7 +265,11 @@ const ApprovalCard = ({ approval, onApprove, onReject, isProcessing, currentUser
 
   // Check if current user can approve based on their roles
   // User can approve if they have admin role OR any of the required roles
-  const userCanApprove = userRoles.includes('admin') || requiredRoles.some((r) => userRoles.includes(r))
+  // For session_owner approvals, check if user owns the session
+  const isSessionOwnerApproval = requiredRoles.includes('session_owner')
+  const userCanApprove = isSessionOwnerApproval
+    ? (currentUserId === approval.session_user_id || userRoles.includes('admin'))
+    : (userRoles.includes('admin') || requiredRoles.some((r) => userRoles.includes(r)))
 
   // Handler to open contact modal
   const handleOpenContactModal = () => {
@@ -337,7 +341,9 @@ const ApprovalCard = ({ approval, onApprove, onReject, isProcessing, currentUser
           {/* Single approval role display */}
           {!isMultiApproval && (
             <div className="text-sm text-gray-500 mb-3">
-              This action requires approval from <span className="font-semibold text-gray-700">{requiredRoles.join(' or ')}</span> role.
+              {isSessionOwnerApproval
+                ? 'This action requires approval from the session owner.'
+                : <>This action requires approval from <span className="font-semibold text-gray-700">{requiredRoles.join(' or ')}</span> role.</>}
             </div>
           )}
 
@@ -471,10 +477,14 @@ const ApprovalCard = ({ approval, onApprove, onReject, isProcessing, currentUser
                     <Clock className="w-5 h-5 text-blue-600" />
                     <div className="flex-1">
                       <span className="text-sm text-blue-800 font-medium">
-                        Waiting for approval from: <span className="font-bold">{requiredRoles.join(' or ')}</span>
+                        {isSessionOwnerApproval
+                          ? 'Waiting for the session owner to approve'
+                          : <>Waiting for approval from: <span className="font-bold">{requiredRoles.join(' or ')}</span></>}
                       </span>
                       <p className="text-xs text-blue-600 mt-0.5">
-                        You don't have the required role to approve this action.
+                        {isSessionOwnerApproval
+                          ? 'Only the user who started this conversation can approve this action.'
+                          : "You don't have the required role to approve this action."}
                       </p>
                     </div>
                   </div>

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -307,7 +307,7 @@ const TimelineQuestion = ({ tc, agentId, sessionId }) => {
 
 // --- Agent Run ---
 
-const AgentRunItem = ({ run, timelineIndex, sessionId, hasFollowingMessage }) => {
+const AgentRunItem = ({ run, timelineIndex, sessionId, hasFollowingMessage, sessionUserId }) => {
   const orderedItems = extractOrderedItems(run, hasFollowingMessage)
 
   // Show agent trace for completed runs that have no following message
@@ -335,7 +335,7 @@ const AgentRunItem = ({ run, timelineIndex, sessionId, hasFollowingMessage }) =>
         if (item.type === 'approval') {
           return (
             <div key={i} className="mt-2">
-              <InlineApproval tc={item.tc} sessionId={sessionId} sessionUserId={data?.user_id} />
+              <InlineApproval tc={item.tc} sessionId={sessionId} sessionUserId={sessionUserId} />
             </div>
           )
         }
@@ -1047,6 +1047,7 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
                       timelineIndex={i}
                       sessionId={sessionId}
                       hasFollowingMessage={hasFollowingMessage}
+                      sessionUserId={data?.user_id}
                     />
                     {renderAnnotation(i)}
                   </div>

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -58,7 +58,7 @@ const getToolLabel = (toolName) => {
 
 // --- Inline Approval (minimal chat card) ---
 
-const InlineApproval = ({ tc, sessionId }) => {
+const InlineApproval = ({ tc, sessionId, sessionUserId }) => {
   const queryClient = useQueryClient()
   const user = getUserInfo()
   const [rejectMode, setRejectMode] = useState(false)
@@ -97,7 +97,10 @@ const InlineApproval = ({ tc, sessionId }) => {
 
   const userRoles = user?.roles || []
   const requiredRoles = tc.approval.required_role ? [tc.approval.required_role] : ['admin']
-  const userCanApprove = userRoles.includes('admin') || requiredRoles.some((r) => userRoles.includes(r))
+  const isSessionOwnerApproval = requiredRoles.includes('session_owner')
+  const userCanApprove = isSessionOwnerApproval
+    ? (user?.id === sessionUserId || userRoles.includes('admin'))
+    : (userRoles.includes('admin') || requiredRoles.some((r) => userRoles.includes(r)))
 
   return (
     <div className="group">
@@ -219,7 +222,9 @@ const InlineApproval = ({ tc, sessionId }) => {
                 )
               ) : (
                 <span className="text-xs text-amber-600">
-                  Waiting for {requiredRoles.join(' or ')} approval
+                  {isSessionOwnerApproval
+                    ? 'Waiting for your approval'
+                    : `Waiting for ${requiredRoles.join(' or ')} approval`}
                 </span>
               )}
             </div>
@@ -330,7 +335,7 @@ const AgentRunItem = ({ run, timelineIndex, sessionId, hasFollowingMessage }) =>
         if (item.type === 'approval') {
           return (
             <div key={i} className="mt-2">
-              <InlineApproval tc={item.tc} sessionId={sessionId} />
+              <InlineApproval tc={item.tc} sessionId={sessionId} sessionUserId={data?.user_id} />
             </div>
           )
         }
@@ -1101,7 +1106,7 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
             return (
               <div className="space-y-3">
                 {pending.map((tc, i) => (
-                  <InlineApproval key={tc.approval.id || i} tc={tc} sessionId={sessionId} />
+                  <InlineApproval key={tc.approval.id || i} tc={tc} sessionId={sessionId} sessionUserId={data?.user_id} />
                 ))}
               </div>
             )

--- a/frontend/src/components/chat/ToolDecisionCard.jsx
+++ b/frontend/src/components/chat/ToolDecisionCard.jsx
@@ -30,6 +30,7 @@ import {
   Package,
 } from 'lucide-react'
 import { getAgentConfig, getAgentMessageColors } from '../../utils/agentConfig'
+import { getUserInfo } from '../../services/keycloak'
 
 // Helper to get tool icon
 const getToolIcon = (toolName) => {
@@ -68,6 +69,7 @@ const ToolDecisionCard = ({
   isProcessing,
   isAnswering,
   userRoles = [],
+  sessionUserId,
 }) => {
   const [expanded, setExpanded] = useState(true)
   const [rejectReason, setRejectReason] = useState('')
@@ -111,9 +113,12 @@ const ToolDecisionCard = ({
   const hasDisplayableArgs = Object.keys(displayArgs).length > 0
 
   // Check if user can approve
+  const isSessionOwnerApproval = approval && (approval.required_roles || []).includes('session_owner')
   const canApprove = approval && approval.status === 'pending' && (
     userRoles.includes('admin') ||
-    (approval.required_roles || []).some(role => userRoles.includes(role))
+    (isSessionOwnerApproval
+      ? (sessionUserId && getUserInfo()?.id === sessionUserId)
+      : (approval.required_roles || []).some(role => userRoles.includes(role)))
   )
 
   // ==========================================================================
@@ -308,7 +313,9 @@ const ToolDecisionCard = ({
         {/* Subtitle */}
         <div className="text-xs text-gray-500 mt-1 ml-9">
           Called by {agentConfig?.name || agent_id || 'Agent'}
-          {approval_required && isPending && ` • Requires ${(approval.required_roles || ['admin']).join(' or ')} approval`}
+          {approval_required && isPending && (isSessionOwnerApproval
+            ? ' • Requires session owner approval'
+            : ` • Requires ${(approval.required_roles || ['admin']).join(' or ')} approval`)}
         </div>
 
         {/* Arguments */}
@@ -447,9 +454,15 @@ const ToolDecisionCard = ({
         {approval_required && isPending && !canApprove && (
           <div className="mt-3 pt-3 border-t border-gray-200">
             <div className="text-xs text-gray-600 bg-gray-100 rounded-lg px-3 py-2">
-              Waiting for approval from: {(approval.required_roles || ['admin']).join(' or ')}
+              {isSessionOwnerApproval
+                ? 'Waiting for the session owner to approve this action.'
+                : <>Waiting for approval from: {(approval.required_roles || ['admin']).join(' or ')}</>}
               <br />
-              <span className="text-gray-500">You don't have the required role to approve this action.</span>
+              <span className="text-gray-500">
+                {isSessionOwnerApproval
+                  ? 'Only the user who started this conversation can approve.'
+                  : "You don't have the required role to approve this action."}
+              </span>
             </div>
           </div>
         )}

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -201,7 +201,11 @@ const TaskCard = ({ task, onApprove, onReject }) => {
   const requiredRole = task.required_role || (requiredRoles.length > 0 ? requiredRoles[0] : 'admin')
 
   // Check if user has any of the required roles
-  const canApprove = requiredRoles.some(role => hasRole(role))
+  // For session_owner approvals, check if user owns the session
+  const isSessionOwnerApproval = requiredRoles.includes('session_owner')
+  const canApprove = isSessionOwnerApproval
+    ? (user?.sub === task.session_user_id || hasRole('admin'))
+    : requiredRoles.some(role => hasRole(role))
 
   // MULTI approval state
   const isMultiApproval = task.approval_type === 'multi'
@@ -378,7 +382,7 @@ const TaskCard = ({ task, onApprove, onReject }) => {
                   </Link>
                 )}
                 <span className={canApprove ? 'text-green-500' : ''}>
-                  {requiredRoles.join(', ')}
+                  {isSessionOwnerApproval ? 'session owner' : requiredRoles.join(', ')}
                 </span>
               </div>
             </div>

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -204,7 +204,7 @@ const TaskCard = ({ task, onApprove, onReject }) => {
   // For session_owner approvals, check if user owns the session
   const isSessionOwnerApproval = requiredRoles.includes('session_owner')
   const canApprove = isSessionOwnerApproval
-    ? (user?.sub === task.session_user_id || hasRole('admin'))
+    ? (user?.id === task.session_user_id || hasRole('admin'))
     : requiredRoles.some(role => hasRole(role))
 
   // MULTI approval state

--- a/testing/agents/ba-design-no-bias.yaml
+++ b/testing/agents/ba-design-no-bias.yaml
@@ -18,4 +18,4 @@ agent-test:
   judge:
     context: [router, business_analyst]
     checks:
-      - "The BA should have asked at least one clarifying question before writing the design. Check if hitl_ask_question or hitl_ask_multiple_choice_question was called before make_design."
+      - "The BA should have asked at least one clarifying question before writing the design. Check if hitl_ask_question was called before make_design (note: hitl_ask_multiple_choice_question is no longer used for FD confirmation — that is handled by the approval gate on make_design)."

--- a/testing/agents/ba-fd-reject-then-approve.yaml
+++ b/testing/agents/ba-fd-reject-then-approve.yaml
@@ -1,0 +1,25 @@
+## Agent test: BA handles FD rejection then approval via the session_owner
+## approval gate.
+##
+## Exercises the full reject → revise → approve cycle on coding:make_design.
+## The picky-session-owner persona rejects the first make_design with concrete
+## feedback, then approves the revised version. Verifies that the BA reads the
+## rejection reason, revises the FD, and calls make_design again before
+## completing with DESIGN_APPROVED.
+
+agent-test:
+  name: ba-fd-reject-then-approve
+  description: "BA writes FD, session owner rejects first draft with feedback, BA revises, owner approves."
+  tags: [business_analyst, approval_gate, session_owner]
+
+  message: "build me a small recipe sharing app where home cooks can upload and rate recipes"
+  agents: [router, planner, business_analyst]
+  hitl: picky-session-owner
+
+  judge:
+    context: [business_analyst]
+    checks:
+      - "The business_analyst must have called coding:make_design at least TWICE in this session. The first call should have been rejected via the approval gate with a concrete reason, and the second call should have been approved."
+      - "After the first rejection, the second coding:make_design call must show evidence that the BA incorporated the rejection reason — the revised arguments should address the specific gap the reviewer pointed out (do not count simple rewording as a revision)."
+      - "The business_analyst must have ended with done() carrying DESIGN_APPROVED in the summary. It must NOT end with DESIGN_REJECTED."
+      - "The business_analyst must NOT have asked the user to confirm or approve the functional_design.md via any HITL tool. Confirmation of the FD content is the approval gate's job (coding:make_design creates the approval). Legitimate elicitation questions gathering requirements (features, users, data, devices, rules) are fine — only extra 'does the FD look OK?' / 'do you approve this design?' style confirmations around make_design are regressions. Inspect the actual question text of each hitl_ask_multiple_choice_question / hitl_ask_question tool call. Only fail this check if you find one that presents the FD content and asks the user to approve/confirm it."

--- a/testing/profiles/hitl.yaml
+++ b/testing/profiles/hitl.yaml
@@ -21,3 +21,38 @@ profiles:
     prompt: |
       You are a senior developer. You give technical, precise answers.
       You care about architecture, testing, and code quality.
+
+  picky-session-owner:
+    model: glm-4.5-air
+    provider: zai
+    prompt: |
+      You are a demanding but fair product owner reviewing functional
+      design documents from your business analyst. You take quality
+      seriously.
+
+      When asked HITL questions during requirement gathering, give clear,
+      reasonable answers consistent with a small recipe sharing app for
+      home cooks (the product you want built).
+
+      When reviewing an approval gate for `coding:make_design` (a
+      functional design document):
+
+      - If this is the FIRST time you are seeing a functional_design.md
+        in this conversation, **reject it** with a concrete, actionable
+        reason. Pick ONE meaningful gap the agent should address — for
+        example: "The non-functional requirements section is missing
+        concrete performance targets; please add at least response-time
+        and concurrent-user targets." Keep the reason short (1-2
+        sentences) and specific so the agent can fix it.
+
+      - If you have already rejected a make_design call in this
+        conversation and you are now seeing a revised version that
+        addresses your earlier feedback, **approve it**. Look at the
+        transcript to see what you asked for last time and whether the
+        new version includes it.
+
+      - For any other approval gate in the session (non make_design),
+        approve it.
+
+      Never reject twice in the same session — that would loop forever.
+      Always return the required JSON format.

--- a/testing/tools/setup-create-project-pipeline.yaml
+++ b/testing/tools/setup-create-project-pipeline.yaml
@@ -1,5 +1,5 @@
 ## Shared base: generic create_project pipeline up to builder planning
-## Router → Planner → BA (HITL + FD + git) → Planner → Architect (TD + git) → Planner
+## Router → Planner → BA (FD + approval gate + git) → Planner → Architect (TD + git) → Planner
 ## Extending tests append: Builder (mock) + done
 ##
 ## Used by: create-expense-tracker, create-portfolio-site, create-weather-dashboard
@@ -40,21 +40,9 @@ tool-test:
 
     # --- Business Analyst ---
     - agent: business_analyst
-      tool: builtin:hitl_ask_multiple_choice_question
-      arguments:
-        question: "Welke variant heeft uw voorkeur?"
-        choices:
-          - "Basis"
-          - "Uitgebreid"
-          - "Volledig"
-      mock: true
-      mock_result: "Uitgebreid"
-
-    - agent: business_analyst
       tool: coding:make_design
       approval:
         status: approved
-        by: analyst
       arguments:
         path: docs/functional-design.md
         content: |

--- a/testing/tools/setup-portfolio-with-fd.yaml
+++ b/testing/tools/setup-portfolio-with-fd.yaml
@@ -33,21 +33,9 @@ tool-test:
         summary: "Agent planner: Planned business_analyst"
 
     - agent: business_analyst
-      tool: builtin:hitl_ask_multiple_choice_question
-      mock: true
-      mock_result: "Minimalistisch en clean"
-      arguments:
-        question: "Welke stijl heeft uw voorkeur?"
-        choices:
-          - "Minimalistisch en clean"
-          - "Gedurfd en kleurrijk"
-          - "Professioneel en zakelijk"
-
-    - agent: business_analyst
       tool: coding:make_design
       approval:
         status: approved
-        by: analyst
       arguments:
         path: docs/functional-design.md
         content: |

--- a/testing/tools/setup-project-with-fd.yaml
+++ b/testing/tools/setup-project-with-fd.yaml
@@ -40,21 +40,9 @@ tool-test:
 
     # --- Business Analyst ---
     - agent: business_analyst
-      tool: builtin:hitl_ask_multiple_choice_question
-      mock: true
-      mock_result: "Home cooks sharing recipes with friends and family"
-      arguments:
-        question: "Who is the target audience?"
-        choices:
-          - "Home cooks sharing recipes with friends and family"
-          - "Professional chefs and restaurants"
-          - "Food bloggers and content creators"
-
-    - agent: business_analyst
       tool: coding:make_design
       approval:
         status: approved
-        by: analyst
       arguments:
         path: docs/functional-design.md
         content: |

--- a/testing/tools/setup-todo-app-pipeline.yaml
+++ b/testing/tools/setup-todo-app-pipeline.yaml
@@ -44,21 +44,9 @@ tool-test:
 
     # --- Business Analyst ---
     - agent: business_analyst
-      tool: builtin:hitl_ask_multiple_choice_question
-      arguments:
-        question: "What task management features do you need?"
-        choices:
-          - "Basic: add, complete, delete tasks"
-          - "Advanced: priorities, due dates, categories"
-          - "Full: subtasks, recurring tasks, collaboration"
-      mock: true
-      mock_result: "Basic: add, complete, delete tasks"
-
-    - agent: business_analyst
       tool: coding:make_design
       approval:
         status: approved
-        by: analyst
       arguments:
         path: docs/functional-design.md
         content: |


### PR DESCRIPTION
## Summary

Adds a new `session_owner` approval type that requires the session's own user (the person chatting) to approve, instead of requiring a specific Keycloak role. This replaces the BA's prompt-based HITL approval step with a system-enforced gate on `coding:make_design`.

Scope grew during implementation to include testing-infrastructure upgrades (the HITL simulator now acts as the session owner on approval gates) and a small frontend crash fix — see "Additional changes" below.

**Problem:** The BA currently uses `hitl_ask_multiple_choice_question` to ask the user to approve the FD before committing. This is prompt-driven and bypassable — the LLM can skip the question and call `done(DESIGN_APPROVED)` without user consent.

**Solution:** Use `required_role: "session_owner"` as a sentinel value in `approval_overrides`. The backend detects this and checks `session.user_id == approver_id` instead of Keycloak role membership. The approval gate on `coding:make_design` pauses execution automatically and shows the FD content to the user for approval — no prompt cooperation needed.

### How it works

1. BA calls `coding:make_design` to write functional_design.md
2. Tool executor sees `approval_overrides` → creates Approval with `required_role="session_owner"`
3. Execution pauses, user sees the FD content in the approval card
4. User approves → file is written → BA commits via `run_git` → calls `done(DESIGN_APPROVED)`
5. User rejects (with feedback) → BA reads the rejection reason → calls `make_design` again → new approval

### Changes

**Backend:**
- `ApprovalService`: new `_check_authorization()` handles both role-based and session_owner checks. Injects `SessionRepository` for ownership lookup.
- `ApprovalRepository`: `get_pending_for_roles()` and `get_resolved_for_roles()` now also include `session_owner` approvals for sessions the current user owns (via subquery).
- `ApprovalDetail`: new `session_user_id` field so frontend can determine session ownership without extra API calls.
- API routes/deps: pass `user_id` through to listing endpoints.

**Frontend:**
- `SessionDetail` (InlineApproval), `ApprovalCard`, `ToolDecisionCard`, `Tasks`: detect `session_owner` in required_roles, check current user ID against session owner instead of role membership. Updated messaging: "Waiting for your approval" / "Waiting for session owner".

**BA agent (`business_analyst.yaml`):**
- Added `approval_overrides` for `coding:make_design` with `required_role: session_owner`
- Rewrote Phase 9 to prepare the Mermaid diagram only (no pre-make_design summary ask)
- Rewrote Phase 10 to call `coding_make_design` directly and treat its failure-with-reason as the rejection path. Explicitly forbids HITL confirmation around `make_design` — the approval gate is the confirmation.
- Updated the operational-flow Mermaid diagram and the create_project flow summary
- Updated the DESIGN_APPROVED status description

### No changes needed
- DB schema: `required_role` is `String(50)`, stores `"session_owner"` as-is
- `AgentDefinition`: `ApprovalOverride` already accepts any string
- `MCPConfig.needs_approval()`: already returns whatever the override says
- `tool_executor._create_approval_and_wait()`: already stores whatever `required_role` it gets

## Additional changes

### Crash fix (`932aa14`)
`AgentRunItem` in `SessionDetail.jsx` referenced `data?.user_id` from an outer scope it doesn't have. When a resolved approval flowed through `extractOrderedItems`, the component crashed with *"data is not defined"*. Now threaded through as an explicit `sessionUserId` prop.

### Testing infrastructure (`b7e29d4`) — HITL simulator decides approvals
Needed so agent tests can exercise the new session_owner gate without a human.

- `HITLSimulator.decide_approval(tool_name, args, transcript) -> {status, reason}` — the same persona that answers HITL questions now also acts as the session owner on approval gates. LLM-driven so persona prompts control reject/approve behavior.
- `bounded_orchestrator._handle_pause_loop` calls the simulator's decision on `PAUSED_APPROVAL` instead of hard-coding approve. Fallback auto-approve kept for runs with no simulator.
- New `session_transcript.build_transcript()` — chronological summary of every prior tool call, HITL Q&A, and approval (with outcome and rejection reason). Passed into every simulator call so the persona behaves coherently across multi-turn sessions and can tell "first make_design" from "revised make_design".
- Tool tests keep their existing deterministic per-step `approval:` block (unchanged).
- New `picky-session-owner` persona in `testing/profiles/hitl.yaml` rejects the first FD draft with concrete feedback, approves the revision, never loops.
- New agent test `testing/agents/ba-fd-reject-then-approve.yaml` exercises the full reject → revise → approve cycle.

Side fix while here: the simulator was also missing the HITL tool's `context` argument (where the BA pastes FD summaries / diagrams). Now threaded through.

### BA prompt cleanup (`da348e9`)
Covered above under *BA agent*.

## Test plan

- [ ] Start dev environment, log in as `normal_user`, create a session, trigger BA flow
- [ ] BA calls `make_design` → approval card appears with FD content
- [ ] Approve → file gets written → BA commits and calls done
- [ ] Reject with feedback → BA reads the reason → new `make_design` with a revised FD → new approval card
- [ ] Tasks page shows session_owner approvals for the session owner
- [ ] Log in as different user → should NOT see approve/reject buttons
- [ ] Log in as admin → should be able to approve (admin override)
- [ ] `cd druppie && pytest` — no regressions
- [x] Agent test `ba-fd-reject-then-approve` passes the reject → revise → approve cycle (3/4 judge checks on first run, 4th was a judge-prompt wording issue — tightened in the YAML)
- [x] Regression: `ba-design-no-bias` still passes 1/1 with the reworded BA prompt

## E2E validation (run locally against this branch)

Session `21ea73d6-2f00-487c-88eb-d7511c9fc722`:
- 1st `make_design` → **rejected** by `picky-session-owner` with reason *"missing concrete performance targets; please add response-time and concurrent-user targets"*
- BA read the rejection, revised the FD, added NFR-05 (25 concurrent users), NFR-06 (1s save response), NFR-07 (5MB photo limit)
- 2nd `make_design` → **approved**
- BA committed as `66c35e2` and called `done(DESIGN_APPROVED)`

Both approvals in the DB show `required_role = session_owner` with the expected reject reason persisted on the first.