### PR TITLE
fix(opencode): retry LLM calls until they work instead of failing in minutes

### DIFF
--- a/background-agents/packages/local-control-plane/package.json
+++ b/background-agents/packages/local-control-plane/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:proxy": "LLM_RETRY_DELAYS_MS=200,400,800,1600 LLM_RETRY_KEEPALIVE_MS=100 LLM_RETRY_BUDGET_MS=10000 tsx tests/proxy/retry-integration.test.ts"
   },
   "dependencies": {
     "@open-inspect/shared": "file:../shared",

--- a/background-agents/packages/local-control-plane/src/proxy/llm-proxy.ts
+++ b/background-agents/packages/local-control-plane/src/proxy/llm-proxy.ts
@@ -44,11 +44,28 @@ const SAME_PROVIDER_RETRY_BUDGET_MS = parseInt(
   process.env.LLM_RETRY_BUDGET_MS || String(24 * 60 * 60 * 1000), // 24h
   10
 );
-const SAME_PROVIDER_DELAYS_MS = [10_000, 30_000, 120_000, 300_000];
+
+/** Parse a CSV of millisecond values (e.g. "100,200,500") into a number array,
+ *  or return null if the env var is unset / malformed. Used by the retry
+ *  integration tests to shrink back-offs below 10s; prod defaults stand. */
+function parseDelaysMs(raw: string | undefined): number[] | null {
+  if (!raw) return null;
+  const parts = raw.split(",").map((s) => parseInt(s.trim(), 10));
+  if (parts.some((n) => !Number.isFinite(n) || n < 0)) return null;
+  if (parts.length === 0) return null;
+  return parts;
+}
+const SAME_PROVIDER_DELAYS_MS: number[] = parseDelaysMs(process.env.LLM_RETRY_DELAYS_MS) ?? [
+  10_000, 30_000, 120_000, 300_000,
+];
 
 /** Keep-alive SSE comments sent to the client during back-off sleeps so its
- *  HTTP socket doesn't idle out while we're waiting on a flaky upstream. */
-const STREAM_KEEPALIVE_INTERVAL_MS = 15_000;
+ *  HTTP socket doesn't idle out while we're waiting on a flaky upstream.
+ *  Env-overridable for tests (via LLM_RETRY_KEEPALIVE_MS). */
+const STREAM_KEEPALIVE_INTERVAL_MS = parseInt(
+  process.env.LLM_RETRY_KEEPALIVE_MS || "15000",
+  10
+);
 
 function nextBackoffDelay(retryIdx: number): number {
   // retryIdx is 1-based (first retry = 1). Cap to the last entry when we

--- a/background-agents/packages/local-control-plane/src/proxy/llm-proxy.ts
+++ b/background-agents/packages/local-control-plane/src/proxy/llm-proxy.ts
@@ -27,12 +27,58 @@ const READ_TIMEOUT_MS = 300_000;
 
 const CONSECUTIVE_ERROR_THRESHOLD = 3;
 
-/** Per-provider retry config: retry same provider before failover */
-const SAME_PROVIDER_MAX_RETRIES = 3;
-const SAME_PROVIDER_DELAYS_MS = [10_000, 30_000, 120_000]; // 10s, 30s, 2min
+/**
+ * Per-provider retry config. Retries against the SAME provider happen until
+ * the wall-clock budget runs out, then we failover to the next provider in
+ * the chain.
+ *
+ * Goal: an upstream outage (rate limit, 5xx, connection reset) should cause
+ * the proxy to wait it out rather than bubble up a 502 to opencode within a
+ * few minutes. The C3 watchdog in SessionInstance (LLM_FAILURE_TIMEOUT_MS,
+ * default 24h) still decides when to give up and kill the sandbox.
+ *
+ * Back-off schedule grows then caps: 10s, 30s, 2min, 5min, 5min, 5min, ...
+ * Override the budget per session via env LLM_RETRY_BUDGET_MS.
+ */
+const SAME_PROVIDER_RETRY_BUDGET_MS = parseInt(
+  process.env.LLM_RETRY_BUDGET_MS || String(24 * 60 * 60 * 1000), // 24h
+  10
+);
+const SAME_PROVIDER_DELAYS_MS = [10_000, 30_000, 120_000, 300_000];
+
+/** Keep-alive SSE comments sent to the client during back-off sleeps so its
+ *  HTTP socket doesn't idle out while we're waiting on a flaky upstream. */
+const STREAM_KEEPALIVE_INTERVAL_MS = 15_000;
+
+function nextBackoffDelay(retryIdx: number): number {
+  // retryIdx is 1-based (first retry = 1). Cap to the last entry when we
+  // run past the end of the schedule.
+  const i = Math.max(0, retryIdx - 1);
+  return SAME_PROVIDER_DELAYS_MS[Math.min(i, SAME_PROVIDER_DELAYS_MS.length - 1)];
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Sleep in short slices so we can emit SSE keepalives to the client during
+ *  the wait. If `writeKeepalive` is provided (streaming requests only), we
+ *  call it every STREAM_KEEPALIVE_INTERVAL_MS to keep the downstream socket
+ *  alive. Returns early and truthy if the client disconnected mid-sleep. */
+async function sleepWithKeepalive(
+  ms: number,
+  writeKeepalive: (() => boolean) | null,
+  isClientGone: () => boolean
+): Promise<boolean> {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    if (isClientGone()) return true;
+    const remaining = end - Date.now();
+    const slice = Math.min(remaining, STREAM_KEEPALIVE_INTERVAL_MS);
+    await sleep(slice);
+    if (writeKeepalive && !writeKeepalive()) return true; // socket write failed
+  }
+  return isClientGone();
 }
 
 /** Map of provider names to their base URLs (fallbacks if not stored). */
@@ -199,7 +245,11 @@ async function attemptStreamingRequest(
   headers: Record<string, string>,
   body: Buffer,
   res: Response,
-  provider: string
+  provider: string,
+  /** Optional: called right before we start forwarding upstream bytes.
+   *  Used by the retry loop to commit SSE headers early (for keepalives)
+   *  so we don't try to writeHead() again here. */
+  onBeforeForward?: () => void
 ): Promise<StreamResult> {
   const startTime = Date.now();
   return new Promise<StreamResult>((resolve) => {
@@ -231,21 +281,26 @@ async function attemptStreamingRequest(
         upstreamRes.statusCode &&
         (upstreamRes.statusCode < 200 || upstreamRes.statusCode >= 300)
       ) {
-        // Any non-2xx — retry with next provider in chain
+        // Any non-2xx — retry (same provider first, then failover).
         upstreamRes.resume();
         upstreamRes.on("end", () => resolve("failed_before_headers"));
         return;
       }
 
-      // Success — forward response (can't retry after this)
-      res.writeHead(upstreamRes.statusCode || 200, {
-        "Content-Type": upstreamRes.headers["content-type"] || "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-        ...(upstreamRes.headers["x-request-id"]
-          ? { "x-request-id": upstreamRes.headers["x-request-id"] }
-          : {}),
-      });
+      // Success — forward response. If the outer retry loop already
+      // committed SSE headers (for keepalive purposes), skip writeHead
+      // and just start piping upstream chunks.
+      if (onBeforeForward) onBeforeForward();
+      if (!res.headersSent) {
+        res.writeHead(upstreamRes.statusCode || 200, {
+          "Content-Type": upstreamRes.headers["content-type"] || "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+          ...(upstreamRes.headers["x-request-id"]
+            ? { "x-request-id": upstreamRes.headers["x-request-id"] }
+            : {}),
+        });
+      }
 
       upstreamRes.on("data", (chunk: Buffer) => {
         chunkCount++;
@@ -523,20 +578,69 @@ async function handleRequestWithFailover(
       );
     }
 
+    // Track whether the downstream client has dropped. `res.on('close')`
+    // fires as soon as opencode disconnects; we stop retrying immediately
+    // rather than burning quota on an orphaned request.
+    let clientGone = false;
+    res.on("close", () => {
+      clientGone = true;
+    });
+    const isClientGone = () => clientGone || res.writableEnded || res.destroyed;
+
     if (streaming) {
-      // Retry same provider with exponential backoff before failover.
-      // Only track the FINAL outcome for health purposes — individual retry
-      // failures should not count toward the consecutive error threshold,
-      // otherwise a single request with 3 retries immediately triggers
-      // provider_unhealthy (threshold is also 3).
-      let streamOutcome: StreamResult = "failed_before_headers";
-      for (let retry = 0; retry < SAME_PROVIDER_MAX_RETRIES; retry++) {
-        if (retry > 0) {
-          const delay = SAME_PROVIDER_DELAYS_MS[retry - 1] ?? 120_000;
+      // We commit to SSE headers BEFORE the first upstream call so we can
+      // send keepalive comments during back-off sleeps. Without this,
+      // opencode's HTTP client idles out after a few tens of seconds while
+      // the proxy waits on a flaky upstream, and the whole retry budget
+      // is wasted on an already-dead socket.
+      //
+      // SSE comment lines (starting with ':') are ignored by parsers —
+      // they exist specifically to keep the socket warm.
+      let headersCommitted = false;
+      const commitStreamingHeaders = () => {
+        if (headersCommitted || res.headersSent) return;
+        res.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+          "X-Accel-Buffering": "no", // disable proxy buffering (nginx etc.)
+        });
+        headersCommitted = true;
+      };
+      const writeKeepalive = (): boolean => {
+        commitStreamingHeaders();
+        try {
+          return res.write(`: keepalive ${Date.now()}\n\n`);
+        } catch {
+          return false;
+        }
+      };
+
+      const startedAt = Date.now();
+      let retry = 0;
+      let lastFailureReason: string = "failed_before_headers";
+
+      while (Date.now() - startedAt < SAME_PROVIDER_RETRY_BUDGET_MS) {
+        if (isClientGone()) {
           console.log(
-            `[llm-proxy] ${attempt.provider} retry ${retry}/${SAME_PROVIDER_MAX_RETRIES - 1} after ${delay}ms`
+            `[llm-proxy] ${attempt.provider} client disconnected during retry loop; abandoning`
           );
-          await sleep(delay);
+          trackLlmResult(proxyKey, attempt.provider, false, credentialStore, callbacks);
+          return;
+        }
+
+        if (retry > 0) {
+          const delay = nextBackoffDelay(retry);
+          const budgetLeft = SAME_PROVIDER_RETRY_BUDGET_MS - (Date.now() - startedAt);
+          console.log(
+            `[llm-proxy] ${attempt.provider} retry ${retry} after ${delay}ms ` +
+              `(budget left: ${Math.round(budgetLeft / 1000)}s, last: ${lastFailureReason})`
+          );
+          const disconnected = await sleepWithKeepalive(delay, writeKeepalive, isClientGone);
+          if (disconnected) {
+            trackLlmResult(proxyKey, attempt.provider, false, credentialStore, callbacks);
+            return;
+          }
         }
 
         const result = await attemptStreamingRequest(
@@ -545,44 +649,86 @@ async function handleRequestWithFailover(
           headers,
           attemptBody,
           res,
-          attempt.provider
+          attempt.provider,
+          commitStreamingHeaders
         );
-
-        streamOutcome = result;
 
         if (result === "success") {
           trackLlmResult(proxyKey, attempt.provider, true, credentialStore, callbacks);
           return;
         }
         if (result === "headers_sent") {
-          // Partially sent — can't retry (headers already forwarded to client)
+          // The upstream started streaming but then errored mid-flight.
+          // We can't recover — headers are already downstream and partial
+          // bytes were forwarded. Let opencode see the truncation.
           trackLlmResult(proxyKey, attempt.provider, false, credentialStore, callbacks);
           return;
         }
-        // failed_before_headers — retry same provider
+        // failed_before_headers — upstream returned 4xx/5xx or connection
+        // died before data flowed to the client. Safe to retry.
+        lastFailureReason = result;
+        retry++;
       }
 
-      // All retries exhausted — track ONE failure for health purposes
+      // Wall-clock budget exhausted on this provider.
+      console.warn(
+        `[llm-proxy] ${attempt.provider} retry budget exhausted after ${Math.round(
+          (Date.now() - startedAt) / 1000
+        )}s and ${retry} attempts`
+      );
       trackLlmResult(proxyKey, attempt.provider, false, credentialStore, callbacks);
 
       if (isLastAttempt) {
-        if (!res.headersSent) {
+        // Nothing more to try. We already committed SSE 200 headers (to
+        // keep the client alive during back-offs), so surface the error
+        // as an SSE error event rather than an HTTP status code.
+        if (headersCommitted) {
+          try {
+            res.write(
+              `event: error\ndata: ${JSON.stringify({
+                error: "All providers failed after retry budget exhausted",
+              })}\n\n`
+            );
+            res.end();
+          } catch {
+            // client already gone
+          }
+        } else if (!res.headersSent) {
           res.status(502).json({ error: "All providers failed" });
         }
         return;
       }
       continue;
     } else {
-      // Retry same provider with exponential backoff before failover.
-      // Only track the FINAL outcome — see streaming path comment above.
+      // Buffered (non-streaming) path: we don't have a downstream socket
+      // to keep warm since the client is waiting for the full response,
+      // but we still want the retry budget so the caller eventually
+      // sees success on transient upstream outages.
       let lastResult: BufferedResult | null = null;
-      for (let retry = 0; retry < SAME_PROVIDER_MAX_RETRIES; retry++) {
-        if (retry > 0) {
-          const delay = SAME_PROVIDER_DELAYS_MS[retry - 1] ?? 120_000;
+      const startedAt = Date.now();
+      let retry = 0;
+
+      while (Date.now() - startedAt < SAME_PROVIDER_RETRY_BUDGET_MS) {
+        if (isClientGone()) {
           console.log(
-            `[llm-proxy] ${attempt.provider} retry ${retry}/${SAME_PROVIDER_MAX_RETRIES - 1} after ${delay}ms`
+            `[llm-proxy] ${attempt.provider} client disconnected during buffered retry loop; abandoning`
           );
-          await sleep(delay);
+          trackLlmResult(proxyKey, attempt.provider, false, credentialStore, callbacks);
+          return;
+        }
+
+        if (retry > 0) {
+          const delay = nextBackoffDelay(retry);
+          const budgetLeft = SAME_PROVIDER_RETRY_BUDGET_MS - (Date.now() - startedAt);
+          console.log(
+            `[llm-proxy] ${attempt.provider} buffered retry ${retry} after ${delay}ms ` +
+              `(budget left: ${Math.round(budgetLeft / 1000)}s)`
+          );
+          const disconnected = await sleepWithKeepalive(delay, null, isClientGone);
+          if (disconnected) {
+            trackLlmResult(proxyKey, attempt.provider, false, credentialStore, callbacks);
+            return;
+          }
         }
 
         lastResult = await attemptBufferedRequest(
@@ -605,11 +751,17 @@ async function handleRequestWithFailover(
         }
 
         console.log(
-          `[llm-proxy] ${attempt.provider} returned ${lastResult.status}, ${retry < SAME_PROVIDER_MAX_RETRIES - 1 ? "retrying same provider" : "trying next provider"}`
+          `[llm-proxy] ${attempt.provider} returned ${lastResult.status}, retrying same provider within budget`
         );
+        retry++;
       }
 
-      // All retries exhausted — track ONE failure
+      // Wall-clock budget exhausted.
+      console.warn(
+        `[llm-proxy] ${attempt.provider} buffered retry budget exhausted after ${Math.round(
+          (Date.now() - startedAt) / 1000
+        )}s and ${retry} attempts`
+      );
       trackLlmResult(proxyKey, attempt.provider, false, credentialStore, callbacks);
 
       if (isLastAttempt && lastResult) {

--- a/background-agents/packages/local-control-plane/tests/proxy/README.md
+++ b/background-agents/packages/local-control-plane/tests/proxy/README.md
@@ -1,0 +1,48 @@
+# LLM proxy retry tests
+
+End-to-end tests for `src/proxy/llm-proxy.ts` — drives the real
+`setupLlmProxy()` handler against a configurable "chaos upstream" so we
+can verify retry, back-off, keepalive, and client-abandon behaviour
+without calling a real LLM provider.
+
+## Files
+
+- `chaos-upstream.ts` — a fake OpenAI-compatible provider. Configurable
+  per-request via query params (`?fail=N&status=429&id=TOKEN`). Exposes
+  `/_counters/<id>` and `/_reset` admin endpoints for test assertions.
+- `retry-integration.test.ts` — the test driver. Starts the chaos
+  upstream as a subprocess, mounts the real proxy on a random port, and
+  drives it through four scenarios.
+
+## Run
+
+From `background-agents/packages/local-control-plane`:
+
+```
+npm run test:proxy
+```
+
+The `test:proxy` script sets short back-off delays
+(`LLM_RETRY_DELAYS_MS=200,400,800,1600`) so the whole suite finishes in
+about 10 seconds. Production defaults (10s/30s/2min/5min with a 24h
+budget) are unchanged — those envs exist **only** so tests can shrink
+them.
+
+## What it covers
+
+| Case | Asserts |
+|---|---|
+| Eventual success after N 429s (buffered) | request count, back-off elapsed, response body |
+| Eventual success after N 429s (streaming) | keepalive comments flow during back-off, final SSE data arrives, `[DONE]` terminator |
+| Client disconnects mid-retry | upstream stops receiving requests the instant the client socket closes (no orphan quota burn) |
+| Parallel requests | per-`id` counters stay independent (no shared mutable state across requests) |
+
+## Adding a new case
+
+1. Add a query-param knob to `chaos-upstream.ts` if the fault type
+   doesn't exist yet (e.g. slow first byte, truncate mid-stream).
+2. Add a `test("...", async () => { ... })` block in
+   `retry-integration.test.ts`. Always pass a unique `id=...` so the
+   chaos counters don't cross-contaminate with other tests.
+3. Keep runtimes short — if a scenario needs more than a couple of
+   seconds, the chaos schedule is probably wrong, not the proxy.

--- a/background-agents/packages/local-control-plane/tests/proxy/chaos-upstream.ts
+++ b/background-agents/packages/local-control-plane/tests/proxy/chaos-upstream.ts
@@ -1,0 +1,189 @@
+/**
+ * Chaos upstream — a fake LLM provider that fails on a configurable schedule.
+ *
+ * Used by the proxy retry integration tests to exercise the real LLM-proxy
+ * retry loop without calling a real provider. Each inbound request picks
+ * its fault schedule from query params:
+ *
+ *   ?fail=N&status=429        First N requests respond with `status` (default 429).
+ *                             Request N+1 succeeds.
+ *   ?hang=ms                  Hold the connection open for `ms` before responding
+ *                             (exercises connect/read timeouts).
+ *   ?drop=N                   First N requests accept the connection then reset
+ *                             it (socket destroy) — exercises ECONNRESET retries.
+ *   ?id=<token>               Partition counters by token so parallel tests
+ *                             don't interfere. Required.
+ *
+ * Admin endpoints:
+ *   GET  /_counters/<id>      Returns { requests, failures } as JSON.
+ *   POST /_reset              Clears all counters.
+ *
+ * Successful responses stream a minimal OpenAI-compatible SSE completion.
+ *
+ * Run:
+ *   npx tsx tests/proxy/chaos-upstream.ts --port 9999
+ */
+
+import http from "node:http";
+import { URL } from "node:url";
+
+interface Counters {
+  requests: number;
+  failures: number;
+}
+
+const counters = new Map<string, Counters>();
+
+function getCounter(id: string): Counters {
+  let c = counters.get(id);
+  if (!c) {
+    c = { requests: 0, failures: 0 };
+    counters.set(id, c);
+  }
+  return c;
+}
+
+function writeSseChunk(res: http.ServerResponse, data: unknown): void {
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+function respondStreaming(res: http.ServerResponse, id: string): void {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+  writeSseChunk(res, {
+    id: `chatcmpl-chaos-${id}`,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: "chaos-model",
+    choices: [
+      { index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: null },
+    ],
+  });
+  writeSseChunk(res, {
+    id: `chatcmpl-chaos-${id}`,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: "chaos-model",
+    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+  });
+  res.write("data: [DONE]\n\n");
+  res.end();
+}
+
+function respondBuffered(res: http.ServerResponse, id: string): void {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(
+    JSON.stringify({
+      id: `chatcmpl-chaos-${id}`,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: "chaos-model",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "ok" },
+          finish_reason: "stop",
+        },
+      ],
+    })
+  );
+}
+
+const portArg = process.argv.indexOf("--port");
+const port = portArg >= 0 ? parseInt(process.argv[portArg + 1], 10) : 9999;
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url || "/", `http://localhost:${port}`);
+
+  // Admin routes
+  if (url.pathname.startsWith("/_counters/")) {
+    const id = url.pathname.replace("/_counters/", "");
+    const c = counters.get(id) || { requests: 0, failures: 0 };
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(c));
+    return;
+  }
+  if (url.pathname === "/_reset") {
+    counters.clear();
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("reset");
+    return;
+  }
+
+  // Fault config can come from (a) query params — useful for direct
+  // curl testing of the chaos server — or (b) a top-level `chaos` object
+  // in the JSON request body, which the LLM proxy forwards unchanged.
+  // The body form is what end-to-end tests use because the proxy drops
+  // the querystring when forwarding to the upstream.
+  const qsId = url.searchParams.get("id");
+  const qsFail = parseInt(url.searchParams.get("fail") || "0", 10);
+  const qsStatus = parseInt(url.searchParams.get("status") || "429", 10);
+  const qsHang = parseInt(url.searchParams.get("hang") || "0", 10);
+  const qsDrop = parseInt(url.searchParams.get("drop") || "0", 10);
+
+  const bodyChunks: Buffer[] = [];
+  req.on("data", (chunk: Buffer) => bodyChunks.push(chunk));
+  req.on("end", async () => {
+    const body = Buffer.concat(bodyChunks).toString("utf8");
+    let parsedBody: any = null;
+    try {
+      parsedBody = body ? JSON.parse(body) : null;
+    } catch {
+      // ignore — body form is optional
+    }
+    const chaos = (parsedBody && typeof parsedBody === "object" && parsedBody.chaos) || {};
+    const id = chaos.id ?? qsId ?? "default";
+    const failCount = chaos.fail ?? qsFail;
+    const failStatus = chaos.status ?? qsStatus;
+    const hangMs = chaos.hang ?? qsHang;
+    const dropCount = chaos.drop ?? qsDrop;
+
+    const counter = getCounter(id);
+    counter.requests += 1;
+    const prevFailures = counter.failures;
+
+    if (hangMs > 0) {
+      await new Promise((r) => setTimeout(r, hangMs));
+    }
+
+    if (prevFailures < dropCount) {
+      counter.failures += 1;
+      // Destroy the socket without responding — client sees ECONNRESET.
+      req.socket.destroy();
+      return;
+    }
+
+    if (prevFailures < failCount) {
+      counter.failures += 1;
+      res.writeHead(failStatus, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: {
+            message: `Chaos: planned failure ${prevFailures + 1}/${failCount}`,
+            type: "rate_limit_error",
+            code: String(failStatus),
+          },
+        })
+      );
+      return;
+    }
+
+    const isStream = /"stream"\s*:\s*true/.test(body);
+    if (isStream) respondStreaming(res, id);
+    else respondBuffered(res, id);
+  });
+});
+
+server.listen(port, () => {
+  console.log(`[chaos-upstream] listening on :${port}`);
+});
+
+process.on("SIGTERM", () => {
+  server.close(() => process.exit(0));
+});
+process.on("SIGINT", () => {
+  server.close(() => process.exit(0));
+});

--- a/background-agents/packages/local-control-plane/tests/proxy/retry-integration.test.ts
+++ b/background-agents/packages/local-control-plane/tests/proxy/retry-integration.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Integration test for the LLM proxy's retry/back-off/keepalive behaviour.
+ *
+ * Drives the REAL setupLlmProxy() handler end-to-end against a chaos
+ * upstream that fails on a configurable schedule. Uses short back-off
+ * delays (via LLM_RETRY_DELAYS_MS / LLM_RETRY_KEEPALIVE_MS) so the
+ * suite finishes in ~10s instead of ~3min.
+ *
+ * Run:
+ *   LLM_RETRY_DELAYS_MS=200,400,800 \
+ *   LLM_RETRY_KEEPALIVE_MS=100 \
+ *   LLM_RETRY_BUDGET_MS=10000 \
+ *   npx tsx tests/proxy/retry-integration.test.ts
+ *
+ * Cases:
+ *   1. Eventual success — chaos 429s N times, proxy retries, request
+ *      succeeds. Asserts: retry count, elapsed ≥ sum of back-offs,
+ *      exactly one upstream success at the end.
+ *   2. Keepalive during back-off — streaming client must see SSE comment
+ *      lines before the real data chunks. Proves opencode won't idle-out.
+ *   3. Client disconnects mid-retry — chaos fails forever; after a few
+ *      retries the client closes its socket. Asserts the upstream stops
+ *      receiving further requests (we abandoned the retry loop).
+ *   4. Per-call counter partitioning — two concurrent requests with
+ *      different `id` tokens don't interfere with each other.
+ */
+
+import http from "node:http";
+import { spawn, type ChildProcess } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import express from "express";
+import { CredentialStore } from "../../src/credentials/credential-store.js";
+import { setupLlmProxy } from "../../src/proxy/llm-proxy.js";
+
+const CHAOS_PORT = 9970;
+const PROXY_PORT = 9971;
+const SESSION_ID = "test-session";
+const PROVIDER = "openai"; // Reuse OpenAI-compat auth injection
+const CHAOS_URL = `http://127.0.0.1:${CHAOS_PORT}`;
+
+// ────────────────────────────────────────────────────────────────────────
+// Minimal test harness (no vitest) — total failures = nonzero exit.
+// ────────────────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+const failures: string[] = [];
+
+async function test(name: string, fn: () => Promise<void>): Promise<void> {
+  process.stdout.write(`• ${name} ... `);
+  const started = Date.now();
+  try {
+    await fn();
+    const ms = Date.now() - started;
+    console.log(`OK (${ms}ms)`);
+    passed++;
+  } catch (err) {
+    const ms = Date.now() - started;
+    const msg = err instanceof Error ? err.stack || err.message : String(err);
+    console.log(`FAIL (${ms}ms)\n  ${msg}`);
+    failed++;
+    failures.push(`${name}: ${msg}`);
+  }
+}
+
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) throw new Error(`Assertion failed: ${msg}`);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Chaos server process management
+// ────────────────────────────────────────────────────────────────────────
+
+let chaos: ChildProcess | null = null;
+
+async function startChaos(): Promise<void> {
+  chaos = spawn(
+    "npx",
+    ["tsx", new URL("./chaos-upstream.ts", import.meta.url).pathname, "--port", String(CHAOS_PORT)],
+    { stdio: ["ignore", "inherit", "inherit"] }
+  );
+  // Poll until it's up
+  for (let i = 0; i < 50; i++) {
+    try {
+      await fetchJson(`${CHAOS_URL}/_counters/ping`);
+      return;
+    } catch {
+      await delay(100);
+    }
+  }
+  throw new Error("chaos server did not start");
+}
+
+async function stopChaos(): Promise<void> {
+  if (chaos) {
+    chaos.kill("SIGTERM");
+    await new Promise<void>((r) => chaos!.once("exit", () => r()));
+    chaos = null;
+  }
+}
+
+async function fetchJson(url: string, init?: RequestInit): Promise<any> {
+  const res = await fetch(url, init);
+  if (!res.ok) throw new Error(`${url} → ${res.status}`);
+  return res.json();
+}
+
+async function resetChaos(): Promise<void> {
+  await fetch(`${CHAOS_URL}/_reset`);
+}
+
+async function getChaosCounter(id: string): Promise<{ requests: number; failures: number }> {
+  return fetchJson(`${CHAOS_URL}/_counters/${id}`);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Proxy setup
+// ────────────────────────────────────────────────────────────────────────
+
+let proxyServer: http.Server | null = null;
+let proxyKey = "";
+
+function startProxy(): Promise<void> {
+  const app = express();
+  const store = new CredentialStore();
+  const keys = store.store(SESSION_ID, {
+    llm: [{ provider: PROVIDER, apiKey: "test-key", baseUrl: CHAOS_URL }],
+  });
+  proxyKey = keys.llmProxyKey!;
+  setupLlmProxy(app, store);
+  return new Promise((resolve) => {
+    proxyServer = app.listen(PROXY_PORT, () => resolve());
+  });
+}
+
+async function stopProxy(): Promise<void> {
+  if (proxyServer) {
+    await new Promise<void>((r) => proxyServer!.close(() => r()));
+    proxyServer = null;
+  }
+}
+
+function proxyUrl(): string {
+  return `http://127.0.0.1:${PROXY_PORT}/llm-proxy/${proxyKey}/${PROVIDER}/chat/completions`;
+}
+
+interface ChaosOpts {
+  id: string;
+  fail?: number;
+  status?: number;
+  hang?: number;
+  drop?: number;
+}
+
+/** Build an OpenAI-shaped request body with a top-level `chaos` object.
+ *  The proxy forwards the body as-is (modulo provider-prefix model rewrite),
+ *  so chaos-upstream can read the schedule from the body even though the
+ *  querystring is stripped by the proxy. */
+function openaiBody(stream: boolean, chaos: ChaosOpts): string {
+  return JSON.stringify({
+    model: "chaos-model",
+    messages: [{ role: "user", content: "hi" }],
+    stream,
+    chaos,
+  });
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  await startChaos();
+  await startProxy();
+  try {
+    await test("eventual success after N 429s (buffered)", async () => {
+      await resetChaos();
+      const id = "t1";
+      const started = Date.now();
+      const res = await fetch(proxyUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: openaiBody(false, { id, fail: 3, status: 429 }),
+      });
+      const elapsed = Date.now() - started;
+      assert(res.status === 200, `expected 200, got ${res.status}`);
+      const body = await res.json();
+      assert(body.choices?.[0]?.message?.content === "ok", "expected OK response body");
+      const counter = await getChaosCounter(id);
+      assert(counter.requests === 4, `expected 4 upstream requests, got ${counter.requests}`);
+      assert(counter.failures === 3, `expected 3 failures, got ${counter.failures}`);
+      // With LLM_RETRY_DELAYS_MS=200,400,800 the first 3 retries sleep
+      // 200+400+800 = 1400ms total. Allow ±300ms slack.
+      assert(elapsed >= 1400, `elapsed ${elapsed}ms < 1400ms — back-off not respected`);
+      assert(elapsed < 5000, `elapsed ${elapsed}ms > 5000ms — took too long`);
+    });
+
+    await test("eventual success after N 429s (streaming, with keepalives)", async () => {
+      await resetChaos();
+      const id = "t2";
+      // Use a longer sleep window so the keepalive path definitely fires
+      const res = await fetch(proxyUrl(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "text/event-stream",
+        },
+        body: openaiBody(true, { id, fail: 2, status: 429 }),
+      });
+      assert(res.status === 200, `expected 200, got ${res.status}`);
+      assert(res.body, "expected response body stream");
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let text = "";
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        text += decoder.decode(value, { stream: true });
+      }
+      // Keepalive comments are lines starting with ':'
+      assert(/^:\s*keepalive/m.test(text), `expected SSE keepalive comments in stream, got:\n${text.slice(0, 500)}`);
+      // Real SSE data arrived after the keepalives
+      assert(/"content":"ok"/.test(text), "expected OK delta in stream");
+      assert(/data: \[DONE\]/.test(text), "expected stream terminator");
+      const counter = await getChaosCounter(id);
+      assert(counter.requests === 3, `expected 3 upstream requests, got ${counter.requests}`);
+    });
+
+    await test("client disconnect during retry abandons upstream", async () => {
+      await resetChaos();
+      const id = "t3";
+      const ctrl = new AbortController();
+      // fail=20 means the proxy will keep retrying; we'll abort mid-loop
+      const req = fetch(proxyUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: openaiBody(false, { id, fail: 20, status: 429 }),
+        signal: ctrl.signal,
+      }).catch(() => undefined);
+      // Let it make a couple of attempts, then abort
+      await delay(500);
+      ctrl.abort();
+      await req;
+      const before = await getChaosCounter(id);
+      // Wait long enough for any in-flight retries to complete
+      await delay(2000);
+      const after = await getChaosCounter(id);
+      assert(
+        after.requests === before.requests,
+        `upstream saw ${after.requests - before.requests} extra requests after client disconnect — should be 0`
+      );
+    });
+
+    await test("parallel requests don't corrupt counters", async () => {
+      await resetChaos();
+      const [r1, r2] = await Promise.all([
+        fetch(proxyUrl(), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: openaiBody(false, { id: "pA", fail: 1, status: 429 }),
+        }),
+        fetch(proxyUrl(), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: openaiBody(false, { id: "pB", fail: 2, status: 429 }),
+        }),
+      ]);
+      assert(r1.status === 200 && r2.status === 200, "both should succeed");
+      await r1.json();
+      await r2.json();
+      const cA = await getChaosCounter("pA");
+      const cB = await getChaosCounter("pB");
+      assert(cA.requests === 2, `A expected 2 requests, got ${cA.requests}`);
+      assert(cB.requests === 3, `B expected 3 requests, got ${cB.requests}`);
+    });
+  } finally {
+    await stopProxy();
+    await stopChaos();
+  }
+
+  console.log();
+  console.log(`${passed} passed, ${failed} failed`);
+  if (failed > 0) {
+    console.log("\nFailures:");
+    for (const f of failures) console.log("  - " + f);
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/background-agents/packages/modal-infra/src/sandbox/entrypoint.py
+++ b/background-agents/packages/modal-infra/src/sandbox/entrypoint.py
@@ -529,6 +529,20 @@ exit 1
                     "options": {
                         "baseURL": f"{llm_proxy}/sandbox",
                         "apiKey": "proxy-managed",
+                        # Disable OpenCode's absolute per-request timeout
+                        # (default 5 min). The LLM proxy runs its own
+                        # 24h wall-clock retry budget with SSE keepalives
+                        # every 15s, so a slow upstream should never cause
+                        # OpenCode to abort the request from the client side.
+                        # See opencode.ai/docs/config#models.
+                        "timeout": False,
+                        # Between-chunk timeout: abort if NO bytes arrive
+                        # for this long. The proxy emits SSE keepalive
+                        # comments every 15s during retry back-offs, so
+                        # anything >15s works. 5 min is generous slack for
+                        # a momentarily stalled proxy (GC pause, I/O hitch)
+                        # while still eventually catching a fully dead one.
+                        "chunkTimeout": 300_000,
                     },
                     "models": models_dict,
                 }

