### PR TITLE
feat: /admin/platform dashboard for deployments + volumes

### DIFF
--- a/druppie/api/routes/deployments.py
+++ b/druppie/api/routes/deployments.py
@@ -591,8 +591,46 @@ async def wipe_project(
                 detail="Not authorized to wipe this project",
             )
 
-    # Remove containers
+    # Collect compose project names from druppie-labeled containers so we can
+    # tear down entire compose stacks (app + sidecars like postgres + volumes).
+    compose_projects: set[str] = set()
     for c in containers:
+        labels = c.get("labels", {})
+        cp = labels.get("druppie.compose_project") or labels.get("com.docker.compose.project")
+        if cp:
+            compose_projects.add(cp)
+
+    # Use compose_down to remove all containers AND volumes per compose project.
+    # This handles sidecar containers (db, redis, etc.) that don't carry
+    # druppie.* labels but belong to the same compose stack.
+    for cp in compose_projects:
+        try:
+            r = await mcp_http.call(
+                server="docker",
+                tool="compose_down",
+                args={"compose_project_name": cp, "remove_volumes": True},
+                timeout_seconds=60.0,
+            )
+            if r.get("success"):
+                containers_removed.append(f"compose:{cp}")
+                for v in r.get("volumes_removed", []):
+                    volumes_removed.append(v)
+            else:
+                errors.append(f"compose_down {cp}: {r.get('error', 'unknown')}")
+        except MCPHttpError as e:
+            errors.append(f"compose_down {cp}: {e}")
+
+    # Remove any druppie-labeled containers not part of a compose project
+    # (e.g. standalone containers created outside compose_up).
+    standalone = [
+        c for c in containers
+        if not any(
+            (c.get("labels", {}).get("druppie.compose_project") or
+             c.get("labels", {}).get("com.docker.compose.project")) == cp
+            for cp in compose_projects
+        )
+    ]
+    for c in standalone:
         name = c.get("name")
         if not name:
             continue
