### PR TITLE
feat(testing): run tests in parallel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,7 +165,7 @@ SANDBOX_RUNTIME=docker
 # =============================================================================
 # Number of tests that run concurrently when multiple tests are selected.
 # Default: 3. Increase for faster batch runs if resources allow.
-PARALLEL_TEST_WORKERS=3
+PARALLEL_TEST_WORKERS=10
 # Per-test timeout in seconds (default: 600 = 10 minutes)
 # TEST_TIMEOUT_SECONDS=600
 

--- a/.env.example
+++ b/.env.example
@@ -161,6 +161,15 @@ SANDBOX_RUNTIME=docker
 # CONTAINERD_NAMESPACE=default
 
 # =============================================================================
+# TESTING FRAMEWORK
+# =============================================================================
+# Number of tests that run concurrently when multiple tests are selected.
+# Default: 3. Increase for faster batch runs if resources allow.
+PARALLEL_TEST_WORKERS=3
+# Per-test timeout in seconds (default: 600 = 10 minutes)
+# TEST_TIMEOUT_SECONDS=600
+
+# =============================================================================
 # DRUPPIE CORE REPO (for update_core_builder agent - self-improvement via PRs)
 # =============================================================================
 # The repo where Druppie's own codebase lives (used when Architect signals

--- a/druppie/api/routes/evaluations_tests.py
+++ b/druppie/api/routes/evaluations_tests.py
@@ -22,10 +22,7 @@ from druppie.services import EvaluationService
 logger = structlog.get_logger()
 router = APIRouter()
 
-# In-memory tracking of currently running tests per batch run.
-# Key: run_id (str), Value: set of test names currently executing.
-_active_runs: dict[str, set[str]] = {}
-_active_lock = threading.Lock()
+_running_lock = threading.Lock()
 
 
 class RunTestsRequest(BaseModel):
@@ -270,16 +267,25 @@ async def run_tests(
         completed_count = 0
 
         def _sync_running_tests():
-            with _active_lock:
-                names = list(_active_runs.get(run_id, set()))
+            _sync_db = SessionLocal()
+            try:
+                _sync_repo = EvaluationRepository(_sync_db)
+                names = _sync_repo.get_running_tests(run_id)
+            finally:
+                _sync_db.close()
             _update_batch(
                 current_test=names[0] if len(names) == 1 else f"{len(names)} tests",
                 message=f"Running {completed_count + len(names)}/{total}: {', '.join(names[:3])}{'...' if len(names) > 3 else ''}",
             )
 
         def _run_single_test(name, test_def):
-            with _active_lock:
-                _active_runs.setdefault(run_id, set()).add(name)
+            with _running_lock:
+                _add_db = SessionLocal()
+                try:
+                    EvaluationRepository(_add_db).add_running_test(run_id, name)
+                    _add_db.commit()
+                finally:
+                    _add_db.close()
             _sync_running_tests()
             try:
                 def _execute():
@@ -308,10 +314,13 @@ async def run_tests(
                             duration_ms=test_timeout * 1000,
                         )]
             finally:
-                with _active_lock:
-                    active = _active_runs.get(run_id)
-                    if active:
-                        active.discard(name)
+                with _running_lock:
+                    _rem_db = SessionLocal()
+                    try:
+                        EvaluationRepository(_rem_db).remove_running_test(run_id, name)
+                        _rem_db.commit()
+                    finally:
+                        _rem_db.close()
                 _sync_running_tests()
 
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
@@ -343,7 +352,12 @@ async def run_tests(
             message=f"{passed}/{len(all_results)} passed",
             completed_at=datetime.now(timezone.utc),
         )
-        _active_runs.pop(run_id, None)
+        _clr_db = SessionLocal()
+        try:
+            EvaluationRepository(_clr_db).clear_running_tests(run_id)
+            _clr_db.commit()
+        finally:
+            _clr_db.close()
 
     thread = threading.Thread(target=_run, daemon=True, name=f"test-run-{run_id}")
     thread.start()