--- a/druppie/llm/litellm_provider.py
+++ b/druppie/llm/litellm_provider.py
@@ -240,7 +240,13 @@ class ChatLiteLLM(BaseLLM):
         temperature: float | None = None,
         max_tokens: int = 16384,
         timeout: float = 300.0,
-        max_retries: int = 3,
+        # Retry budget for the Druppie backend's direct LLM calls (router,
+        # planner, architect etc. — NOT the sandbox path, which goes through
+        # the local-control-plane proxy with its own wall-clock budget).
+        # Kept higher than LiteLLM's default so a brief upstream outage or
+        # 429 burst doesn't fail an agent run we could otherwise complete.
+        # Back-off is LiteLLM's built-in exponential schedule.
+        max_retries: int = 20,
     ):
         """Initialize LiteLLM provider.
 


### PR DESCRIPTION
## Summary

When an upstream LLM (z.ai in our case) rate-limits or briefly outages, the sandbox call was failing within minutes even though the C3 watchdog in the local-control-plane was supposed to tolerate 24h of failures. Root cause: two short-horizon timers below the watchdog that were actually deciding the outcome.

1. **Proxy retry loop** in `background-agents/.../proxy/llm-proxy.ts` — 3 retries with `[10s, 30s, 2min]` back-off ≈ 3 min budget, then 502 to opencode.
2. **Opencode client-side request timeout** — default 300000 ms (5 min) on the provider. Even with more proxy retries, the client was killing the socket after 5 min.

Both raise the ceiling well below the 24h watchdog we already have.

## What this PR changes

**`llm-proxy.ts`** — retry on wall-clock budget, not fixed attempts:
- `SAME_PROVIDER_RETRY_BUDGET_MS` (default 24h, env `LLM_RETRY_BUDGET_MS`)
- Back-off grows then caps: `[10s, 30s, 2min, 5min, 5min, ...]`, CSV-overridable via `LLM_RETRY_DELAYS_MS` (primarily for tests)
- Streaming path commits SSE headers early and emits `: keepalive <ts>\n\n` comments every 15s (configurable via `LLM_RETRY_KEEPALIVE_MS`) during back-off sleeps so opencode's socket doesn't idle out
- Both paths watch `res.on('close')` and abandon the retry loop immediately if opencode disconnects — no quota burned on orphan requests

**`druppie/llm/litellm_provider.py`** — bump the Druppie backend's direct LLM retries (router/planner/architect path, NOT sandbox): `max_retries: 3 → 20`. LiteLLM's built-in exponential back-off covers the delay.

**`background-agents/.../entrypoint.py`** — set on the sandbox `@ai-sdk/openai-compatible` provider config:
- `"timeout": false` — disable opencode's 5-min per-request hard deadline (documented at https://opencode.ai/docs/config)
- `"chunkTimeout": 300000` — 5 min between streamed bytes before opencode aborts. Our keepalives fire every 15s, so this is generous slack for a momentarily stalled proxy while still eventually noticing a fully-dead one.

## Tests

New `tests/proxy/` suite — a chaos-upstream + integration harness that drives the real `setupLlmProxy()` handler end-to-end. Currently 4/4 passing in ~5s:

| # | Case | What it proves |
|---|---|---|
| 1 | Buffered eventual success after 3 × 429 | retries happen, back-off elapsed ≥ sum of configured delays, response body is forwarded |
| 2 | Streaming eventual success after 2 × 429 + keepalives | SSE `: keepalive` comments flow during back-off; real SSE data arrives once upstream recovers; `[DONE]` terminator present |
| 3 | Client disconnects mid-retry | upstream stops receiving requests the instant the client socket closes — no orphan quota burn |
| 4 | Parallel requests | per-session chaos counters stay independent (no shared mutable state across requests) |

Run locally:
```
cd background-agents/packages/local-control-plane
npm install
npm run test:proxy
```

## Why a separate PR

Split off from PR #171 (`feature/ask-expert-tool`) so the retry/backoff change can land independently. Ask-expert is still being iterated on; this fix is self-contained and benefits every sandbox run regardless.

## Test plan

- [x] Unit/integration: `npm run test:proxy` — 4/4 passing
- [ ] Rebuild control plane (`docker compose build sandbox-control-plane`) and sandbox image (`docker compose build sandbox-image-builder`), bring the stack up, spawn a sandbox task.
- [ ] Observe proxy logs during a 429 burst: should see repeated `retry N after Xms (budget left: …s)` instead of `retry 1/2`, and `: keepalive` SSE comments flowing to the sandbox during back-off.
- [ ] Kill opencode mid-retry; verify proxy logs `client disconnected during retry loop; abandoning` instead of continuing to burn quota.
- [ ] Sanity-check: `LLM_RETRY_BUDGET_MS=60000 docker compose up` should make the proxy give up after 1 min (for tests / short-outage scenarios).