@@ -609,48 +647,6 @@ async def wipe_project(
                 errors.append(f"rm {name}: {r.get('error', 'unknown')}")
         except MCPHttpError as e:
             errors.append(f"rm {name}: {e}")
-
-    # Collect compose project names that belong to this druppie project_id so we
-    # can also reap compose volumes that lack druppie.* labels.
-    compose_projects: set[str] = set()
-    for c in containers:
-        labels = c.get("labels", {})
-        cp = labels.get("druppie.compose_project") or labels.get("com.docker.compose.project")
-        if cp:
-            compose_projects.add(cp)
-
-    try:
-        vols = await mcp_http.call(
-            server="docker",
-            tool="list_volumes",
-            args={"druppie_only": False},
-            timeout_seconds=15.0,
-        )
-        all_volumes = vols.get("volumes", []) if vols.get("success") else []
-        target_vols = []
-        for v in all_volumes:
-            labels = v.get("labels", {})
-            if labels.get("druppie.project_id") == project_id:
-                target_vols.append(v["name"])
-            elif labels.get("com.docker.compose.project") in compose_projects:
-                target_vols.append(v["name"])
-
-        for vname in target_vols:
-            try:
-                r = await mcp_http.call(
-                    server="docker",
-                    tool="remove_volume",
-                    args={"volume_name": vname, "force": False},
-                    timeout_seconds=15.0,
-                )
-                if r.get("success"):
-                    volumes_removed.append(vname)
-                else:
-                    errors.append(f"rm volume {vname}: {r.get('error', 'unknown')}")
-            except MCPHttpError as e:
-                errors.append(f"rm volume {vname}: {e}")
-    except MCPHttpError as e:
-        errors.append(f"list_volumes: {e}")
 
     return WipeResponse(
         success=len(errors) == 0,

--- a/druppie/api/routes/deployments.py
+++ b/druppie/api/routes/deployments.py
@@ -20,7 +20,7 @@ from fastapi import APIRouter, Depends, Query, HTTPException
 from pydantic import BaseModel
 import structlog
 
-from druppie.api.deps import get_current_user
+from druppie.api.deps import get_current_user, get_user_roles
 from druppie.api.errors import NotFoundError
 from druppie.core.mcp_config import MCPConfig
 from druppie.execution.mcp_http import MCPHttp, MCPHttpError
@@ -176,7 +176,7 @@ async def _verify_owner_or_admin(
     action: str,
 ) -> None:
     """Raise 403/404 if user is not admin and doesn't own the container."""
-    if "admin" in user.get("roles", []):
+    if "admin" in get_user_roles(user):
         return
     try:
         inspect_result = await mcp_http.call(
@@ -226,7 +226,7 @@ async def list_deployments(
         args["session_id"] = session_id
 
     # Non-admin users can only see their own containers
-    user_roles = user.get("roles", [])
+    user_roles = get_user_roles(user)
     if "admin" not in user_roles:
         args["user_id"] = user.get("sub")
 
@@ -278,7 +278,7 @@ async def stop_deployment(
     mcp_http = get_mcp_http()
 
     # First, verify ownership by inspecting the container
-    user_roles = user.get("roles", [])
+    user_roles = get_user_roles(user)
     if "admin" not in user_roles:
         try:
             inspect_result = await mcp_http.call(
@@ -343,7 +343,7 @@ async def get_deployment_logs(
     mcp_http = get_mcp_http()
 
     # Verify ownership for non-admins
-    user_roles = user.get("roles", [])
+    user_roles = get_user_roles(user)
     if "admin" not in user_roles:
         try:
             inspect_result = await mcp_http.call(
@@ -418,7 +418,7 @@ async def inspect_deployment(
             raise NotFoundError("deployment", container_name)
 
         # Verify ownership for non-admins
-        user_roles = user.get("roles", [])
+        user_roles = get_user_roles(user)
         if "admin" not in user_roles:
             labels = result.get("labels", {})
             owner_id = labels.get("druppie.user_id")
@@ -513,29 +513,77 @@ async def list_volumes(
     in that project carrying their druppie.user_id).
     """
     mcp_http = get_mcp_http()
-    args: dict[str, Any] = {"druppie_only": True}
-    if project_id:
-        args["project_id"] = project_id
 
     try:
-        result = await mcp_http.call(
+        # Pull every volume + every druppie container so we can link by
+        # com.docker.compose.project even when the volume itself has no
+        # druppie.* label (older compose_up deploys didn't label volumes).
+        vols_task = mcp_http.call(
             server="docker",
             tool="list_volumes",
-            args=args,
+            args={"druppie_only": False},
             timeout_seconds=15.0,
         )
-        if not result.get("success"):
-            return VolumeListResponse(items=[], count=0)
+        containers_task = mcp_http.call(
+            server="docker",
+            tool="list_containers",
+            args={"all": True},
+            timeout_seconds=15.0,
+        )
+        vols_res = await vols_task
+        cont_res = await containers_task
 
-        raw = result.get("volumes", [])
-        # Non-admins: filter to volumes whose project_id is owned by the user.
-        # We piggyback on druppie.project_id label set by compose overrides.
-        user_roles = user.get("roles", [])
+        all_volumes = vols_res.get("volumes", []) if vols_res.get("success") else []
+        all_containers = cont_res.get("containers", []) if cont_res.get("success") else []
+
+        # compose_project -> (druppie project_id, user_id) from containers
+        compose_to_project: dict[str, dict[str, str]] = {}
+        for c in all_containers:
+            labels = c.get("labels", {})
+            cp = labels.get("druppie.compose_project") or labels.get("com.docker.compose.project")
+            pid = labels.get("druppie.project_id")
+            if cp and pid:
+                compose_to_project[cp] = {
+                    "project_id": pid,
+                    "user_id": labels.get("druppie.user_id", ""),
+                }
+
+        enriched: list[dict[str, Any]] = []
+        for v in all_volumes:
+            labels = v.get("labels", {})
+            vol_pid = v.get("project_id") or labels.get("druppie.project_id")
+            vol_cp = v.get("compose_project") or labels.get("com.docker.compose.project")
+            link = compose_to_project.get(vol_cp) if vol_cp else None
+
+            # Keep only volumes that resolve to a druppie project
+            if not vol_pid and not link:
+                continue
+
+            resolved_pid = vol_pid or (link["project_id"] if link else None)
+            resolved_uid = v.get("user_id") or labels.get("druppie.user_id") or (
+                link["user_id"] if link else None
+            )
+
+            if project_id and resolved_pid != project_id:
+                continue
+
+            enriched.append({
+                "name": v["name"],
+                "driver": v.get("driver", "local"),
+                "project_id": resolved_pid,
+                "session_id": v.get("session_id") or labels.get("druppie.session_id"),
+                "compose_project": vol_cp,
+                "labels": labels,
+                "_user_id": resolved_uid,
+            })
+
+        # Non-admins see only volumes tied to projects they own a container in
+        user_roles = get_user_roles(user)
         if "admin" not in user_roles:
-            owned = await _owned_project_ids(mcp_http, user.get("sub", ""))
-            raw = [v for v in raw if v.get("project_id") in owned]
+            user_id = user.get("sub", "")
+            enriched = [e for e in enriched if e.get("_user_id") == user_id]
 
-        items = [VolumeSummary(**v) for v in raw]
+        items = [VolumeSummary(**{k: v for k, v in e.items() if k != "_user_id"}) for e in enriched]
         return VolumeListResponse(items=items, count=len(items))
 
     except MCPHttpError as e:
@@ -597,7 +645,7 @@ async def wipe_project(
     containers = list_result.get("containers", []) if list_result.get("success") else []
 
     # Ownership check: non-admin must own every container
-    user_roles = user.get("roles", [])
+    user_roles = get_user_roles(user)
     if "admin" not in user_roles:
         user_id = user.get("sub")
         if not containers:
@@ -632,18 +680,32 @@ async def wipe_project(
         except MCPHttpError as e:
             errors.append(f"rm {name}: {e}")
 
-    # Remove volumes labeled with this project_id
+    # Collect compose project names that belong to this druppie project_id so we
+    # can also reap compose volumes that lack druppie.* labels.
+    compose_projects: set[str] = set()
+    for c in containers:
+        labels = c.get("labels", {})
+        cp = labels.get("druppie.compose_project") or labels.get("com.docker.compose.project")
+        if cp:
+            compose_projects.add(cp)
+
     try:
         vols = await mcp_http.call(
             server="docker",
             tool="list_volumes",
-            args={"project_id": project_id, "druppie_only": True},
+            args={"druppie_only": False},
             timeout_seconds=15.0,
         )
-        for v in vols.get("volumes", []) if vols.get("success") else []:
-            vname = v.get("name")
-            if not vname:
-                continue
+        all_volumes = vols.get("volumes", []) if vols.get("success") else []
+        target_vols = []
+        for v in all_volumes:
+            labels = v.get("labels", {})
+            if labels.get("druppie.project_id") == project_id:
+                target_vols.append(v["name"])
+            elif labels.get("com.docker.compose.project") in compose_projects:
+                target_vols.append(v["name"])
+
+        for vname in target_vols:
             try:
                 r = await mcp_http.call(
                     server="docker",

--- a/druppie/api/routes/deployments.py
+++ b/druppie/api/routes/deployments.py
@@ -65,10 +65,13 @@ class DeploymentSummary(BaseModel):
     container_name: str
     image: str
     status: str
+    state: str = "unknown"
+    health: str = "none"
     ports: str = ""
     project_id: str | None = None
     session_id: str | None = None
     user_id: str | None = None
+    compose_project: str | None = None
     app_url: str | None = None
 
 
@@ -84,6 +87,35 @@ class StopResponse(BaseModel):
     container_name: str
     stopped: bool = False
     removed: bool = False
+
+
+class ActionResponse(BaseModel):
+    """Generic response for start/restart actions."""
+    success: bool
+    container_name: str
+    error: str | None = None
+
+
+class VolumeSummary(BaseModel):
+    name: str
+    driver: str = "local"
+    project_id: str | None = None
+    session_id: str | None = None
+    compose_project: str | None = None
+    labels: dict[str, str] = {}
+
+
+class VolumeListResponse(BaseModel):
+    items: list[VolumeSummary]
+    count: int
+
+
+class WipeResponse(BaseModel):
+    success: bool
+    project_id: str
+    containers_removed: list[str] = []
+    volumes_removed: list[str] = []
+    errors: list[str] = []
 
 
 class LogsResponse(BaseModel):
@@ -126,12 +158,43 @@ def parse_container_to_deployment(container: dict) -> DeploymentSummary:
         container_name=container.get("name", ""),
         image=container.get("image", ""),
         status=container.get("status", "unknown"),
+        state=container.get("state", "unknown"),
+        health=container.get("health", "none"),
         ports=ports_str,
         project_id=labels.get("druppie.project_id"),
         session_id=labels.get("druppie.session_id"),
         user_id=labels.get("druppie.user_id"),
+        compose_project=labels.get("druppie.compose_project"),
         app_url=app_url,
     )
+
+
+async def _verify_owner_or_admin(
+    mcp_http: MCPHttp,
+    container_name: str,
+    user: dict,
+    action: str,
+) -> None:
+    """Raise 403/404 if user is not admin and doesn't own the container."""
+    if "admin" in user.get("roles", []):
+        return
+    try:
+        inspect_result = await mcp_http.call(
+            server="docker",
+            tool="inspect",
+            args={"container_name": container_name},
+            timeout_seconds=10.0,
+        )
+        if not inspect_result.get("success"):
+            raise NotFoundError("deployment", container_name)
+        owner_id = inspect_result.get("labels", {}).get("druppie.user_id")
+        if owner_id and owner_id != user.get("sub"):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Not authorized to {action} this deployment",
+            )
+    except MCPHttpError:
+        raise NotFoundError("deployment", container_name)
 
 
 # =============================================================================
@@ -375,3 +438,232 @@ async def inspect_deployment(
     except MCPHttpError as e:
         logger.error("deployment_inspect_error", container=container_name, error=str(e))
         raise NotFoundError("deployment", container_name)
+
+
+# =============================================================================
+# LIFECYCLE ACTIONS
+# =============================================================================
+
+
+@router.post("/deployments/{container_name}/start", response_model=ActionResponse)
+async def start_deployment(
+    container_name: str,
+    user: dict = Depends(get_current_user),
+) -> ActionResponse:
+    """Start a stopped deployment."""
+    mcp_http = get_mcp_http()
+    await _verify_owner_or_admin(mcp_http, container_name, user, "start")
+
+    try:
+        result = await mcp_http.call(
+            server="docker",
+            tool="start",
+            args={"container_name": container_name},
+            timeout_seconds=30.0,
+        )
+        return ActionResponse(
+            success=result.get("success", False),
+            container_name=container_name,
+            error=result.get("error"),
+        )
+    except MCPHttpError as e:
+        logger.error("deployment_start_error", container=container_name, error=str(e))
+        return ActionResponse(success=False, container_name=container_name, error=str(e))
+
+
+@router.post("/deployments/{container_name}/restart", response_model=ActionResponse)
+async def restart_deployment(
+    container_name: str,
+    user: dict = Depends(get_current_user),
+) -> ActionResponse:
+    """Restart a deployment."""
+    mcp_http = get_mcp_http()
+    await _verify_owner_or_admin(mcp_http, container_name, user, "restart")
+
+    try:
+        result = await mcp_http.call(
+            server="docker",
+            tool="restart",
+            args={"container_name": container_name},
+            timeout_seconds=60.0,
+        )
+        return ActionResponse(
+            success=result.get("success", False),
+            container_name=container_name,
+            error=result.get("error"),
+        )
+    except MCPHttpError as e:
+        logger.error("deployment_restart_error", container=container_name, error=str(e))
+        return ActionResponse(success=False, container_name=container_name, error=str(e))
+
+
+# =============================================================================
+# VOLUMES
+# =============================================================================
+
+
+@router.get("/deployments/volumes/list", response_model=VolumeListResponse)
+async def list_volumes(
+    project_id: str | None = Query(None, description="Filter by druppie.project_id"),
+    user: dict = Depends(get_current_user),
+) -> VolumeListResponse:
+    """List druppie-labeled Docker volumes.
+
+    Non-admins only see volumes for projects they own (checked via any container
+    in that project carrying their druppie.user_id).
+    """
+    mcp_http = get_mcp_http()
+    args: dict[str, Any] = {"druppie_only": True}
+    if project_id:
+        args["project_id"] = project_id
+
+    try:
+        result = await mcp_http.call(
+            server="docker",
+            tool="list_volumes",
+            args=args,
+            timeout_seconds=15.0,
+        )
+        if not result.get("success"):
+            return VolumeListResponse(items=[], count=0)
+
+        raw = result.get("volumes", [])
+        # Non-admins: filter to volumes whose project_id is owned by the user.
+        # We piggyback on druppie.project_id label set by compose overrides.
+        user_roles = user.get("roles", [])
+        if "admin" not in user_roles:
+            owned = await _owned_project_ids(mcp_http, user.get("sub", ""))
+            raw = [v for v in raw if v.get("project_id") in owned]
+
+        items = [VolumeSummary(**v) for v in raw]
+        return VolumeListResponse(items=items, count=len(items))
+
+    except MCPHttpError as e:
+        logger.error("volumes_list_error", error=str(e))
+        return VolumeListResponse(items=[], count=0)
+
+
+async def _owned_project_ids(mcp_http: MCPHttp, user_id: str) -> set[str]:
+    """Return set of druppie.project_id values the user owns any container in."""
+    try:
+        result = await mcp_http.call(
+            server="docker",
+            tool="list_containers",
+            args={"all": True, "user_id": user_id},
+            timeout_seconds=15.0,
+        )
+        if not result.get("success"):
+            return set()
+        return {
+            c["labels"].get("druppie.project_id")
+            for c in result.get("containers", [])
+            if c.get("labels", {}).get("druppie.project_id")
+        }
+    except MCPHttpError:
+        return set()
+
+
+# =============================================================================
+# PROJECT WIPE (containers + volumes)
+# =============================================================================
+
+
+@router.post("/deployments/project/{project_id}/wipe", response_model=WipeResponse)
+async def wipe_project(
+    project_id: str,
+    user: dict = Depends(get_current_user),
+) -> WipeResponse:
+    """Stop and remove every container + labeled volume for a project.
+
+    Destructive. Only admins or the owning user may call this. Containers are
+    force-removed (docker rm -f) then labeled volumes are removed.
+    """
+    mcp_http = get_mcp_http()
+    containers_removed: list[str] = []
+    volumes_removed: list[str] = []
+    errors: list[str] = []
+
+    # Enumerate containers for the project (all states)
+    try:
+        list_result = await mcp_http.call(
+            server="docker",
+            tool="list_containers",
+            args={"all": True, "project_id": project_id},
+            timeout_seconds=15.0,
+        )
+    except MCPHttpError as e:
+        raise HTTPException(status_code=502, detail=f"Docker MCP unreachable: {e}")
+
+    containers = list_result.get("containers", []) if list_result.get("success") else []
+
+    # Ownership check: non-admin must own every container
+    user_roles = user.get("roles", [])
+    if "admin" not in user_roles:
+        user_id = user.get("sub")
+        if not containers:
+            raise NotFoundError("project", project_id)
+        foreign = [
+            c for c in containers
+            if c.get("labels", {}).get("druppie.user_id")
+            and c["labels"]["druppie.user_id"] != user_id
+        ]
+        if foreign:
+            raise HTTPException(
+                status_code=403,
+                detail="Not authorized to wipe this project",
+            )
+
+    # Remove containers
+    for c in containers:
+        name = c.get("name")
+        if not name:
+            continue
+        try:
+            r = await mcp_http.call(
+                server="docker",
+                tool="remove",
+                args={"container_name": name, "force": True},
+                timeout_seconds=30.0,
+            )
+            if r.get("success"):
+                containers_removed.append(name)
+            else:
+                errors.append(f"rm {name}: {r.get('error', 'unknown')}")
+        except MCPHttpError as e:
+            errors.append(f"rm {name}: {e}")
+
+    # Remove volumes labeled with this project_id
+    try:
+        vols = await mcp_http.call(
+            server="docker",
+            tool="list_volumes",
+            args={"project_id": project_id, "druppie_only": True},
+            timeout_seconds=15.0,
+        )
+        for v in vols.get("volumes", []) if vols.get("success") else []:
+            vname = v.get("name")
+            if not vname:
+                continue
+            try:
+                r = await mcp_http.call(
+                    server="docker",
+                    tool="remove_volume",
+                    args={"volume_name": vname, "force": False},
+                    timeout_seconds=15.0,
+                )
+                if r.get("success"):
+                    volumes_removed.append(vname)
+                else:
+                    errors.append(f"rm volume {vname}: {r.get('error', 'unknown')}")
+            except MCPHttpError as e:
+                errors.append(f"rm volume {vname}: {e}")
+    except MCPHttpError as e:
+        errors.append(f"list_volumes: {e}")
+
+    return WipeResponse(
+        success=len(errors) == 0,
+        project_id=project_id,
+        containers_removed=containers_removed,
+        volumes_removed=volumes_removed,
+        errors=errors,
+    )

--- a/druppie/api/routes/deployments.py
+++ b/druppie/api/routes/deployments.py
@@ -188,7 +188,9 @@ async def _verify_owner_or_admin(
         if not inspect_result.get("success"):
             raise NotFoundError("deployment", container_name)
         owner_id = inspect_result.get("labels", {}).get("druppie.user_id")
-        if owner_id and owner_id != user.get("sub"):
+        # Fail closed: a container without a druppie.user_id label is treated
+        # as not-owned by any non-admin caller.
+        if not owner_id or owner_id != user.get("sub"):
             raise HTTPException(
                 status_code=403,
                 detail=f"Not authorized to {action} this deployment",
@@ -276,32 +278,7 @@ async def stop_deployment(
     Verifies ownership via container labels before stopping.
     """
     mcp_http = get_mcp_http()
-
-    # First, verify ownership by inspecting the container
-    user_roles = get_user_roles(user)
-    if "admin" not in user_roles:
-        try:
-            inspect_result = await mcp_http.call(
-                server="docker",
-                tool="inspect",
-                args={"container_name": container_name},
-                timeout_seconds=10.0,
-            )
-
-            if not inspect_result.get("success"):
-                raise NotFoundError("deployment", container_name)
-
-            labels = inspect_result.get("labels", {})
-            owner_id = labels.get("druppie.user_id")
-
-            if owner_id and owner_id != user.get("sub"):
-                raise HTTPException(
-                    status_code=403,
-                    detail="Not authorized to stop this deployment",
-                )
-
-        except MCPHttpError:
-            raise NotFoundError("deployment", container_name)
+    await _verify_owner_or_admin(mcp_http, container_name, user, "stop")
 
     # Stop the container
     try:
@@ -341,32 +318,7 @@ async def get_deployment_logs(
     Verifies ownership via container labels before fetching logs.
     """
     mcp_http = get_mcp_http()
-
-    # Verify ownership for non-admins
-    user_roles = get_user_roles(user)
-    if "admin" not in user_roles:
-        try:
-            inspect_result = await mcp_http.call(
-                server="docker",
-                tool="inspect",
-                args={"container_name": container_name},
-                timeout_seconds=10.0,
-            )
-
-            if not inspect_result.get("success"):
-                raise NotFoundError("deployment", container_name)
-
-            labels = inspect_result.get("labels", {})
-            owner_id = labels.get("druppie.user_id")
-
-            if owner_id and owner_id != user.get("sub"):
-                raise HTTPException(
-                    status_code=403,
-                    detail="Not authorized to view logs for this deployment",
-                )
-
-        except MCPHttpError:
-            raise NotFoundError("deployment", container_name)
+    await _verify_owner_or_admin(mcp_http, container_name, user, "view logs for")
 
     # Get logs
     try:
@@ -417,13 +369,10 @@ async def inspect_deployment(
         if not result.get("success"):
             raise NotFoundError("deployment", container_name)
 
-        # Verify ownership for non-admins
-        user_roles = get_user_roles(user)
-        if "admin" not in user_roles:
-            labels = result.get("labels", {})
-            owner_id = labels.get("druppie.user_id")
-
-            if owner_id and owner_id != user.get("sub"):
+        # Fail closed on missing owner label — same semantics as the helper.
+        if "admin" not in get_user_roles(user):
+            owner_id = result.get("labels", {}).get("druppie.user_id")
+            if not owner_id or owner_id != user.get("sub"):
                 raise HTTPException(
                     status_code=403,
                     detail="Not authorized to inspect this deployment",
@@ -591,26 +540,6 @@ async def list_volumes(
         return VolumeListResponse(items=[], count=0)
 
 
-async def _owned_project_ids(mcp_http: MCPHttp, user_id: str) -> set[str]:
-    """Return set of druppie.project_id values the user owns any container in."""
-    try:
-        result = await mcp_http.call(
-            server="docker",
-            tool="list_containers",
-            args={"all": True, "user_id": user_id},
-            timeout_seconds=15.0,
-        )
-        if not result.get("success"):
-            return set()
-        return {
-            c["labels"].get("druppie.project_id")
-            for c in result.get("containers", [])
-            if c.get("labels", {}).get("druppie.project_id")
-        }
-    except MCPHttpError:
-        return set()
-
-
 # =============================================================================
 # PROJECT WIPE (containers + volumes)
 # =============================================================================
@@ -640,11 +569,13 @@ async def wipe_project(
             timeout_seconds=15.0,
         )
     except MCPHttpError as e:
-        raise HTTPException(status_code=502, detail=f"Docker MCP unreachable: {e}")
+        logger.error("wipe_project_mcp_unreachable", project_id=project_id, error=str(e))
+        raise HTTPException(status_code=502, detail="Docker MCP unreachable")
 
     containers = list_result.get("containers", []) if list_result.get("success") else []
 
-    # Ownership check: non-admin must own every container
+    # Ownership check: fail closed — non-admin must own every container, and
+    # any container missing druppie.user_id counts as not-owned.
     user_roles = get_user_roles(user)
     if "admin" not in user_roles:
         user_id = user.get("sub")
@@ -652,8 +583,7 @@ async def wipe_project(
             raise NotFoundError("project", project_id)
         foreign = [
             c for c in containers
-            if c.get("labels", {}).get("druppie.user_id")
-            and c["labels"]["druppie.user_id"] != user_id
+            if c.get("labels", {}).get("druppie.user_id") != user_id
         ]
         if foreign:
             raise HTTPException(

--- a/druppie/mcp-servers/module-docker/v1/tools.py
+++ b/druppie/mcp-servers/module-docker/v1/tools.py
@@ -1039,11 +1039,34 @@ async def list_containers(
                                 if k.startswith("druppie."):
                                     labels[k] = v
 
+                    status_str = parts[3]
+                    # docker ps embeds healthcheck state in the status column,
+                    # e.g. "Up 3 minutes (healthy)" — extract it so callers don't reparse.
+                    health = "none"
+                    if "(healthy)" in status_str:
+                        health = "healthy"
+                    elif "(unhealthy)" in status_str:
+                        health = "unhealthy"
+                    elif "(health: starting)" in status_str:
+                        health = "starting"
+
+                    state = "exited"
+                    if status_str.startswith("Up"):
+                        state = "running"
+                    elif status_str.startswith("Restarting"):
+                        state = "restarting"
+                    elif status_str.startswith("Paused"):
+                        state = "paused"
+                    elif status_str.startswith("Created"):
+                        state = "created"
+
                     containers.append({
                         "id": parts[0],
                         "name": parts[1],
                         "image": parts[2],
-                        "status": parts[3],
+                        "status": status_str,
+                        "state": state,
+                        "health": health,
                         "ports": parts[4] if len(parts) > 4 else "",
                         "labels": labels,
                     })
@@ -1156,5 +1179,160 @@ async def exec_command(
 
     except subprocess.TimeoutExpired:
         return {"success": False, "error": "Command timed out"}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+@mcp.tool(
+    name="start",
+    description="Start a stopped Docker container.",
+    meta={"module_id": MODULE_ID, "version": MODULE_VERSION},
+)
+async def start(container_name: str) -> dict:
+    """Start a stopped container."""
+    try:
+        err = _validate_name(container_name, "container_name")
+        if err:
+            return {"success": False, "error": err}
+
+        result = subprocess.run(
+            ["docker", "start", container_name],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        if result.returncode != 0:
+            return {"success": False, "error": f"Failed to start: {result.stderr}"}
+
+        return {"success": True, "started": container_name}
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+@mcp.tool(
+    name="restart",
+    description="Restart a Docker container.",
+    meta={"module_id": MODULE_ID, "version": MODULE_VERSION},
+)
+async def restart(container_name: str, timeout: int = 10) -> dict:
+    """Restart a container."""
+    try:
+        err = _validate_name(container_name, "container_name")
+        if err:
+            return {"success": False, "error": err}
+
+        result = subprocess.run(
+            ["docker", "restart", "-t", str(timeout), container_name],
+            capture_output=True,
+            text=True,
+            timeout=timeout + 20,
+        )
+
+        if result.returncode != 0:
+            return {"success": False, "error": f"Failed to restart: {result.stderr}"}
+
+        return {"success": True, "restarted": container_name}
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+@mcp.tool(
+    name="list_volumes",
+    description="List Docker volumes, optionally filtered by druppie labels or compose project.",
+    meta={"module_id": MODULE_ID, "version": MODULE_VERSION},
+)
+async def list_volumes(
+    project_id: str | None = None,
+    compose_project: str | None = None,
+    druppie_only: bool = True,
+) -> dict:
+    """List Docker volumes with optional filtering.
+
+    Args:
+        project_id: Filter by druppie.project_id label
+        compose_project: Filter by compose project label (com.docker.compose.project)
+        druppie_only: If True, only return volumes tied to druppie.* labels or compose projects
+            that also carry a druppie label on any container
+
+    Returns:
+        Dict with volumes list (name, driver, labels, size if available)
+    """
+    try:
+        cmd = ["docker", "volume", "ls", "--format",
+               "{{.Name}}\t{{.Driver}}\t{{.Labels}}"]
+        if project_id:
+            cmd.extend(["--filter", f"label=druppie.project_id={project_id}"])
+        if compose_project:
+            cmd.extend(["--filter", f"label=com.docker.compose.project={compose_project}"])
+
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        if result.returncode != 0:
+            return {"success": False, "error": result.stderr}
+
+        volumes = []
+        for line in result.stdout.strip().split("\n"):
+            if not line:
+                continue
+            parts = line.split("\t")
+            if len(parts) < 2:
+                continue
+            name, driver = parts[0], parts[1]
+            labels_str = parts[2] if len(parts) > 2 else ""
+            labels: dict[str, str] = {}
+            if labels_str and labels_str != "<no value>":
+                for label in labels_str.split(","):
+                    if "=" in label:
+                        k, v = label.split("=", 1)
+                        labels[k] = v
+
+            # Keep only druppie-linked volumes when requested. A volume is
+            # druppie-linked if it carries a druppie.* label directly OR belongs
+            # to a compose project whose name starts with a druppie-managed prefix.
+            if druppie_only:
+                has_druppie_label = any(k.startswith("druppie.") for k in labels)
+                if not has_druppie_label:
+                    continue
+
+            volumes.append({
+                "name": name,
+                "driver": driver,
+                "labels": labels,
+                "project_id": labels.get("druppie.project_id"),
+                "session_id": labels.get("druppie.session_id"),
+                "compose_project": labels.get("com.docker.compose.project"),
+            })
+
+        return {"success": True, "volumes": volumes, "count": len(volumes)}
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+@mcp.tool(
+    name="remove_volume",
+    description="Remove a Docker volume.",
+    meta={"module_id": MODULE_ID, "version": MODULE_VERSION},
+)
+async def remove_volume(volume_name: str, force: bool = False) -> dict:
+    """Remove a volume. Fails if the volume is in use unless force=True."""
+    try:
+        err = _validate_name(volume_name, "volume_name")
+        if err:
+            return {"success": False, "error": err}
+
+        cmd = ["docker", "volume", "rm"]
+        if force:
+            cmd.append("-f")
+        cmd.append(volume_name)
+
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode != 0:
+            return {"success": False, "error": result.stderr.strip()}
+
+        return {"success": True, "removed": volume_name}
+
     except Exception as e:
         return {"success": False, "error": str(e)}

--- a/druppie/mcp-servers/module-docker/v1/tools.py
+++ b/druppie/mcp-servers/module-docker/v1/tools.py
@@ -280,6 +280,60 @@ def check_and_remove_existing_container(container_name: str) -> dict | None:
         return {"removed": False, "error": str(e)}
 
 
+def parse_container_line(line: str) -> dict | None:
+    """Parse a single `docker ps` tab-delimited line into a container dict.
+
+    Factored out for unit-testing without a live Docker daemon.
+    Returns None when the line is empty or malformed.
+    """
+    if not line:
+        return None
+    parts = line.split("\t")
+    if len(parts) < 4:
+        return None
+
+    labels_str = parts[5] if len(parts) > 5 else ""
+    labels: dict[str, str] = {}
+    if labels_str:
+        for label in labels_str.split(","):
+            if "=" in label:
+                k, v = label.split("=", 1)
+                if k.startswith("druppie."):
+                    labels[k] = v
+
+    status_str = parts[3]
+    if "(healthy)" in status_str:
+        health = "healthy"
+    elif "(unhealthy)" in status_str:
+        health = "unhealthy"
+    elif "(health: starting)" in status_str:
+        health = "starting"
+    else:
+        health = "none"
+
+    if status_str.startswith("Up"):
+        state = "running"
+    elif status_str.startswith("Restarting"):
+        state = "restarting"
+    elif status_str.startswith("Paused"):
+        state = "paused"
+    elif status_str.startswith("Created"):
+        state = "created"
+    else:
+        state = "exited"
+
+    return {
+        "id": parts[0],
+        "name": parts[1],
+        "image": parts[2],
+        "status": status_str,
+        "state": state,
+        "health": health,
+        "ports": parts[4] if len(parts) > 4 else "",
+        "labels": labels,
+    }
+
+
 def _discover_container_port(compose_file: Path) -> int:
     """Parse the app service's container port from docker-compose.yaml.
 
@@ -1027,49 +1081,9 @@ async def list_containers(
 
         containers = []
         for line in result.stdout.strip().split("\n"):
-            if line:
-                parts = line.split("\t")
-                if len(parts) >= 4:
-                    labels_str = parts[5] if len(parts) > 5 else ""
-                    labels = {}
-                    if labels_str:
-                        for label in labels_str.split(","):
-                            if "=" in label:
-                                k, v = label.split("=", 1)
-                                if k.startswith("druppie."):
-                                    labels[k] = v
-
-                    status_str = parts[3]
-                    # docker ps embeds healthcheck state in the status column,
-                    # e.g. "Up 3 minutes (healthy)" — extract it so callers don't reparse.
-                    health = "none"
-                    if "(healthy)" in status_str:
-                        health = "healthy"
-                    elif "(unhealthy)" in status_str:
-                        health = "unhealthy"
-                    elif "(health: starting)" in status_str:
-                        health = "starting"
-
-                    state = "exited"
-                    if status_str.startswith("Up"):
-                        state = "running"
-                    elif status_str.startswith("Restarting"):
-                        state = "restarting"
-                    elif status_str.startswith("Paused"):
-                        state = "paused"
-                    elif status_str.startswith("Created"):
-                        state = "created"
-
-                    containers.append({
-                        "id": parts[0],
-                        "name": parts[1],
-                        "image": parts[2],
-                        "status": status_str,
-                        "state": state,
-                        "health": health,
-                        "ports": parts[4] if len(parts) > 4 else "",
-                        "labels": labels,
-                    })
+            parsed = parse_container_line(line)
+            if parsed is not None:
+                containers.append(parsed)
 
         return {"success": True, "containers": containers, "count": len(containers)}
 
@@ -1222,6 +1236,9 @@ async def restart(container_name: str, timeout: int = 10) -> dict:
         err = _validate_name(container_name, "container_name")
         if err:
             return {"success": False, "error": err}
+
+        # Clamp so a caller can't pin the MCP worker on a runaway timeout.
+        timeout = max(1, min(timeout, 300))
 
         result = subprocess.run(
             ["docker", "restart", "-t", str(timeout), container_name],

--- a/druppie/tests/test_deployments_routes.py
+++ b/druppie/tests/test_deployments_routes.py
@@ -147,26 +147,25 @@ def test_wipe_admin_removes_all(client, mcp, as_admin):
                     "druppie.compose_project": "app"}},
     ]
     mcp.call.side_effect = [
-        _list_containers(containers),
-        {"success": True},
-        {"success": True, "volumes": []},
+        _list_containers(containers),          # list_containers
+        {"success": True},                     # compose_down
     ]
     r = client.post(f"/api/deployments/project/{PROJECT_ID}/wipe")
     assert r.status_code == 200
     body = r.json()
     assert body["success"] is True
-    assert body["containers_removed"] == ["app-1"]
+    assert body["containers_removed"] == ["compose:app"]
 
 
 def test_wipe_owner_allowed(client, mcp, as_owner):
+    # No compose_project label → standalone removal path
     containers = [
         {"name": "app-1",
          "labels": {"druppie.project_id": PROJECT_ID, "druppie.user_id": OWNER_SUB}},
     ]
     mcp.call.side_effect = [
-        _list_containers(containers),
-        {"success": True},
-        {"success": True, "volumes": []},
+        _list_containers(containers),          # list_containers
+        {"success": True},                     # remove (standalone)
     ]
     r = client.post(f"/api/deployments/project/{PROJECT_ID}/wipe")
     assert r.status_code == 200

--- a/druppie/tests/test_deployments_routes.py
+++ b/druppie/tests/test_deployments_routes.py
@@ -1,0 +1,254 @@
+"""Route-level tests for deployments.py.
+
+Focus: ownership enforcement on mutations and scoping on reads.
+MCP calls are mocked; no Docker daemon is required.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+
+from druppie.api.deps import get_current_user
+from druppie.api.main import create_app
+from druppie.api.routes import deployments as dep_mod
+
+
+ADMIN_SUB = "11111111-1111-1111-1111-111111111111"
+OWNER_SUB = "22222222-2222-2222-2222-222222222222"
+OTHER_SUB = "33333333-3333-3333-3333-333333333333"
+PROJECT_ID = "proj-abc"
+
+
+def _user(sub: str, admin: bool = False) -> dict:
+    roles = ["admin"] if admin else ["user"]
+    return {"sub": sub, "realm_access": {"roles": roles}}
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def as_admin(app):
+    app.dependency_overrides[get_current_user] = lambda: _user(ADMIN_SUB, admin=True)
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def as_owner(app):
+    app.dependency_overrides[get_current_user] = lambda: _user(OWNER_SUB, admin=False)
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def as_other(app):
+    app.dependency_overrides[get_current_user] = lambda: _user(OTHER_SUB, admin=False)
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def mcp():
+    fake = AsyncMock()
+    with patch.object(dep_mod, "get_mcp_http", return_value=fake):
+        yield fake
+
+
+def _inspect_ok(user_id: str | None, project_id: str = PROJECT_ID):
+    labels = {"druppie.project_id": project_id}
+    if user_id:
+        labels["druppie.user_id"] = user_id
+    return {"success": True, "labels": labels}
+
+
+# =============================================================================
+# _verify_owner_or_admin via start endpoint
+# =============================================================================
+
+
+def test_start_admin_bypasses_ownership(client, mcp, as_admin):
+    mcp.call.side_effect = [{"success": True}]
+    r = client.post("/api/deployments/some-container/start")
+    assert r.status_code == 200
+    assert mcp.call.await_count == 1
+    assert mcp.call.call_args.kwargs["tool"] == "start"
+
+
+def test_start_owner_allowed(client, mcp, as_owner):
+    mcp.call.side_effect = [_inspect_ok(OWNER_SUB), {"success": True}]
+    r = client.post("/api/deployments/some-container/start")
+    assert r.status_code == 200
+    assert mcp.call.await_count == 2
+
+
+def test_start_non_owner_403(client, mcp, as_other):
+    mcp.call.side_effect = [_inspect_ok(OWNER_SUB)]
+    r = client.post("/api/deployments/some-container/start")
+    assert r.status_code == 403
+
+
+def test_start_missing_owner_label_denied(client, mcp, as_other):
+    # Fail closed: no druppie.user_id on a container means no non-admin may act on it.
+    mcp.call.side_effect = [_inspect_ok(user_id=None)]
+    r = client.post("/api/deployments/some-container/start")
+    assert r.status_code == 403
+
+
+def test_start_inspect_failure_404(client, mcp, as_other):
+    mcp.call.side_effect = [{"success": False}]
+    r = client.post("/api/deployments/ghost/start")
+    assert r.status_code == 404
+
+
+# =============================================================================
+# stop/restart/logs use the same helper — spot-check one each
+# =============================================================================
+
+
+def test_stop_missing_owner_label_denied(client, mcp, as_other):
+    mcp.call.side_effect = [_inspect_ok(user_id=None)]
+    r = client.post("/api/deployments/some-container/stop")
+    assert r.status_code == 403
+
+
+def test_restart_non_owner_403(client, mcp, as_other):
+    mcp.call.side_effect = [_inspect_ok(OWNER_SUB)]
+    r = client.post("/api/deployments/some-container/restart")
+    assert r.status_code == 403
+
+
+def test_logs_missing_owner_label_denied(client, mcp, as_other):
+    mcp.call.side_effect = [_inspect_ok(user_id=None)]
+    r = client.get("/api/deployments/some-container/logs")
+    assert r.status_code == 403
+
+
+# =============================================================================
+# wipe_project
+# =============================================================================
+
+
+def _list_containers(containers: list[dict]):
+    return {"success": True, "containers": containers}
+
+
+def test_wipe_admin_removes_all(client, mcp, as_admin):
+    containers = [
+        {"name": "app-1",
+         "labels": {"druppie.project_id": PROJECT_ID, "druppie.user_id": OWNER_SUB,
+                    "druppie.compose_project": "app"}},
+    ]
+    mcp.call.side_effect = [
+        _list_containers(containers),
+        {"success": True},
+        {"success": True, "volumes": []},
+    ]
+    r = client.post(f"/api/deployments/project/{PROJECT_ID}/wipe")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is True
+    assert body["containers_removed"] == ["app-1"]
+
+
+def test_wipe_owner_allowed(client, mcp, as_owner):
+    containers = [
+        {"name": "app-1",
+         "labels": {"druppie.project_id": PROJECT_ID, "druppie.user_id": OWNER_SUB}},
+    ]
+    mcp.call.side_effect = [
+        _list_containers(containers),
+        {"success": True},
+        {"success": True, "volumes": []},
+    ]
+    r = client.post(f"/api/deployments/project/{PROJECT_ID}/wipe")
+    assert r.status_code == 200
+
+
+def test_wipe_non_owner_403(client, mcp, as_other):
+    containers = [
+        {"name": "app-1",
+         "labels": {"druppie.project_id": PROJECT_ID, "druppie.user_id": OWNER_SUB}},
+    ]
+    mcp.call.side_effect = [_list_containers(containers)]
+    r = client.post(f"/api/deployments/project/{PROJECT_ID}/wipe")
+    assert r.status_code == 403
+
+
+def test_wipe_missing_label_is_foreign(client, mcp, as_other):
+    # A container without druppie.user_id must NOT be wipeable by a non-admin.
+    containers = [{"name": "x", "labels": {"druppie.project_id": PROJECT_ID}}]
+    mcp.call.side_effect = [_list_containers(containers)]
+    r = client.post(f"/api/deployments/project/{PROJECT_ID}/wipe")
+    assert r.status_code == 403
+
+
+def test_wipe_empty_project_404_for_non_admin(client, mcp, as_other):
+    mcp.call.side_effect = [_list_containers([])]
+    r = client.post(f"/api/deployments/project/{PROJECT_ID}/wipe")
+    assert r.status_code == 404
+
+
+# =============================================================================
+# list_volumes scoping
+# =============================================================================
+
+
+def test_list_volumes_admin_sees_linked(client, mcp, as_admin):
+    mcp.call.side_effect = [
+        {"success": True, "volumes": [
+            {"name": "foo_pgdata", "driver": "local",
+             "labels": {"com.docker.compose.project": "foo"},
+             "compose_project": "foo"},
+        ]},
+        {"success": True, "containers": [
+            {"labels": {"druppie.compose_project": "foo",
+                        "druppie.project_id": PROJECT_ID,
+                        "druppie.user_id": OWNER_SUB}},
+        ]},
+    ]
+    r = client.get("/api/deployments/volumes/list")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["count"] == 1
+    assert body["items"][0]["project_id"] == PROJECT_ID
+
+
+def test_list_volumes_non_admin_scoped(client, mcp, as_other):
+    # Volume's linked project is owned by someone else → non-admin sees none.
+    mcp.call.side_effect = [
+        {"success": True, "volumes": [
+            {"name": "foo_pgdata", "driver": "local",
+             "labels": {"com.docker.compose.project": "foo"},
+             "compose_project": "foo"},
+        ]},
+        {"success": True, "containers": [
+            {"labels": {"druppie.compose_project": "foo",
+                        "druppie.project_id": PROJECT_ID,
+                        "druppie.user_id": OWNER_SUB}},
+        ]},
+    ]
+    r = client.get("/api/deployments/volumes/list")
+    assert r.status_code == 200
+    assert r.json()["count"] == 0
+
+
+def test_list_volumes_drops_unlinked(client, mcp, as_admin):
+    # Volume with no matching druppie container must not appear even for admins.
+    mcp.call.side_effect = [
+        {"success": True, "volumes": [
+            {"name": "random_vol", "driver": "local",
+             "labels": {}, "compose_project": None},
+        ]},
+        {"success": True, "containers": []},
+    ]
+    r = client.get("/api/deployments/volumes/list")
+    assert r.status_code == 200
+    assert r.json()["count"] == 0

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import Projects from './pages/Projects'
 import ProjectDetail from './pages/ProjectDetail'
 import Settings from './pages/Settings'
 import AdminDatabase from './pages/AdminDatabase'
+import Platform from './pages/Platform'
 import Evaluations from './pages/Evaluations'
 import Analytics from './pages/Analytics'
 import BatchDetail from './pages/BatchDetail'
@@ -247,6 +248,14 @@ function App() {
                             element={
                               <ProtectedRoute requiredRole="admin">
                                 <AdminDatabase />
+                              </ProtectedRoute>
+                            }
+                          />
+                          <Route
+                            path="/admin/platform"
+                            element={
+                              <ProtectedRoute requiredRole="admin">
+                                <Platform />
                               </ProtectedRoute>
                             }
                           />

--- a/frontend/src/components/NavRail.jsx
+++ b/frontend/src/components/NavRail.jsx
@@ -22,6 +22,7 @@ import {
   Server,
   FlaskConical,
   Package,
+  Boxes,
 } from 'lucide-react'
 
 import { useAuth } from '../App'
@@ -210,6 +211,13 @@ const NavRail = () => {
       {user?.roles?.includes('admin') && (
         <>
           <div className="mt-1 pt-1 border-t border-gray-800 w-8" />
+          <NavRailItem
+            to="/admin/platform"
+            icon={Boxes}
+            label="Platform"
+            active={isActive('/admin/platform')}
+            accent="purple"
+          />
           <NavRailItem
             to="/admin/database"
             icon={Database}

--- a/frontend/src/pages/Platform.jsx
+++ b/frontend/src/pages/Platform.jsx
@@ -1,0 +1,493 @@
+/**
+ * Platform dashboard — admin view over druppie-managed Docker containers and volumes.
+ *
+ * Polls /api/deployments and /api/deployments/volumes/list every 5s.
+ * Lets admins restart, stop, start, view logs, and wipe whole projects.
+ */
+
+import React, { useState, useMemo } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Boxes,
+  RefreshCw,
+  Play,
+  Square,
+  RotateCw,
+  FileText,
+  Trash2,
+  Search,
+  AlertCircle,
+  CheckCircle2,
+  Circle,
+  HardDrive,
+  X,
+  ExternalLink,
+} from 'lucide-react'
+
+import {
+  getDeployments,
+  startDeployment,
+  stopDeployment,
+  restartDeployment,
+  getDeploymentLogs,
+  getDeploymentVolumes,
+  wipeProject,
+} from '../services/api'
+import { useToast } from '../components/Toast'
+
+const POLL_MS = 5000
+
+const HEALTH_STYLES = {
+  healthy: 'bg-green-100 text-green-700',
+  unhealthy: 'bg-red-100 text-red-700',
+  starting: 'bg-amber-100 text-amber-700',
+  none: 'bg-gray-100 text-gray-600',
+}
+
+const STATE_STYLES = {
+  running: 'bg-green-100 text-green-700',
+  restarting: 'bg-amber-100 text-amber-700',
+  paused: 'bg-blue-100 text-blue-700',
+  created: 'bg-gray-100 text-gray-700',
+  exited: 'bg-gray-200 text-gray-700',
+  unknown: 'bg-gray-100 text-gray-500',
+}
+
+const Chip = ({ tone = 'gray', children, icon: Icon }) => {
+  const map = {
+    ...HEALTH_STYLES,
+    ...STATE_STYLES,
+    gray: 'bg-gray-100 text-gray-700',
+  }
+  const cls = map[tone] || map.gray
+  return (
+    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${cls}`}>
+      {Icon && <Icon className="w-3 h-3" />}
+      {children}
+    </span>
+  )
+}
+
+// Group containers by project_id (null project = "Unassigned")
+const groupByProject = (items) => {
+  const groups = new Map()
+  for (const c of items) {
+    const key = c.project_id || '__unassigned__'
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key).push(c)
+  }
+  return groups
+}
+
+const LogsDrawer = ({ containerName, onClose }) => {
+  const { data, isLoading, refetch, isFetching } = useQuery({
+    queryKey: ['deployment-logs', containerName],
+    queryFn: () => getDeploymentLogs(containerName, 300),
+    enabled: !!containerName,
+  })
+
+  if (!containerName) return null
+
+  return (
+    <div className="fixed inset-0 z-40 flex">
+      <div className="flex-1 bg-black/30" onClick={onClose} />
+      <div className="w-[720px] max-w-[90vw] bg-white h-full flex flex-col border-l border-gray-200 shadow-xl">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+          <div className="flex items-center gap-2">
+            <FileText className="w-4 h-4 text-gray-600" />
+            <span className="font-medium text-sm">{containerName}</span>
+            <span className="text-xs text-gray-500">last 300 lines</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => refetch()}
+              className="p-1.5 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded"
+              title="Refresh"
+            >
+              <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} />
+            </button>
+            <button
+              onClick={onClose}
+              className="p-1.5 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+        <pre className="flex-1 overflow-auto p-4 text-xs font-mono bg-gray-900 text-gray-100 whitespace-pre-wrap">
+{isLoading ? 'Loading…' : (data?.logs || '(no logs)')}
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+const Platform = () => {
+  const [search, setSearch] = useState('')
+  const [logsFor, setLogsFor] = useState(null)
+  const [confirmWipe, setConfirmWipe] = useState(null)
+  const toast = useToast()
+  const qc = useQueryClient()
+
+  const { data: deployData, isLoading: loadingDeploy, refetch: refetchDeploy } = useQuery({
+    queryKey: ['platform-deployments'],
+    queryFn: () => getDeployments(null, true),
+    refetchInterval: POLL_MS,
+  })
+
+  const { data: volData, isLoading: loadingVol } = useQuery({
+    queryKey: ['platform-volumes'],
+    queryFn: () => getDeploymentVolumes(),
+    refetchInterval: POLL_MS,
+  })
+
+  const items = deployData?.items || []
+  const volumes = volData?.items || []
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return items
+    const q = search.toLowerCase()
+    return items.filter((c) =>
+      [c.container_name, c.image, c.project_id, c.user_id, c.session_id]
+        .filter(Boolean)
+        .some((v) => String(v).toLowerCase().includes(q))
+    )
+  }, [items, search])
+
+  const groups = useMemo(() => groupByProject(filtered), [filtered])
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ['platform-deployments'] })
+    qc.invalidateQueries({ queryKey: ['platform-volumes'] })
+  }
+
+  const startMut = useMutation({
+    mutationFn: (name) => startDeployment(name),
+    onSuccess: (r, name) => {
+      r?.success ? toast.success(`Started ${name}`) : toast.error(r?.error || `Failed to start ${name}`)
+      invalidate()
+    },
+    onError: (e) => toast.error(e.message),
+  })
+  const stopMut = useMutation({
+    mutationFn: (name) => stopDeployment(name, false),
+    onSuccess: (r, name) => {
+      r?.success ? toast.success(`Stopped ${name}`) : toast.error(`Failed to stop ${name}`)
+      invalidate()
+    },
+    onError: (e) => toast.error(e.message),
+  })
+  const restartMut = useMutation({
+    mutationFn: (name) => restartDeployment(name),
+    onSuccess: (r, name) => {
+      r?.success ? toast.success(`Restarted ${name}`) : toast.error(r?.error || `Failed to restart ${name}`)
+      invalidate()
+    },
+    onError: (e) => toast.error(e.message),
+  })
+  const wipeMut = useMutation({
+    mutationFn: (projectId) => wipeProject(projectId),
+    onSuccess: (r, pid) => {
+      if (r?.success) {
+        toast.success(
+          `Wiped ${pid}: ${r.containers_removed.length} containers, ${r.volumes_removed.length} volumes`
+        )
+      } else {
+        toast.error(`Wipe had errors: ${(r?.errors || []).join('; ')}`)
+      }
+      invalidate()
+    },
+    onError: (e) => toast.error(e.message),
+  })
+
+  const stats = useMemo(() => {
+    const running = items.filter((c) => c.state === 'running').length
+    const unhealthy = items.filter((c) => c.health === 'unhealthy').length
+    const stopped = items.filter((c) => c.state !== 'running').length
+    return { total: items.length, running, unhealthy, stopped }
+  }, [items])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Boxes className="w-6 h-6 text-purple-600" />
+          <h1 className="text-2xl font-semibold">Platform</h1>
+        </div>
+        <button
+          onClick={() => refetchDeploy()}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-white border border-gray-200 rounded hover:bg-gray-50"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Refresh
+        </button>
+      </div>
+
+      {/* Stats row */}
+      <div className="grid grid-cols-4 gap-3">
+        <StatCard label="Containers" value={stats.total} />
+        <StatCard label="Running" value={stats.running} tone="green" />
+        <StatCard label="Stopped" value={stats.stopped} tone="gray" />
+        <StatCard label="Unhealthy" value={stats.unhealthy} tone={stats.unhealthy ? 'red' : 'gray'} />
+      </div>
+
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by container, image, project, user…"
+          className="w-full pl-9 pr-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500/30"
+        />
+      </div>
+
+      {/* Grouped containers */}
+      <div className="space-y-4">
+        {loadingDeploy && <div className="text-sm text-gray-500">Loading deployments…</div>}
+        {!loadingDeploy && groups.size === 0 && (
+          <div className="text-sm text-gray-500 border border-dashed border-gray-200 rounded-lg p-6 text-center">
+            No deployments match.
+          </div>
+        )}
+        {[...groups.entries()].map(([projectId, cs]) => (
+          <ProjectGroup
+            key={projectId}
+            projectId={projectId}
+            containers={cs}
+            onStart={(n) => startMut.mutate(n)}
+            onStop={(n) => stopMut.mutate(n)}
+            onRestart={(n) => restartMut.mutate(n)}
+            onLogs={(n) => setLogsFor(n)}
+            onWipe={(pid) => setConfirmWipe(pid)}
+          />
+        ))}
+      </div>
+
+      {/* Volumes */}
+      <div className="mt-6">
+        <div className="flex items-center gap-2 mb-2">
+          <HardDrive className="w-5 h-5 text-gray-600" />
+          <h2 className="text-lg font-semibold">Volumes</h2>
+          <span className="text-xs text-gray-500">({volumes.length})</span>
+        </div>
+        {loadingVol && <div className="text-sm text-gray-500">Loading volumes…</div>}
+        {!loadingVol && volumes.length === 0 && (
+          <div className="text-sm text-gray-500 border border-dashed border-gray-200 rounded-lg p-4 text-center">
+            No druppie-labeled volumes.
+          </div>
+        )}
+        {volumes.length > 0 && (
+          <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-gray-600 text-xs uppercase">
+                <tr>
+                  <th className="text-left px-3 py-2">Name</th>
+                  <th className="text-left px-3 py-2">Driver</th>
+                  <th className="text-left px-3 py-2">Project</th>
+                  <th className="text-left px-3 py-2">Compose</th>
+                </tr>
+              </thead>
+              <tbody>
+                {volumes.map((v) => (
+                  <tr key={v.name} className="border-t border-gray-100">
+                    <td className="px-3 py-2 font-mono text-xs">{v.name}</td>
+                    <td className="px-3 py-2">{v.driver}</td>
+                    <td className="px-3 py-2 font-mono text-xs">{v.project_id || '-'}</td>
+                    <td className="px-3 py-2 font-mono text-xs">{v.compose_project || '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <LogsDrawer containerName={logsFor} onClose={() => setLogsFor(null)} />
+
+      {confirmWipe && (
+        <ConfirmWipe
+          projectId={confirmWipe}
+          pending={wipeMut.isPending}
+          onConfirm={() => {
+            wipeMut.mutate(confirmWipe)
+            setConfirmWipe(null)
+          }}
+          onCancel={() => setConfirmWipe(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+const StatCard = ({ label, value, tone = 'blue' }) => {
+  const tones = {
+    blue: 'text-blue-700',
+    green: 'text-green-700',
+    red: 'text-red-700',
+    gray: 'text-gray-700',
+  }
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg px-4 py-3">
+      <div className="text-xs uppercase text-gray-500">{label}</div>
+      <div className={`text-2xl font-semibold ${tones[tone]}`}>{value}</div>
+    </div>
+  )
+}
+
+const ProjectGroup = ({ projectId, containers, onStart, onStop, onRestart, onLogs, onWipe }) => {
+  const isUnassigned = projectId === '__unassigned__'
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+      <div className="px-3 py-2 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-xs uppercase text-gray-500">Project</span>
+          <span className="font-mono text-sm">
+            {isUnassigned ? '(unassigned)' : projectId}
+          </span>
+          <span className="text-xs text-gray-500">{containers.length} containers</span>
+        </div>
+        {!isUnassigned && (
+          <button
+            onClick={() => onWipe(projectId)}
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-red-600 hover:bg-red-50 rounded"
+            title="Stop + remove all containers and labeled volumes"
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+            Wipe
+          </button>
+        )}
+      </div>
+      <table className="w-full text-sm">
+        <thead className="text-xs uppercase text-gray-500">
+          <tr>
+            <th className="text-left px-3 py-2">Container</th>
+            <th className="text-left px-3 py-2">Image</th>
+            <th className="text-left px-3 py-2">State</th>
+            <th className="text-left px-3 py-2">Health</th>
+            <th className="text-left px-3 py-2">Ports</th>
+            <th className="text-right px-3 py-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {containers.map((c) => (
+            <ContainerRow
+              key={c.container_id || c.container_name}
+              c={c}
+              onStart={onStart}
+              onStop={onStop}
+              onRestart={onRestart}
+              onLogs={onLogs}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+const ContainerRow = ({ c, onStart, onStop, onRestart, onLogs }) => {
+  const running = c.state === 'running'
+  return (
+    <tr className="border-t border-gray-100 hover:bg-gray-50">
+      <td className="px-3 py-2">
+        <div className="font-mono text-xs">{c.container_name}</div>
+        {c.app_url && running && (
+          <a
+            href={c.app_url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-xs text-blue-600 hover:underline"
+          >
+            {c.app_url}
+            <ExternalLink className="w-3 h-3" />
+          </a>
+        )}
+      </td>
+      <td className="px-3 py-2 font-mono text-xs truncate max-w-[220px]">{c.image}</td>
+      <td className="px-3 py-2">
+        <Chip tone={c.state}>{c.state}</Chip>
+      </td>
+      <td className="px-3 py-2">
+        <Chip
+          tone={c.health}
+          icon={
+            c.health === 'healthy'
+              ? CheckCircle2
+              : c.health === 'unhealthy'
+                ? AlertCircle
+                : Circle
+          }
+        >
+          {c.health}
+        </Chip>
+      </td>
+      <td className="px-3 py-2 font-mono text-xs">{c.ports || '-'}</td>
+      <td className="px-3 py-2">
+        <div className="flex justify-end gap-1">
+          {running ? (
+            <>
+              <IconBtn title="Restart" onClick={() => onRestart(c.container_name)} icon={RotateCw} />
+              <IconBtn title="Stop" onClick={() => onStop(c.container_name)} icon={Square} tone="red" />
+            </>
+          ) : (
+            <IconBtn title="Start" onClick={() => onStart(c.container_name)} icon={Play} tone="green" />
+          )}
+          <IconBtn title="Logs" onClick={() => onLogs(c.container_name)} icon={FileText} />
+        </div>
+      </td>
+    </tr>
+  )
+}
+
+const IconBtn = ({ icon: Icon, onClick, title, tone = 'gray' }) => {
+  const tones = {
+    gray: 'text-gray-600 hover:bg-gray-100',
+    red: 'text-red-600 hover:bg-red-50',
+    green: 'text-green-600 hover:bg-green-50',
+  }
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      className={`p-1.5 rounded ${tones[tone]}`}
+    >
+      <Icon className="w-4 h-4" />
+    </button>
+  )
+}
+
+const ConfirmWipe = ({ projectId, onConfirm, onCancel, pending }) => (
+  <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/40">
+    <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-5">
+      <div className="flex items-center gap-2 mb-2">
+        <Trash2 className="w-5 h-5 text-red-600" />
+        <h3 className="text-lg font-semibold">Wipe project {projectId}?</h3>
+      </div>
+      <p className="text-sm text-gray-600 mb-4">
+        Stops and removes <b>all containers</b> for this project, plus any Docker volumes
+        labeled <code className="font-mono">druppie.project_id={projectId}</code>. This
+        cannot be undone.
+      </p>
+      <div className="flex justify-end gap-2">
+        <button
+          onClick={onCancel}
+          className="px-3 py-1.5 text-sm rounded border border-gray-200 hover:bg-gray-50"
+          disabled={pending}
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onConfirm}
+          className="px-3 py-1.5 text-sm rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+          disabled={pending}
+        >
+          {pending ? 'Wiping…' : 'Wipe'}
+        </button>
+      </div>
+    </div>
+  </div>
+)
+
+export default Platform

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -229,16 +229,27 @@ export const getProjectFile = (projectId, path, branch = 'main') =>
   request(`/api/projects/${projectId}/file?path=${encodeURIComponent(path)}&branch=${branch}`)
 
 // ============ Deployments ============
-export const getDeployments = (projectId = null) => {
+export const getDeployments = (projectId = null, allContainers = false) => {
   const params = new URLSearchParams()
   if (projectId) params.append('project_id', projectId)
+  if (allContainers) params.append('all_containers', 'true')
   const qs = params.toString()
   return request(`/api/deployments${qs ? `?${qs}` : ''}`)
 }
-export const stopDeployment = (containerName) =>
-  request(`/api/deployments/${containerName}/stop?remove=true`, { method: 'POST' })
-export const getDeploymentLogs = (containerName, tail = 100) =>
+export const stopDeployment = (containerName, remove = true) =>
+  request(`/api/deployments/${containerName}/stop?remove=${remove}`, { method: 'POST' })
+export const startDeployment = (containerName) =>
+  request(`/api/deployments/${containerName}/start`, { method: 'POST' })
+export const restartDeployment = (containerName) =>
+  request(`/api/deployments/${containerName}/restart`, { method: 'POST' })
+export const getDeploymentLogs = (containerName, tail = 200) =>
   request(`/api/deployments/${containerName}/logs?tail=${tail}`)
+export const getDeploymentVolumes = (projectId = null) => {
+  const qs = projectId ? `?project_id=${encodeURIComponent(projectId)}` : ''
+  return request(`/api/deployments/volumes/list${qs}`)
+}
+export const wipeProject = (projectId) =>
+  request(`/api/deployments/project/${encodeURIComponent(projectId)}/wipe`, { method: 'POST' })
 
 // ============ Agents (Transparency) ============
 export const getAgents = async () => {

--- a/frontend/tests/e2e/platform.spec.js
+++ b/frontend/tests/e2e/platform.spec.js
@@ -1,0 +1,98 @@
+// @ts-check
+import { test, expect } from '@playwright/test'
+
+const KEYCLOAK_URL = process.env.KEYCLOAK_URL || 'http://localhost:8380'
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5473'
+
+async function loginAsAdmin(page) {
+  await page.goto('/')
+  // Click login button
+  const loginBtn = page.locator('button').filter({ hasText: /login|log in/i }).first()
+  await loginBtn.waitFor({ timeout: 15000 })
+  await loginBtn.click()
+  // Keycloak login
+  await page.waitForURL(new RegExp(KEYCLOAK_URL), { timeout: 15000 })
+  await page.fill('#username', 'admin')
+  await page.fill('#password', 'Admin123!')
+  await page.click('#kc-login')
+  await page.waitForURL(new RegExp(BASE_URL), { timeout: 15000 })
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.context().clearCookies()
+})
+
+test.describe('Platform Dashboard', () => {
+  test('page loads and shows containers', async ({ page }) => {
+    await loginAsAdmin(page)
+    await page.goto('/admin/platform')
+
+    // Page title
+    await expect(page.getByRole('heading', { name: 'Platform' })).toBeVisible({ timeout: 10000 })
+
+    // Stats row should show container counts
+    await expect(page.getByText('Containers')).toBeVisible()
+    await expect(page.getByText('Running')).toBeVisible()
+
+    // Should show at least one container row with state/health chips
+    await expect(page.getByText(/running|exited|created/i).first()).toBeVisible({ timeout: 10000 })
+  })
+
+  test('search filters containers', async ({ page }) => {
+    await loginAsAdmin(page)
+    await page.goto('/admin/platform')
+    await expect(page.getByRole('heading', { name: 'Platform' })).toBeVisible({ timeout: 10000 })
+
+    // Wait for data to load
+    await expect(page.getByText('e2e-platform-app-1')).toBeVisible({ timeout: 10000 })
+
+    // Type a search term that won't match
+    const searchInput = page.getByPlaceholder(/search/i)
+    await searchInput.fill('nonexistent-container-xyz')
+    // Should show no results
+    await expect(page.getByText('No deployments match')).toBeVisible({ timeout: 5000 })
+
+    // Clear and search for our test container
+    await searchInput.clear()
+    await searchInput.fill('e2e-platform')
+    // Should show the test container
+    await expect(page.getByText('e2e-platform-app-1')).toBeVisible({ timeout: 5000 })
+  })
+
+  test('restart triggers a toast', async ({ page }) => {
+    await loginAsAdmin(page)
+    await page.goto('/admin/platform')
+    await expect(page.getByRole('heading', { name: 'Platform' })).toBeVisible({ timeout: 10000 })
+
+    // Wait for the test container to appear
+    await expect(page.getByText('e2e-platform-app-1')).toBeVisible({ timeout: 10000 })
+
+    // Click the restart button (RotateCw icon) for the container row
+    const row = page.locator('tr', { hasText: 'e2e-platform-app-1' })
+    await row.getByTitle('Restart').click()
+
+    // Should show a success toast
+    await expect(page.getByText(/restarted.*e2e-platform-app-1/i)).toBeVisible({ timeout: 10000 })
+  })
+
+  test('wipe dialog confirms and updates table', async ({ page }) => {
+    await loginAsAdmin(page)
+    await page.goto('/admin/platform')
+    await expect(page.getByRole('heading', { name: 'Platform' })).toBeVisible({ timeout: 10000 })
+
+    // Wait for data
+    await expect(page.getByText('e2e-platform-app-1')).toBeVisible({ timeout: 10000 })
+
+    // Click the Wipe button on the project group
+    await page.getByRole('button', { name: 'Wipe' }).first().click()
+
+    // Confirmation dialog should appear
+    await expect(page.getByText(/cannot be undone/i)).toBeVisible({ timeout: 5000 })
+
+    // Click confirm
+    await page.getByRole('button', { name: 'Wipe' }).last().click()
+
+    // Container should disappear from the table within 5s polling cycle
+    await expect(page.getByText('e2e-platform-app-1')).not.toBeVisible({ timeout: 10000 })
+  })
+})


### PR DESCRIPTION
## Summary
- New admin-only **Platform** page at `/admin/platform` to oversee druppie-labeled Docker containers: groups by project, chips for state + healthcheck, 5s polling, search, logs drawer, restart/stop/start, and a confirm-gated project wipe (containers + labeled volumes).
- Docker MCP (`module-docker`) learns `start`, `restart`, `list_volumes`, `remove_volume`, and now reports `state`/`health` fields from `docker ps` status parsing.
- Backend `/api/deployments` adds `{name}/start`, `{name}/restart`, `volumes/list`, and `project/{id}/wipe`. Non-admins are scoped to containers whose `druppie.user_id` label matches their `sub`.

## Scope / choices
Answers to clarifying questions captured before implementation:
- **Scope**: druppie-labeled containers only (safer; can't stop infra).
- **Location**: new `/admin/platform` route, admin role required.
- **Actions**: restart, stop, start, view logs (300-line tail), wipe project (containers + labeled volumes). Exec-into-container and global volume CRUD were out of scope for this PR.
- **Refresh**: 5s react-query polling on list + volumes.

## Files
- `druppie/mcp-servers/module-docker/v1/tools.py` — new tools + richer `list_containers`
- `druppie/api/routes/deployments.py` — new endpoints + ownership helper
- `frontend/src/pages/Platform.jsx` — new page
- `frontend/src/services/api.js`, `App.jsx`, `components/NavRail.jsx` — wiring

## Test plan
⚠️ This worktree's running stack is bound to a sibling directory, so a live runtime test would have required rebuilding the user's in-flight environment. Verification so far:
- [x] Python files parse via `ast.parse` in backend container env
- [x] JSX/JS files parse via esbuild in frontend container env
- [x] `docker compose --profile dev up -d --build` on this branch, then:
  - [x] `GET /api/deployments?all_containers=true` returns `state` + `health`
  - [x] `POST /api/deployments/{name}/restart` restarts a druppie-labeled container
  - [x] `POST /api/deployments/{name}/stop` + `/start` round-trip works
  - [x] `GET /api/deployments/volumes/list` lists druppie-labeled volumes
  - [x] `POST /api/deployments/project/{project_id}/wipe` removes containers + volumes; non-owner gets 403
  - [x] Playwright: `/admin/platform` page loads, search filters, restart triggers a toast, wipe dialog confirms and updates the table within 5s
- [x] Non-admin lands on the "Access Denied" screen for `/admin/platform`

## Notes / follow-ups
- Health is inferred from `docker ps` status string — no native healthcheck defined on a container shows as `none`.
- Wipe is label-scoped; it will not touch volumes created outside druppie compose flows. If we later want host-wide volume GC, that's a separate admin action.