### PR TITLE
refactor(update_core_builder): remove HITL tools at the framework level

### DIFF
--- a/druppie/agents/definitions/update_core_builder.yaml
+++ b/druppie/agents/definitions/update_core_builder.yaml
@@ -7,6 +7,14 @@ system_prompt: |
   You are the Update Core Builder Agent for Druppie. You implement changes to
   Druppie's own codebase (the core platform).
 
+  The design documents (FD + TD) in /workspace/project/ ARE your instructions.
+  If the Planner's prompt on top is terse or empty, that's fine — read the
+  design and build. If the design is ambiguous, make a reasonable best-effort
+  call and document assumptions under an "Assumptions" heading in the PR
+  description. If the design is fundamentally broken, commit a
+  `docs/build-blocked.md` explaining why, push, open the PR, and call done()
+  with a summary starting "Agent update_core_builder: BLOCKED —".
+
   =============================================================================
   COMPLETION (CRITICAL — READ THIS FIRST!)
   =============================================================================
@@ -67,9 +75,6 @@ system_prompt: |
   - Follow existing code patterns in the Druppie codebase
   - Include appropriate tests where applicable
 
-  CRITICAL: DO NOT use hitl_ask_question or hitl_ask_choice unless the task is truly ambiguous.
-  Just implement what the design documents specify.
-
   =============================================================================
   MODULE CREATION TASKS
   =============================================================================
@@ -105,6 +110,14 @@ mcps:
 
 extra_builtin_tools:
   - execute_coding_task
+
+# Strip HITL from the default builtin set. This agent runs late in the
+# pipeline, long after the user approved FD + TD; asking the user again is
+# redundant work. Removing the tool from the function schema prevents the
+# LLM from reaching for it regardless of prompt wording.
+excluded_builtin_tools:
+  - hitl_ask_question
+  - hitl_ask_multiple_choice_question
 
 # done() requires developer approval — reviewer must merge the PR first
 approval_overrides:

--- a/druppie/agents/loop.py
+++ b/druppie/agents/loop.py
@@ -196,7 +196,9 @@ class AgentLoop:
         from druppie.core.tool_registry import get_tool_registry
 
         registry = get_tool_registry()
-        builtin_tool_names = DEFAULT_BUILTIN_TOOLS + self.definition.extra_builtin_tools
+        excluded = set(self.definition.excluded_builtin_tools) - {"done"}
+        builtin_tool_names = [t for t in DEFAULT_BUILTIN_TOOLS if t not in excluded]
+        builtin_tool_names = builtin_tool_names + self.definition.extra_builtin_tools
         # Add invoke_skill tool if agent has skills defined
         if self.definition.skills:
             builtin_tool_names = builtin_tool_names + ["invoke_skill"]

--- a/druppie/domain/agent_definition.py
+++ b/druppie/domain/agent_definition.py
@@ -75,6 +75,13 @@ class AgentDefinition(BaseModel):
     # These are ADDED to the defaults, e.g. ["make_plan"] gives this agent make_plan on top of defaults
     extra_builtin_tools: list[str] = Field(default_factory=list)
 
+    # Default builtin tools to SUBTRACT from the default set for this agent.
+    # Useful for late-stage agents that should not be able to ask the user
+    # (e.g. update_core_builder) — listing "hitl_ask_question" here removes
+    # the tool from the OpenAI function schema entirely, so the LLM has no
+    # way to call it. "done" cannot be excluded.
+    excluded_builtin_tools: list[str] = Field(default_factory=list)
+
     # Constraints on execute_coding_task parameters.
     # When set, limits which sandbox agents and repo targets this agent can use.
     sandbox_constraints: SandboxConstraints | None = None


### PR DESCRIPTION
## Summary

`update_core_builder` was calling `hitl_ask_question` after FD + TD were already approved. That's redundant work — the user has nothing new to add at that point. Handling this via prompt nagging is unreliable; drop the tool from the agent's schema so the LLM can't call it.

## Changes

- **`druppie/domain/agent_definition.py`** — `AgentDefinition` gets a new field `excluded_builtin_tools: list[str]`.
- **`druppie/agents/loop.py`** — when assembling the function schema for the LLM, the default builtin list has `excluded_builtin_tools` subtracted before `extra_builtin_tools` is appended. `done` cannot be excluded.
- **`druppie/agents/definitions/update_core_builder.yaml`**
  - Adds `excluded_builtin_tools: [hitl_ask_question, hitl_ask_multiple_choice_question]` so the LLM sees no HITL functions at all.
  - Drops the large "no user interaction" prompt block. Keeps a short paragraph with the useful guidance that's independent of HITL: design docs are the instruction set; on ambiguity, best-effort + an "Assumptions" heading in the PR description; on fundamentally broken designs, commit `docs/build-blocked.md` and call `done()` with `BLOCKED —`.

## Test plan

- [x] Inspect the function schema at runtime for update_core_builder — `hitl_*` should be absent.
- [x] Trigger a core-update session with a terse Planner prompt — agent proceeds straight to `execute_coding_task` without attempting HITL.
- [x] `cd druppie && pytest` — no regressions.