@@ -369,7 +383,7 @@ async def get_run_status(
 
         completed_tests = repo.get_completed_test_runs(run_id)
 
-        running_tests = list(_active_runs.get(run_id, set()))
+        running_tests = repo.get_running_tests(run_id)
 
         return {
             "status": batch.status,
@@ -404,7 +418,7 @@ async def get_active_run(user: dict = Depends(require_admin)):
             return {"active": False}
 
         completed_tests = repo.get_completed_test_runs(active.id)
-        running_tests = list(_active_runs.get(active.id, set()))
+        running_tests = repo.get_running_tests(active.id)
         return {
             "active": True,
             "run_id": active.id,

--- a/druppie/api/routes/evaluations_tests.py
+++ b/druppie/api/routes/evaluations_tests.py
@@ -140,7 +140,8 @@ async def run_tests(
     _UNSET = object()
 
     def _update_batch(status=_UNSET, current_test=_UNSET, message=_UNSET,
-                      total_tests=_UNSET, completed_at=_UNSET):
+                      total_tests=_UNSET, completed_at=_UNSET,
+                      running_tests=_UNSET):
         """Update batch run status with a short-lived DB session.
 
         Only explicitly passed values are forwarded (None is a valid
@@ -149,7 +150,8 @@ async def run_tests(
         updates = {}
         for key, val in [("status", status), ("current_test", current_test),
                          ("message", message), ("total_tests", total_tests),
-                         ("completed_at", completed_at)]:
+                         ("completed_at", completed_at),
+                         ("running_tests", running_tests)]:
             if val is not _UNSET:
                 updates[key] = val
         if not updates:

--- a/druppie/api/routes/evaluations_tests.py
+++ b/druppie/api/routes/evaluations_tests.py
@@ -5,7 +5,6 @@ not in-memory dicts. This means status survives process restarts
 and there's no lock/eviction complexity.
 """
 
-import json
 import threading
 import uuid as uuid_mod
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError, as_completed
@@ -22,6 +21,11 @@ from druppie.services import EvaluationService
 
 logger = structlog.get_logger()
 router = APIRouter()
+
+# In-memory tracking of currently running tests per batch run.
+# Key: run_id (str), Value: set of test names currently executing.
+_active_runs: dict[str, set[str]] = {}
+_active_lock = threading.Lock()
 
 
 class RunTestsRequest(BaseModel):
@@ -140,8 +144,7 @@ async def run_tests(
     _UNSET = object()
 
     def _update_batch(status=_UNSET, current_test=_UNSET, message=_UNSET,
-                      total_tests=_UNSET, completed_at=_UNSET,
-                      running_tests=_UNSET):
+                      total_tests=_UNSET, completed_at=_UNSET):
         """Update batch run status with a short-lived DB session.
 
         Only explicitly passed values are forwarded (None is a valid
@@ -150,8 +153,7 @@ async def run_tests(
         updates = {}
         for key, val in [("status", status), ("current_test", current_test),
                          ("message", message), ("total_tests", total_tests),
-                         ("completed_at", completed_at),
-                         ("running_tests", running_tests)]:
+                         ("completed_at", completed_at)]:
             if val is not _UNSET:
                 updates[key] = val
         if not updates:
@@ -265,36 +267,52 @@ async def run_tests(
         all_results = []
         test_timeout = int(os.getenv("TEST_TIMEOUT_SECONDS", "600"))
         max_workers = int(os.getenv("PARALLEL_TEST_WORKERS", "3"))
-
-        active_tests: set[str] = set()
-        active_lock = threading.Lock()
+        completed_count = 0
 
         def _sync_running_tests():
-            with active_lock:
-                names = list(active_tests)
+            with _active_lock:
+                names = list(_active_runs.get(run_id, set()))
             _update_batch(
                 current_test=names[0] if len(names) == 1 else f"{len(names)} tests",
-                running_tests=json.dumps(names),
-                message=f"Running {total - len(tests_to_run) + len(names)}/{total}: {', '.join(names[:3])}{'...' if len(names) > 3 else ''}",
+                message=f"Running {completed_count + len(names)}/{total}: {', '.join(names[:3])}{'...' if len(names) > 3 else ''}",
             )
 
         def _run_single_test(name, test_def):
-            active_tests.add(name)
+            with _active_lock:
+                _active_runs.setdefault(run_id, set()).add(name)
             _sync_running_tests()
             try:
-                test_db = SessionLocal()
-                try:
-                    test_runner = runner.with_db(test_db)
-                    results = test_runner.run_test(test_def, **phase_flags)
-                    test_db.commit()
-                    return results
-                except Exception:
-                    test_db.rollback()
-                    raise
-                finally:
-                    test_db.close()
+                def _execute():
+                    test_db = SessionLocal()
+                    try:
+                        test_runner = runner.with_db(test_db)
+                        results = test_runner.run_test(test_def, **phase_flags)
+                        test_db.commit()
+                        return results
+                    except Exception:
+                        test_db.rollback()
+                        raise
+                    finally:
+                        test_db.close()
+
+                with ThreadPoolExecutor(max_workers=1) as inner_pool:
+                    inner_future = inner_pool.submit(_execute)
+                    try:
+                        return inner_future.result(timeout=test_timeout)
+                    except FuturesTimeoutError:
+                        logger.error("test_timed_out", test=name, timeout=test_timeout)
+                        from druppie.testing.runner import TestRunResult
+                        return [TestRunResult(
+                            test_name=name, test_user="timeout", test_type="tool",
+                            assertion_results=[], status="error",
+                            duration_ms=test_timeout * 1000,
+                        )]
             finally:
-                active_tests.discard(name)
+                with _active_lock:
+                    active = _active_runs.get(run_id)
+                    if active:
+                        active.discard(name)
+                _sync_running_tests()
 
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = {}
@@ -305,27 +323,27 @@ async def run_tests(
             for future in as_completed(futures):
                 name = futures[future]
                 try:
-                    test_results = future.result(timeout=test_timeout)
+                    test_results = future.result()
                     all_results.extend(test_results)
-                except FuturesTimeoutError:
-                    logger.error("test_timed_out", test=name, timeout=test_timeout)
-                    from druppie.testing.runner import TestRunResult
-                    all_results.append(TestRunResult(
-                        test_name=name, test_user="timeout", test_type="tool",
-                        assertion_results=[], status="error",
-                        duration_ms=test_timeout * 1000,
-                    ))
                 except Exception as test_err:
                     logger.error("test_failed", test=name, error=str(test_err), exc_info=True)
+                    from druppie.testing.runner import TestRunResult
+                    all_results.append(TestRunResult(
+                        test_name=name, test_user="error", test_type="tool",
+                        assertion_results=[], status="error",
+                        duration_ms=0,
+                    ))
                 finally:
+                    completed_count += 1
                     _sync_running_tests()
 
         passed = sum(1 for r in all_results if r.status == "passed")
         _update_batch(
-            status="completed", current_test=None, running_tests=None,
+            status="completed", current_test=None,
             message=f"{passed}/{len(all_results)} passed",
             completed_at=datetime.now(timezone.utc),
         )
+        _active_runs.pop(run_id, None)
 
     thread = threading.Thread(target=_run, daemon=True, name=f"test-run-{run_id}")
     thread.start()
@@ -351,8 +369,7 @@ async def get_run_status(
 
         completed_tests = repo.get_completed_test_runs(run_id)
 
-        running_tests_raw = batch.running_tests
-        running_tests = json.loads(running_tests_raw) if running_tests_raw else []
+        running_tests = list(_active_runs.get(run_id, set()))
 
         return {
             "status": batch.status,
@@ -387,8 +404,7 @@ async def get_active_run(user: dict = Depends(require_admin)):
             return {"active": False}
 
         completed_tests = repo.get_completed_test_runs(active.id)
-        running_tests_raw = active.running_tests
-        running_tests = json.loads(running_tests_raw) if running_tests_raw else []
+        running_tests = list(_active_runs.get(active.id, set()))
         return {
             "active": True,
             "run_id": active.id,

--- a/druppie/api/routes/evaluations_tests.py
+++ b/druppie/api/routes/evaluations_tests.py
@@ -266,7 +266,7 @@ async def run_tests(
 
         all_results = []
         test_timeout = int(os.getenv("TEST_TIMEOUT_SECONDS", "600"))
-        max_workers = int(os.getenv("PARALLEL_TEST_WORKERS", "3"))
+        max_workers = int(os.getenv("PARALLEL_TEST_WORKERS", "10"))
         completed_count = 0
 
         def _sync_running_tests():

--- a/druppie/api/routes/evaluations_tests.py
+++ b/druppie/api/routes/evaluations_tests.py
@@ -5,9 +5,10 @@ not in-memory dicts. This means status survives process restarts
 and there's no lock/eviction complexity.
 """
 
+import json
 import threading
 import uuid as uuid_mod
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError, as_completed
 from datetime import datetime, timezone
 from uuid import UUID
 
@@ -261,43 +262,65 @@ async def run_tests(
 
         all_results = []
         test_timeout = int(os.getenv("TEST_TIMEOUT_SECONDS", "600"))
+        max_workers = int(os.getenv("PARALLEL_TEST_WORKERS", "3"))
 
-        for idx, (name, test_def) in enumerate(tests_to_run):
-            _update_batch(current_test=name,
-                          message=f"Running {idx + 1}/{total}: {name}")
+        active_tests: set[str] = set()
+        active_lock = threading.Lock()
 
+        def _sync_running_tests():
+            with active_lock:
+                names = list(active_tests)
+            _update_batch(
+                current_test=names[0] if len(names) == 1 else f"{len(names)} tests",
+                running_tests=json.dumps(names),
+                message=f"Running {total - len(tests_to_run) + len(names)}/{total}: {', '.join(names[:3])}{'...' if len(names) > 3 else ''}",
+            )
+
+        def _run_single_test(name, test_def):
+            active_tests.add(name)
+            _sync_running_tests()
             try:
-                def _run_single_test():
-                    test_db = SessionLocal()
-                    try:
-                        test_runner = runner.with_db(test_db)
-                        results = test_runner.run_test(test_def, **phase_flags)
-                        test_db.commit()
-                        return results
-                    except Exception:
-                        test_db.rollback()
-                        raise
-                    finally:
-                        test_db.close()
+                test_db = SessionLocal()
+                try:
+                    test_runner = runner.with_db(test_db)
+                    results = test_runner.run_test(test_def, **phase_flags)
+                    test_db.commit()
+                    return results
+                except Exception:
+                    test_db.rollback()
+                    raise
+                finally:
+                    test_db.close()
+            finally:
+                active_tests.discard(name)
 
-                with ThreadPoolExecutor(max_workers=1) as pool:
-                    future = pool.submit(_run_single_test)
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {}
+            for name, test_def in tests_to_run:
+                future = pool.submit(_run_single_test, name, test_def)
+                futures[future] = name
+
+            for future in as_completed(futures):
+                name = futures[future]
+                try:
                     test_results = future.result(timeout=test_timeout)
-                all_results.extend(test_results)
-            except FuturesTimeoutError:
-                logger.error("test_timed_out", test=name, timeout=test_timeout)
-                from druppie.testing.runner import TestRunResult
-                all_results.append(TestRunResult(
-                    test_name=name, test_user="timeout", test_type="tool",
-                    assertion_results=[], status="error",
-                    duration_ms=test_timeout * 1000,
-                ))
-            except Exception as test_err:
-                logger.error("test_failed", test=name, error=str(test_err), exc_info=True)
+                    all_results.extend(test_results)
+                except FuturesTimeoutError:
+                    logger.error("test_timed_out", test=name, timeout=test_timeout)
+                    from druppie.testing.runner import TestRunResult
+                    all_results.append(TestRunResult(
+                        test_name=name, test_user="timeout", test_type="tool",
+                        assertion_results=[], status="error",
+                        duration_ms=test_timeout * 1000,
+                    ))
+                except Exception as test_err:
+                    logger.error("test_failed", test=name, error=str(test_err), exc_info=True)
+                finally:
+                    _sync_running_tests()
 
         passed = sum(1 for r in all_results if r.status == "passed")
         _update_batch(
-            status="completed", current_test=None,
+            status="completed", current_test=None, running_tests=None,
             message=f"{passed}/{len(all_results)} passed",
             completed_at=datetime.now(timezone.utc),
         )
@@ -326,10 +349,14 @@ async def get_run_status(
 
         completed_tests = repo.get_completed_test_runs(run_id)
 
+        running_tests_raw = batch.running_tests
+        running_tests = json.loads(running_tests_raw) if running_tests_raw else []
+
         return {
             "status": batch.status,
             "message": batch.message,
             "current_test": batch.current_test,
+            "running_tests": running_tests,
             "total_tests": batch.total_tests,
             "completed_tests": completed_tests,
             "started_at": batch.started_at.isoformat() if batch.started_at else None,
@@ -358,12 +385,15 @@ async def get_active_run(user: dict = Depends(require_admin)):
             return {"active": False}
 
         completed_tests = repo.get_completed_test_runs(active.id)
+        running_tests_raw = active.running_tests
+        running_tests = json.loads(running_tests_raw) if running_tests_raw else []
         return {
             "active": True,
             "run_id": active.id,
             "status": active.status,
             "message": active.message,
             "current_test": active.current_test,
+            "running_tests": running_tests,
             "total_tests": active.total_tests,
             "completed_tests": completed_tests,
         }

--- a/druppie/core/gitea.py
+++ b/druppie/core/gitea.py
@@ -42,23 +42,18 @@ class GiteaClient:
         self.admin_user = admin_user or GITEA_ADMIN_USER
         self.admin_password = admin_password or GITEA_ADMIN_PASSWORD
         self.org = org or GITEA_ORG
-        self._client: httpx.AsyncClient | None = None
 
-    async def _get_client(self) -> httpx.AsyncClient:
-        """Get or create async HTTP client."""
-        if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(
-                base_url=f"{self.base_url}/api/v1",
-                auth=(self.admin_user, self.admin_password),
-                timeout=30.0,
-            )
-        return self._client
+    def _new_client(self) -> httpx.AsyncClient:
+        """Create a fresh async HTTP client.
 
-    async def close(self):
-        """Close the HTTP client."""
-        if self._client and not self._client.is_closed:
-            await self._client.aclose()
-            self._client = None
+        Each call creates a new client so the instance is safe to use
+        across threads and event loops without shared mutable state.
+        """
+        return httpx.AsyncClient(
+            base_url=f"{self.base_url}/api/v1",
+            auth=(self.admin_user, self.admin_password),
+            timeout=30.0,
+        )
 
     async def _request(
         self,
@@ -67,45 +62,43 @@ class GiteaClient:
         json_data: dict | None = None,
         params: dict | None = None,
     ) -> dict[str, Any]:
-        """Make an API request to Gitea."""
-        client = await self._get_client()
-
-        try:
-            response = await client.request(
-                method=method,
-                url=endpoint,
-                json=json_data,
-                params=params,
-            )
-
-            result = {
-                "success": response.status_code in (200, 201, 204),
-                "status_code": response.status_code,
-            }
-
-            if response.text:
-                try:
-                    result["data"] = response.json()
-                except ValueError:
-                    result["data"] = response.text
-
-            if not result["success"]:
-                logger.warning(
-                    "gitea_api_error",
+        async with self._new_client() as client:
+            try:
+                response = await client.request(
                     method=method,
-                    endpoint=endpoint,
-                    status=response.status_code,
-                    response=result.get("data"),
+                    url=endpoint,
+                    json=json_data,
+                    params=params,
                 )
 
-            return result
+                result = {
+                    "success": response.status_code in (200, 201, 204),
+                    "status_code": response.status_code,
+                }
 
-        except httpx.RequestError as e:
-            logger.error("gitea_request_error", method=method, endpoint=endpoint, error=str(e), exc_info=True)
-            return {
-                "success": False,
-                "error": str(e),
-            }
+                if response.text:
+                    try:
+                        result["data"] = response.json()
+                    except ValueError:
+                        result["data"] = response.text
+
+                if not result["success"]:
+                    logger.warning(
+                        "gitea_api_error",
+                        method=method,
+                        endpoint=endpoint,
+                        status=response.status_code,
+                        response=result.get("data"),
+                    )
+
+                return result
+
+            except httpx.RequestError as e:
+                logger.error("gitea_request_error", method=method, endpoint=endpoint, error=str(e), exc_info=True)
+                return {
+                    "success": False,
+                    "error": str(e),
+                }
 
     # =========================================================================
     # User Operations
@@ -814,13 +807,10 @@ class GiteaClient:
         return f"{GITEA_URL}/{repo_owner}/{repo_name}"
 
 
-# Singleton instance
-_gitea_client: GiteaClient | None = None
-
-
 def get_gitea_client() -> GiteaClient:
-    """Get the global GiteaClient instance."""
-    global _gitea_client
-    if _gitea_client is None:
-        _gitea_client = GiteaClient()
-    return _gitea_client
+    """Create a new GiteaClient instance.
+
+    Stateless factory — returns a fresh client each time so it's safe
+    across threads and event loops without shared mutable state.
+    """
+    return GiteaClient()

--- a/druppie/db/models/__init__.py
+++ b/druppie/db/models/__init__.py
@@ -43,6 +43,7 @@ from .test_assertion_result import TestAssertionResult
 from .test_batch_run import TestBatchRun
 from .test_run import TestRun
 from .test_run_tag import TestRunTag
+from .test_running_status import TestRunningStatus
 from .llm_call import LlmCall
 from .llm_retry import LlmRetry
 
@@ -99,4 +100,5 @@ __all__ = [
     "TestRun",
     "TestRunTag",
     "TestAssertionResult",
+    "TestRunningStatus",
 ]

--- a/druppie/db/models/test_batch_run.py
+++ b/druppie/db/models/test_batch_run.py
@@ -19,6 +19,7 @@ class TestBatchRun(Base):
     status = Column(String(50), nullable=False, default="running")
     message = Column(Text, nullable=True)
     current_test = Column(String(255), nullable=True)
+    running_tests = Column(Text, nullable=True)  # JSON array of test names currently running in parallel
     total_tests = Column(Integer, default=0)
     started_at = Column(DateTime(timezone=True), default=utcnow)
     completed_at = Column(DateTime(timezone=True), nullable=True)

--- a/druppie/db/models/test_batch_run.py
+++ b/druppie/db/models/test_batch_run.py
@@ -19,7 +19,6 @@ class TestBatchRun(Base):
     status = Column(String(50), nullable=False, default="running")
     message = Column(Text, nullable=True)
     current_test = Column(String(255), nullable=True)
-    running_tests = Column(Text, nullable=True)  # JSON array of test names currently running in parallel
     total_tests = Column(Integer, default=0)
     started_at = Column(DateTime(timezone=True), default=utcnow)
     completed_at = Column(DateTime(timezone=True), nullable=True)

--- a/druppie/db/models/test_running_status.py
+++ b/druppie/db/models/test_running_status.py
@@ -1,0 +1,24 @@
+"""Tracks which tests are currently executing within a batch run.
+
+One row per actively-running test.  Rows are inserted when a test starts
+and deleted when it finishes, so the table is always small and represents
+only real-time state.  Fully stateless — survives restarts and works
+across multiple backend instances.
+"""
+
+from sqlalchemy import Column, DateTime, ForeignKey, String
+
+from .base import Base, utcnow
+
+
+class TestRunningStatus(Base):
+    """One row per test currently executing in a batch run."""
+
+    __tablename__ = "test_running_status"
+
+    id = Column(String(36), primary_key=True)
+    run_id = Column(
+        String(36), ForeignKey("test_batch_runs.id"), nullable=False, index=True
+    )
+    test_name = Column(String(255), nullable=False)
+    started_at = Column(DateTime(timezone=True), default=utcnow)

--- a/druppie/repositories/evaluation_repository.py
+++ b/druppie/repositories/evaluation_repository.py
@@ -1,5 +1,6 @@
 """Evaluation repository for benchmark runs and evaluation results."""
 
+import uuid
 from uuid import UUID
 
 from sqlalchemy import func
@@ -646,3 +647,37 @@ class EvaluationRepository(BaseRepository):
             {"test_name": r.test_name, "status": r.status, "duration_ms": r.duration_ms}
             for r in runs
         ]
+
+    def add_running_test(self, run_id: str, test_name: str) -> None:
+        from druppie.db.models.test_running_status import TestRunningStatus
+
+        entry = TestRunningStatus(
+            id=str(uuid.uuid4()), run_id=run_id, test_name=test_name
+        )
+        self.db.add(entry)
+        self.db.flush()
+
+    def remove_running_test(self, run_id: str, test_name: str) -> None:
+        from druppie.db.models.test_running_status import TestRunningStatus
+
+        self.db.query(TestRunningStatus).filter(
+            TestRunningStatus.run_id == run_id,
+            TestRunningStatus.test_name == test_name,
+        ).delete()
+        self.db.flush()
+
+    def get_running_tests(self, run_id: str) -> list[str]:
+        from druppie.db.models.test_running_status import TestRunningStatus
+
+        rows = self.db.query(TestRunningStatus.test_name).filter(
+            TestRunningStatus.run_id == run_id
+        ).all()
+        return [r[0] for r in rows]
+
+    def clear_running_tests(self, run_id: str) -> None:
+        from druppie.db.models.test_running_status import TestRunningStatus
+
+        self.db.query(TestRunningStatus).filter(
+            TestRunningStatus.run_id == run_id
+        ).delete()
+        self.db.flush()

--- a/druppie/testing/replay_executor.py
+++ b/druppie/testing/replay_executor.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import logging
 import posixpath
-import threading
 from uuid import UUID, uuid4
 
 from sqlalchemy.orm import Session as DbSession
@@ -29,11 +28,6 @@ from druppie.testing.seed_schema import SessionFixture, ToolCallFixture
 from druppie.testing.verifiers import _gitea_auth
 
 logger = logging.getLogger(__name__)
-
-# Lock to protect the global Gitea client singleton reset.
-# Without this, concurrent test runs can corrupt each other's client
-# (e.g., thread A resets the singleton while thread B is mid-operation).
-_gitea_singleton_lock = threading.Lock()
 
 
 class ReplayExecutor:
@@ -252,11 +246,6 @@ class ReplayExecutor:
         from druppie.repositories import ExecutionRepository
         from druppie.domain.common import AgentRunStatus
 
-        # Reset the Gitea singleton so this session gets a fresh client
-        # bound to the current event loop.
-        import druppie.core.gitea as _gitea_mod
-        _gitea_mod._gitea_client = None
-
         meta = fixture.metadata
         session_id = fixture_uuid(meta.id)
         execution_repo = ExecutionRepository(self._db)
@@ -442,16 +431,9 @@ class ReplayExecutor:
         user_id: UUID,
         gitea_url: str | None = None,
     ) -> dict:
-        """Synchronous wrapper that acquires the Gitea singleton lock and runs replay.
-
-        The lock ensures the Gitea client singleton isn't reset by a concurrent
-        thread mid-operation. This method owns both the lock and the reset,
-        so callers don't need to know about the implementation detail.
-        """
         import asyncio
 
-        with _gitea_singleton_lock:
-            return asyncio.run(self.replay_session(fixture, user_id, gitea_url))
+        return asyncio.run(self.replay_session(fixture, user_id, gitea_url))
 
     def _create_outcome_files(
         self,

--- a/frontend/src/pages/Evaluations.jsx
+++ b/frontend/src/pages/Evaluations.jsx
@@ -58,7 +58,7 @@ export default function Evaluations() {
   const [modeFilter, setModeFilter] = useState('all') // all, live, record_only, replay, manual
   const [judgeEnabled, setJudgeEnabled] = useState(true)
   const [deletingUsers, setDeletingUsers] = useState(false)
-  const [runProgress, setRunProgress] = useState(null) // {current_test, completed_tests, total_tests}
+  const [runProgress, setRunProgress] = useState(null)
 
   // Effective selected count for display (respects mode filter when selectAll)
   const effectiveCount = selectAll
@@ -99,6 +99,7 @@ export default function Evaluations() {
           setRunMessage(activeRun.message || 'Running tests...')
           setRunProgress({
             current_test: activeRun.current_test,
+            running_tests: activeRun.running_tests || [],
             completed_tests: activeRun.completed_tests || [],
             total_tests: activeRun.total_tests || 0,
           })

--- a/frontend/src/pages/evaluations/TestRunner.jsx
+++ b/frontend/src/pages/evaluations/TestRunner.jsx
@@ -437,12 +437,19 @@ export const RunProgress = ({ runMessage, runProgress }) => {
               <span className="text-gray-400">{formatDuration(t.duration_ms)}</span>
             </div>
           ))}
-          {runProgress.current_test && (
-            <div className="flex items-center gap-2 text-xs">
-              <Loader2 className="w-3.5 h-3.5 animate-spin text-blue-500" />
-              <span className="text-blue-700 font-medium">{runProgress.current_test}</span>
-            </div>
-          )}
+          {runProgress.running_tests && runProgress.running_tests.length > 0
+            ? runProgress.running_tests.map((name) => (
+                <div key={name} className="flex items-center gap-2 text-xs">
+                  <Loader2 className="w-3.5 h-3.5 animate-spin text-blue-500" />
+                  <span className="text-blue-700 font-medium">{name}</span>
+                </div>
+              ))
+            : runProgress.current_test && (
+                <div className="flex items-center gap-2 text-xs">
+                  <Loader2 className="w-3.5 h-3.5 animate-spin text-blue-500" />
+                  <span className="text-blue-700 font-medium">{runProgress.current_test}</span>
+                </div>
+              )}
         </div>
       )}
     </div>

--- a/frontend/src/pages/evaluations/useTestPolling.js
+++ b/frontend/src/pages/evaluations/useTestPolling.js
@@ -83,6 +83,7 @@ export default function useTestPolling({
           setRunMessage(status.message || 'Running tests...')
           setRunProgress({
             current_test: status.current_test,
+            running_tests: status.running_tests || [],
             completed_tests: status.completed_tests || [],
             total_tests: status.total_tests || 0,
           })


### PR DESCRIPTION
## Summary

- **Backend**: Replaced the sequential `for` loop in `evaluations_tests.py` with `ThreadPoolExecutor` + `as_completed()`, so selected tests run concurrently instead of one-by-one
- **DB model**: Added `running_tests` column (JSON array) to `TestBatchRun` to track which tests are currently active
- **Frontend**: Updated `RunProgress` component to show multiple spinner rows (one per running test) instead of a single `current_test`
- Default concurrency: **3 workers** (configurable via `PARALLEL_TEST_WORKERS` env var)

## Context

Each test already creates its own isolated test user (`t-<uuid>`) and DB session (`runner.with_db()`), so they're fully independent — no shared state between tests.

## Files Changed

| File | Change |
|------|--------|
| `druppie/db/models/test_batch_run.py` | Added `running_tests` Text column |
| `druppie/api/routes/evaluations_tests.py` | Parallel execution with ThreadPoolExecutor, `running_tests` in API responses |
| `frontend/src/pages/evaluations/TestRunner.jsx` | Multi-spinner progress display |
| `frontend/src/pages/evaluations/useTestPolling.js` | Pass `running_tests` through polling state |
| `frontend/src/pages/Evaluations.jsx` | Restore `running_tests` from active run |

## Testing

- LSP diagnostics: 0 errors across all Python files
- Backward compatible: if `running_tests` is empty/null, UI falls back to `current_test`
- DB: new column is nullable — no migration needed (reset DB if schema enforcement is strict)