### PR TITLE
fix(docker): add buildx plugin to nuke/reset container

### DIFF
--- a/Dockerfile.reset
+++ b/Dockerfile.reset
@@ -10,11 +10,14 @@ RUN apt-get update && apt-get install -y \
     docker.io \
     && rm -rf /var/lib/apt/lists/*
 
-# Install docker compose plugin
+# Install docker compose + buildx plugins
 RUN mkdir -p /usr/local/lib/docker/cli-plugins && \
     curl -SL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$(uname -m)" \
     -o /usr/local/lib/docker/cli-plugins/docker-compose && \
-    chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
+    curl -SL "https://github.com/docker/buildx/releases/download/v0.22.0/buildx-v0.22.0.linux-$(uname -m)" \
+    -o /usr/local/lib/docker/cli-plugins/docker-buildx && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
 
 # Install Python dependencies for setup scripts
 RUN pip install --no-cache-dir requests pyyaml


### PR DESCRIPTION
## Summary
- Adds Docker buildx v0.22.0 plugin to the nuke/reset container (`Dockerfile.reset`)
- The container already installs docker compose but was missing buildx, which recent compose versions require (>= 0.17.0)
- Fixes `compose build requires buildx 0.17.0 or later` error when running `docker compose --profile nuke run --rm nuke` with rootless Docker

## Test plan
- [ ] Run `docker compose --profile nuke run --rm nuke` and verify builds complete without buildx version error