### PR TITLE
fix(testing): YAML error handling and validation

### DIFF
--- a/druppie/api/routes/evaluations_tests.py
+++ b/druppie/api/routes/evaluations_tests.py
@@ -164,6 +164,25 @@ async def run_tests(
     def _run():
         import os
         from druppie.testing.runner import TestRunner
+        from druppie.testing.loaders import YAMLLoadError
+
+        try:
+            _run_inner(run_id, test_name, test_names, tag, run_all,
+                       execute, judge, input_values)
+        except YAMLLoadError as e:
+            logger.error("test_yaml_error", run_id=run_id, file=str(e.path), error=str(e))
+            _update_batch(status="error", current_test=None,
+                          message=f"YAML error in {e.path.name}: {e}",
+                          completed_at=datetime.now(timezone.utc))
+        except Exception as e:
+            logger.error("tests_run_fatal", run_id=run_id, error=str(e), exc_info=True)
+            _update_batch(status="error", current_test=None,
+                          message=str(e), completed_at=datetime.now(timezone.utc))
+
+    def _run_inner(run_id, test_name, test_names, tag, run_all,
+                   execute, judge, input_values):
+        import os
+        from druppie.testing.runner import TestRunner
 
         # Use a short-lived session just for loading test definitions.
         # Each individual test gets its own session via runner.with_db().
@@ -241,60 +260,47 @@ async def run_tests(
         _update_batch(total_tests=total, message=f"Running 0/{total} tests...")
 
         all_results = []
-        test_timeout = int(os.getenv("TEST_TIMEOUT_SECONDS", "600"))  # 10 min default
+        test_timeout = int(os.getenv("TEST_TIMEOUT_SECONDS", "600"))
 
-        try:
-            for idx, (name, test_def) in enumerate(tests_to_run):
-                _update_batch(current_test=name,
-                              message=f"Running {idx + 1}/{total}: {name}")
+        for idx, (name, test_def) in enumerate(tests_to_run):
+            _update_batch(current_test=name,
+                          message=f"Running {idx + 1}/{total}: {name}")
 
-                try:
-                    # Each test gets its own DB session — created and closed
-                    # within the worker thread so no cross-thread sharing.
-                    def _run_single_test():
-                        test_db = SessionLocal()
-                        try:
-                            test_runner = runner.with_db(test_db)
-                            results = test_runner.run_test(test_def, **phase_flags)
-                            test_db.commit()  # Persist TestRun + assertions
-                            return results
-                        except Exception:
-                            test_db.rollback()
-                            raise
-                        finally:
-                            test_db.close()
-
-                    with ThreadPoolExecutor(max_workers=1) as pool:
-                        future = pool.submit(_run_single_test)
-                        test_results = future.result(timeout=test_timeout)
-                    all_results.extend(test_results)
-                except FuturesTimeoutError:
-                    logger.error("test_timed_out", test=name, timeout=test_timeout)
-                    from druppie.testing.runner import TestRunResult
-                    all_results.append(TestRunResult(
-                        test_name=name, test_user="timeout", test_type="tool",
-                        assertion_results=[], status="error",
-                        duration_ms=test_timeout * 1000,
-                    ))
-                except Exception as test_err:
-                    logger.error("test_failed", test=name, error=str(test_err), exc_info=True)
-
-            passed = sum(1 for r in all_results if r.status == "passed")
-            _update_batch(
-                status="completed", current_test=None,
-                message=f"{passed}/{len(all_results)} passed",
-                completed_at=datetime.now(timezone.utc),
-            )
-
-        except Exception as e:
-            logger.error("tests_run_error", run_id=run_id, error=str(e), exc_info=True)
             try:
-                _update_batch(
-                    status="error", current_test=None,
-                    message=str(e), completed_at=datetime.now(timezone.utc),
-                )
-            except Exception:
-                pass
+                def _run_single_test():
+                    test_db = SessionLocal()
+                    try:
+                        test_runner = runner.with_db(test_db)
+                        results = test_runner.run_test(test_def, **phase_flags)
+                        test_db.commit()
+                        return results
+                    except Exception:
+                        test_db.rollback()
+                        raise
+                    finally:
+                        test_db.close()
+
+                with ThreadPoolExecutor(max_workers=1) as pool:
+                    future = pool.submit(_run_single_test)
+                    test_results = future.result(timeout=test_timeout)
+                all_results.extend(test_results)
+            except FuturesTimeoutError:
+                logger.error("test_timed_out", test=name, timeout=test_timeout)
+                from druppie.testing.runner import TestRunResult
+                all_results.append(TestRunResult(
+                    test_name=name, test_user="timeout", test_type="tool",
+                    assertion_results=[], status="error",
+                    duration_ms=test_timeout * 1000,
+                ))
+            except Exception as test_err:
+                logger.error("test_failed", test=name, error=str(test_err), exc_info=True)
+
+        passed = sum(1 for r in all_results if r.status == "passed")
+        _update_batch(
+            status="completed", current_test=None,
+            message=f"{passed}/{len(all_results)} passed",
+            completed_at=datetime.now(timezone.utc),
+        )
 
     thread = threading.Thread(target=_run, daemon=True, name=f"test-run-{run_id}")
     thread.start()

--- a/druppie/testing/loaders.py
+++ b/druppie/testing/loaders.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-
 import yaml
 
 from druppie.testing.schema import (
@@ -18,6 +17,62 @@ from druppie.testing.schema import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class YAMLLoadError(Exception):
+    """Raised when a YAML test file cannot be parsed or validated.
+
+    Carries the file path and original error for clear diagnostics.
+    """
+
+    def __init__(self, path: Path, detail: str, original: Exception | None = None):
+        self.path = path
+        self.original = original
+        super().__init__(f"{path.name}: {detail}")
+
+
+def _load_yaml_file(path: Path) -> dict:
+    """Load and validate a single YAML file into a dict.
+
+    Catches three classes of mistake early with actionable messages:
+      1. YAML syntax errors (e.g. bare text outside a comment)
+      2. File parses but result is not a dict (bare scalar document)
+      3. File is empty or all-comments (yaml.safe_load returns None)
+    """
+    raw = path.read_text()
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as e:
+        line = getattr(e, "problem_mark", None)
+        line_info = f" (line {line.line + 1})" if line else ""
+        raise YAMLLoadError(
+            path,
+            f"YAML syntax error{line_info}: {e}",
+            original=e,
+        ) from e
+
+    if data is None:
+        raise YAMLLoadError(
+            path,
+            "File is empty or contains only comments — no YAML content found. "
+            "Make sure the file starts with a top-level key like 'tool-test:', 'check:', or 'agent-test:'.",
+        )
+
+    if not isinstance(data, dict):
+        # This is the exact failure mode when a comment line loses its ## prefix.
+        # yaml.safe_load returns the bare string as the document, ignoring the
+        # real content below it.
+        preview = str(data)[:80]
+        raise YAMLLoadError(
+            path,
+            f"File parsed as a '{type(data).__name__}' ({preview!r}…) instead of a mapping. "
+            "This usually means a line that should be a comment (##) is missing its prefix, "
+            "causing YAML to treat it as the document body. "
+            "Check for un-commented text above your top-level key.",
+            original=None,
+        )
+
+    return data
 
 
 # ---------------------------------------------------------------------------
@@ -39,15 +94,21 @@ class ProfileLoader:
     def _load(self) -> None:
         hitl_path = self._profiles_dir / "hitl.yaml"
         if hitl_path.exists():
-            data = yaml.safe_load(hitl_path.read_text())
-            parsed = HITLProfilesFile(**data)
-            self._hitl = dict(parsed.profiles)
+            try:
+                data = _load_yaml_file(hitl_path)
+                parsed = HITLProfilesFile(**data)
+                self._hitl = dict(parsed.profiles)
+            except (YAMLLoadError, Exception) as e:
+                logger.error("Failed to load %s: %s", hitl_path.name, e)
 
         judges_path = self._profiles_dir / "judges.yaml"
         if judges_path.exists():
-            data = yaml.safe_load(judges_path.read_text())
-            parsed = JudgeProfilesFile(**data)
-            self._judges = dict(parsed.profiles)
+            try:
+                data = _load_yaml_file(judges_path)
+                parsed = JudgeProfilesFile(**data)
+                self._judges = dict(parsed.profiles)
+            except (YAMLLoadError, Exception) as e:
+                logger.error("Failed to load %s: %s", judges_path.name, e)
 
     def get_hitl(self, name: str) -> HITLProfile:
         if name == "default":
@@ -94,9 +155,12 @@ class CheckLoader:
             logger.warning("Checks directory not found: %s", self._checks_dir)
             return
         for path in sorted(self._checks_dir.glob("*.yaml")):
-            data = yaml.safe_load(path.read_text())
-            parsed = CheckFile(**data)
-            self._checks[parsed.check.name] = parsed.check
+            try:
+                data = _load_yaml_file(path)
+                parsed = CheckFile(**data)
+                self._checks[parsed.check.name] = parsed.check
+            except (YAMLLoadError, Exception) as e:
+                logger.error("Failed to load check %s: %s", path.name, e)
 
     def get(self, name: str) -> CheckDefinition:
         if name not in self._checks:
@@ -126,9 +190,12 @@ class ToolTestLoader:
             logger.warning("Tools directory not found: %s", self._tools_dir)
             return
         for path in sorted(self._tools_dir.glob("*.yaml")):
-            data = yaml.safe_load(path.read_text())
-            parsed = ToolTestFile(**data)
-            self._tests[parsed.tool_test.name] = parsed.tool_test
+            try:
+                data = _load_yaml_file(path)
+                parsed = ToolTestFile(**data)
+                self._tests[parsed.tool_test.name] = parsed.tool_test
+            except (YAMLLoadError, Exception) as e:
+                logger.error("Failed to load tool test %s: %s", path.name, e)
 
     def get(self, name: str) -> ToolTestDefinition:
         if name not in self._tests:

--- a/druppie/testing/runner.py
+++ b/druppie/testing/runner.py
@@ -44,7 +44,7 @@ from druppie.testing.assertions import AssertionResult, match_assertions
 from druppie.testing.bounded_orchestrator import BoundedOrchestrator
 from druppie.testing.hitl_simulator import HITLSimulator
 from druppie.testing.judge_runner import JudgeCheckResult, JudgeRunner
-from druppie.testing.loaders import CheckLoader, ProfileLoader, ToolTestLoader
+from druppie.testing.loaders import CheckLoader, ProfileLoader, ToolTestLoader, YAMLLoadError, _load_yaml_file
 from druppie.testing.schema import (
     AgentTestDefinition,
     AgentTestFile,
@@ -118,16 +118,16 @@ class TestRunner:
         return clone
 
     def load_agent_test(self, path: Path) -> AgentTestDefinition:
-        data = yaml.safe_load(path.read_text())
+        data = _load_yaml_file(path)
         return AgentTestFile(**data).agent_test
 
     def load_tool_test(self, path: Path) -> ToolTestDefinition:
-        data = yaml.safe_load(path.read_text())
+        data = _load_yaml_file(path)
         return ToolTestFile(**data).tool_test
 
     def load_test(self, path: Path) -> AgentTestDefinition | ToolTestDefinition:
         """Load a test from any path, detecting type from content."""
-        data = yaml.safe_load(path.read_text())
+        data = _load_yaml_file(path)
         if "tool-test" in data:
             return ToolTestFile(**data).tool_test
         elif "agent-test" in data:

--- a/testing/tools/ba-paused-on-requirement-challenge.yaml
+++ b/testing/tools/ba-paused-on-requirement-challenge.yaml
@@ -2,7 +2,7 @@
 ##
 ## The full first leg of the loop is scripted:
 ##   router → planner → BA writes FD (NFR-02 <5s explicitly flagged in
-architect reads the FD, writes research.md with draft recommendation (Step 3),
+##    architect reads the FD, writes research.md with draft recommendation (Step 3),
 ##        the FD, hits the Requirement Challenge Gate (Step 3b), and calls the
 ##        Requirement Challenge Gate (Step 3b), and calls
 ##        done(DESIGN_FEEDBACK) with Issue REQUIREMENT_CHALLENGE


### PR DESCRIPTION
## Summary
- Add `_load_yaml_file()` validation that catches malformed YAML early with actionable error messages (syntax errors with line numbers, bare scalar documents from missing `##` prefixes, empty files)
- Wrap test run background thread in top-level error handler so YAML/load failures surface as batch status `"error"` instead of silently hanging on "loading" forever
- Fix missing `##` comment prefix on line 5 of `ba-paused-on-requirement-challenge.yaml` that caused `yaml.safe_load` to parse it as a bare scalar

## Root Cause
A bare text line (missing `##` comment prefix) in a YAML test file caused `yaml.safe_load()` to return a string instead of a dict. This crashed the `ToolTestLoader` during init, which crashed `TestRunner.__init__`, which made the background test thread die silently — the batch run status stayed `"running"` forever, and the frontend showed perpetual "loading".

## Test plan
- [x] Run `ba-paused-on-requirement-challenge` test — passes with session created
- [x] Other tests continue to load and run when one YAML file is broken