### PR TITLE
feat: Azure SQL support for the data-access MCP

### DIFF
--- a/docs/MCP/data-access.md
+++ b/docs/MCP/data-access.md
@@ -16,28 +16,76 @@ tools. Replaces the standalone `module-azure-datalake` MCP.
 ## Configuration
 
 Data sources are declared via `DATA_SOURCE_1` … `DATA_SOURCE_9` in `.env`.
-Each entry is a single colon-delimited string: `type:name:config_parts...`.
-The MCP loads them at container startup (see
-`v1/module.py::_load_data_sources`); changes require a `docker compose up -d
---force-recreate --no-deps module-data-access` — a plain `restart` does not
-re-read `.env`.
+Each entry is a colon-delimited string `type:name:config_blob`. Only the
+leading `type` and `name` are split off (`split(":", 2)`); the remaining
+`config_blob` keeps every internal colon, so an ODBC connection string
+(`Server=tcp:host,1433;…`) survives intact. The MCP loads them at container
+startup (see `v1/module.py::_load_data_sources`); changes require a
+`docker compose up -d --force-recreate --no-deps module-data-access` — a
+plain `restart` does not re-read `.env`.
 
 | Source type | Format |
 |---|---|
 | Azure Data Lake (key) | `azure-datalake:<source_id>:<account_name>:<storage_key>` |
 | Azure Data Lake (public) | `azure-datalake:<source_id>:<account_name>` |
-| Azure SQL (connection string) | `azure-sql:<source_id>:<connection_string>` |
-| Azure SQL (OBO token) | `azure-sql-obo:<source_id>:<tenant_id>:<client_id>:<client_secret>:<scope>:<server>:<database>` |
+| Azure SQL (connection string) | `azure-sql:<source_id>:<odbc_connection_string>` |
+| Azure SQL (OBO token — interim) | `azure-sql-obo:<source_id>:<tenant_id>:<client_id>:<client_secret>:<scope>:<server>:<database>` |
 
-`<source_id>` is the handle agents pass back to every other tool. OBO tokens
-are fetched fresh per request and are **never** cached or persisted (see
-`adapter/base.py`).
+`<source_id>` is the handle agents pass back to every other tool.
 
-Example:
+> **Auth status.** `azure-datalake` (key / public) and `azure-sql`
+> (connection string, incl. service-principal auth) are supported and
+> tested. `azure-sql-obo` is **interim**: it currently runs an OAuth
+> `client_credentials` grant (one shared service identity), not a true
+> per-user on-behalf-of exchange — true OBO is a separate follow-up.
+
+Examples:
 
 ```dotenv
 DATA_SOURCE_1=azure-datalake:dlspublichhrhhskexp01:dlspublichhrhhskexp01:<base64-storage-key>
+DATA_SOURCE_3=azure-sql:synapsedwh:Driver={ODBC Driver 18 for SQL Server};Server=<ws>-ondemand.sql.azuresynapse.net;Database=<db>;Authentication=ActiveDirectoryServicePrincipal;UID=<client-id>;PWD=<client-secret>;Encrypt=yes;TrustServerCertificate=no;
 ```
+
+See [Azure SQL setup (Synapse serverless)](#azure-sql-setup-synapse-serverless)
+below for how to provision the endpoint and service principal.
+
+## Azure SQL setup (Synapse serverless)
+
+The `azure-sql` source type connects through `pyodbc` + the Microsoft
+**ODBC Driver 18** (installed in the MCP image — see `Dockerfile`). Steps to
+provision a serverless endpoint and a service principal for it:
+
+1. **Synapse workspace.** Create an Azure Synapse Analytics workspace (or
+   reuse one). The *serverless* SQL pool is built in; its endpoint is
+   `<workspace-name>-ondemand.sql.azuresynapse.net`.
+2. **Service principal.** In Microsoft Entra ID, register an application,
+   then create a client secret. Record the **tenant id**, **client (app)
+   id**, and **secret value**.
+3. **Database + grant.** In the serverless pool create a database, then
+   grant the service principal read access:
+   ```sql
+   -- run on the serverless endpoint, master context
+   CREATE LOGIN [<sp-display-name>] FROM EXTERNAL PROVIDER;
+   -- run in the target database
+   CREATE USER  [<sp-display-name>] FROM LOGIN [<sp-display-name>];
+   ALTER ROLE   db_datareader ADD MEMBER [<sp-display-name>];
+   ```
+   Grant **`db_datareader` only** — read-only is also what bounds the
+   `filter_expr` injection surface (see [Security boundaries](#security-boundaries)).
+4. **Storage access.** If the serverless pool reads lake data via
+   `OPENROWSET` / external tables, give the service principal
+   **Storage Blob Data Reader** on the backing ADLS account.
+5. **Firewall.** On the Synapse workspace, allow the Druppie host's IP (or
+   enable "Allow Azure services").
+6. **Configure the source.** Add to `.env` (single line):
+   ```dotenv
+   DATA_SOURCE_3=azure-sql:synapsedwh:Driver={ODBC Driver 18 for SQL Server};Server=<ws>-ondemand.sql.azuresynapse.net;Database=<db>;Authentication=ActiveDirectoryServicePrincipal;UID=<client-id>;PWD=<client-secret>;Encrypt=yes;TrustServerCertificate=no;
+   ```
+   `Authentication=ActiveDirectoryServicePrincipal` lets ODBC Driver 18 do
+   the token exchange — no manual token code runs for this path. Recreate
+   the container (`docker compose up -d --force-recreate --no-deps
+   module-data-access`) and confirm the startup log shows
+   `Loaded data source: synapsedwh (azure-sql)`.
 
 ## Tools
 
@@ -73,8 +121,21 @@ Builder when consuming sample data, most likely).
 - Azure SQL: empty path → tables; schema path → table list filtered.
 
 `read_data` filter syntax:
-- Azure SQL: SQL `WHERE` clause fragment.
+- Azure SQL: a SQL `WHERE`-clause **fragment** only (e.g. `Status = 'open'
+  AND Year >= 2020`). Statement terminators, comment markers and
+  stored-procedure calls are rejected — see [Security boundaries](#security-boundaries).
 - Azure Data Lake: pandas `DataFrame.query()` expression.
+
+### Azure SQL row caps
+
+`read_data` against Azure SQL caps unbounded reads so an agent cannot pull a
+whole Synapse table into the LLM context:
+
+- With no `limit`, the result is capped at **1000 rows**; `metadata.capped`
+  is `true` and `warnings[]` says so. Pass an explicit `limit` to read more.
+- `download_data` streams the full table to CSV in 5000-row batches (no
+  in-memory materialisation) with a hard **1,000,000-row** ceiling; if hit,
+  the CSV is truncated and `warnings[]` reports it.
 
 ### CSV robustness
 
@@ -103,17 +164,24 @@ Builder when consuming sample data, most likely).
   guard fires before the adapter is touched, so it does not depend on the
   source being reachable. Pinned by
   `testing/tools/data-access-download-data-path-traversal.yaml`.
+- **`filter_expr` is a WHERE-clause fragment, not arbitrary SQL.** The
+  Azure SQL adapter rejects a `filter_expr` containing statement
+  terminators (`;`), comment markers (`--`, `/*`), batch separators
+  (`GO`) or stored-procedure calls (`xp_`, `sp_`, `EXEC`) before it is
+  appended to the query (`AzureSQLAdapter._validate_filter`). Defence in
+  depth — the configured SQL principal should also be `db_datareader`
+  only, which bounds anything that slips through to read-only.
 - **No OBO token caching**. Azure SQL OBO adapters obtain a fresh token per
   call. There is no persistence layer or in-memory cache. Reviewers should
   treat any change to that behavior as a security-sensitive diff.
 - **Secrets in `.env`**. Storage keys and client secrets live only in the
   process environment; they are not stored in the database or surfaced to
-  agents. `list_sources` returns `auth_type` (`key`, `connection-string`,
+  agents. `list_sources` returns `auth_type` (`key`, `connection_string`,
   `obo`) but not the credential itself.
 
 ## Testing
 
-The MCP is covered by 13 YAML tool tests in `testing/tools/data-access-*.yaml`.
+The MCP is covered by 16 YAML tool tests in `testing/tools/data-access-*.yaml`.
 Run them via the evaluations endpoint (admin token required):
 
 ```bash
@@ -151,6 +219,19 @@ Azure Data Lake account, with the seeded `dwhpublic/HHR/` content present.
 | `data-access-get-schema-csv` | Schema for `VW_HHR_Fudura_MeteringPoints.csv` exposes `meteringPointId`, `channelId`, etc. |
 | `data-access-read-data-with-limit` | `limit: 2` returns 2 rows with `"limited": true` and the column metadata. |
 | `data-access-download-data-success` | The CSV lands in `/workspaces/default/<project_id>/<session_id>/data/metering-points.csv` with non-zero `size_bytes`. |
+
+### Azure SQL (3, tagged `live` + `azure-sql`)
+
+These need an `azure-sql` source named `synapsedwh` configured via
+`DATA_SOURCE_N` (see [Azure SQL setup](#azure-sql-setup-synapse-serverless)).
+`data-access-sql-filter-rejected` passes even if the endpoint is
+unreachable — the filter guard runs before the connection is opened.
+
+| Test | What it pins |
+|---|---|
+| `data-access-sql-test-connection` | `test_connection` actually reaches the SQL endpoint and runs `SELECT 1`. |
+| `data-access-sql-list-tables` | `list_available_data` enumerates tables from `INFORMATION_SCHEMA.TABLES`. |
+| `data-access-sql-filter-rejected` | `read_data` rejects a `filter_expr` containing `;` with a `WHERE-clause` error. |
 
 All assertions use `{matches: "\"success\"\\s*:\\s*(true|false)"}` so they
 remain robust to JSON whitespace.

--- a/druppie/mcp-servers/module-data-access/Dockerfile
+++ b/druppie/mcp-servers/module-data-access/Dockerfile
@@ -2,10 +2,16 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
-    unixodbc-dev \
-    gcc \
-    curl \
+# Microsoft ODBC Driver 18 is required by pyodbc for Azure SQL / Synapse.
+# python:3.11-slim is Debian 12 (bookworm), so use the bookworm prod repo.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        unixodbc-dev gcc curl gnupg ca-certificates \
+    && curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+        | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" \
+        > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update \
+    && ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY module-data-access/requirements.txt .

--- a/druppie/mcp-servers/module-data-access/v1/adapter/azure_sql.py
+++ b/druppie/mcp-servers/module-data-access/v1/adapter/azure_sql.py
@@ -4,6 +4,7 @@ Supports OBO token authentication via Keycloak.
 """
 
 import logging
+import re
 from typing import Any
 
 import pyodbc
@@ -11,6 +12,26 @@ import pyodbc
 from .base import BaseDataSourceAdapter, DataSourceInfo, DataItem, SchemaInfo
 
 logger = logging.getLogger("dataaccess-mcp")
+
+# When read_data is called without an explicit limit, cap the result so an
+# agent can't pull an entire Synapse table into the LLM context by accident.
+DEFAULT_ROW_CAP = 1000
+
+# Hard ceiling for download_data so a runaway table can't exhaust memory /
+# disk in the MCP container.
+DOWNLOAD_ROW_CAP = 1_000_000
+
+# Rows fetched per round-trip while streaming a download.
+DOWNLOAD_BATCH_SIZE = 5000
+
+# filter_expr is a WHERE-clause fragment, not arbitrary SQL. Reject tokens
+# that would let it break out of the clause (statement terminators, comment
+# markers, batch separators, extended stored procedures). Defence in depth —
+# the configured SQL principal should also be db_datareader only.
+_FILTER_FORBIDDEN = re.compile(
+    r";|--|/\*|\*/|\bxp_|\bsp_|\bexec\b|\bexecute\b|\bgo\b",
+    re.IGNORECASE,
+)
 
 
 class AzureSQLAdapter(BaseDataSourceAdapter):
@@ -63,6 +84,32 @@ class AzureSQLAdapter(BaseDataSourceAdapter):
 
         self._connection = pyodbc.connect(conn_str)
         return self._connection
+
+    async def _ensure_connection(self):
+        """Prove connectivity for the inherited test_connection().
+
+        The base class test_connection() only awaits _ensure_connection();
+        without this override it would hit the base no-op and report success
+        even when the database is unreachable. Open a real connection and run
+        a trivial query so a failure surfaces honestly.
+        """
+        conn = await self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT 1")
+        cursor.fetchone()
+
+    @staticmethod
+    def _validate_filter(filter_expr: str) -> None:
+        """Reject a filter_expr that tries to break out of the WHERE clause.
+
+        Raises ValueError on a forbidden token.
+        """
+        if _FILTER_FORBIDDEN.search(filter_expr):
+            raise ValueError(
+                "filter_expr must be a plain WHERE-clause fragment — "
+                "statement terminators, comments and stored-procedure "
+                "calls are not allowed"
+            )
 
     async def _fetch_obo_token(self) -> str:
         """Fetch fresh OBO token from Keycloak.
@@ -179,48 +226,61 @@ class AzureSQLAdapter(BaseDataSourceAdapter):
         limit: int | None = None,
         offset: int | None = None,
     ) -> dict:
-        """Read data from a table with optional filtering and limiting."""
+        """Read data from a table with optional filtering and limiting.
+
+        When no limit is given the result is capped at DEFAULT_ROW_CAP so an
+        agent cannot accidentally pull an entire table into context; the cap
+        is reported in warnings[] and metadata.capped.
+        """
         try:
             schema, table_name = data_id.split(".", 1)
+            if filter_expr:
+                self._validate_filter(filter_expr)
+
+            warnings: list[str] = []
+            capped = limit is None
+            effective_limit = limit if limit is not None else DEFAULT_ROW_CAP
+
             conn = await self._get_connection()
             cursor = conn.cursor()
 
             query = f"SELECT * FROM [{schema}].[{table_name}]"
-            params = []
+            params: list = []
 
             if filter_expr:
                 query += f" WHERE {filter_expr}"
 
-            if limit is not None:
-                if offset is not None:
-                    query += f" ORDER BY (SELECT NULL) OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
-                    params.extend([offset, limit])
-                else:
-                    query += f" ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY"
-                    params.append(limit)
-            elif offset is not None:
-                query += f" ORDER BY (SELECT NULL) OFFSET ? ROWS"
-                params.append(offset)
+            query += " ORDER BY (SELECT NULL) OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+            params.extend([offset or 0, effective_limit])
 
             cursor.execute(query, params)
 
             columns = [desc[0] for desc in cursor.description]
             rows = cursor.fetchall()
-
             data = [{col: value for col, value in zip(columns, row)} for row in rows]
+
+            if capped and len(data) == effective_limit:
+                warnings.append(
+                    f"No limit was given — result capped at {DEFAULT_ROW_CAP} "
+                    "rows. Pass an explicit 'limit' to read more."
+                )
 
             return {
                 "success": True,
                 "data": data,
                 "row_count": len(data),
                 "columns": columns,
+                "warnings": warnings,
                 "metadata": {
                     "table": f"{schema}.{table_name}",
                     "filtered": filter_expr is not None,
                     "limited": limit is not None,
                     "offset": offset,
+                    "capped": capped and len(data) == effective_limit,
                 },
             }
+        except ValueError as e:
+            return {"success": False, "error": str(e)}
         except Exception as e:
             return {"success": False, "error": str(e)}
 
@@ -229,24 +289,51 @@ class AzureSQLAdapter(BaseDataSourceAdapter):
         data_id: str,
         destination_path: str,
     ) -> dict:
-        """Download table data as CSV."""
+        """Download a full table to CSV, streaming in batches.
+
+        Rows are fetched DOWNLOAD_BATCH_SIZE at a time and written
+        incrementally so a large table does not have to be materialised in
+        memory. A hard DOWNLOAD_ROW_CAP guards against a runaway table.
+        """
         try:
             import csv
 
-            result = await self.read_data(data_id)
+            schema, table_name = data_id.split(".", 1)
+            conn = await self._get_connection()
+            cursor = conn.cursor()
+            cursor.execute(f"SELECT * FROM [{schema}].[{table_name}]")
 
-            if not result["success"]:
-                return result
+            columns = [desc[0] for desc in cursor.description]
+            row_count = 0
+            truncated = False
+            warnings: list[str] = []
 
             with open(destination_path, "w", newline="") as f:
-                writer = csv.DictWriter(f, fieldnames=result["columns"])
-                writer.writeheader()
-                writer.writerows(result["data"])
+                writer = csv.writer(f)
+                writer.writerow(columns)
+                while True:
+                    batch = cursor.fetchmany(DOWNLOAD_BATCH_SIZE)
+                    if not batch:
+                        break
+                    if row_count + len(batch) > DOWNLOAD_ROW_CAP:
+                        batch = batch[: DOWNLOAD_ROW_CAP - row_count]
+                        truncated = True
+                    writer.writerows(batch)
+                    row_count += len(batch)
+                    if truncated:
+                        break
+
+            if truncated:
+                warnings.append(
+                    f"Table exceeded the {DOWNLOAD_ROW_CAP}-row download cap; "
+                    "the CSV is truncated."
+                )
 
             return {
                 "success": True,
                 "destination": destination_path,
-                "row_count": result["row_count"],
+                "row_count": row_count,
+                "warnings": warnings,
             }
         except Exception as e:
             return {"success": False, "error": str(e)}

--- a/druppie/mcp-servers/module-data-access/v1/module.py
+++ b/druppie/mcp-servers/module-data-access/v1/module.py
@@ -25,11 +25,16 @@ class DataAccessModule:
     def _load_data_sources(self):
         """Load data sources from environment variables.
 
-        Format: DATA_SOURCE_1=type:name:config_parts...
+        Format: DATA_SOURCE_1=type:name:config_blob
 
-        Azure Data Lake: azure-datalake:name:account_name:key
+        Only the type and name are split off the front (split(":", 2)); the
+        remaining config_blob keeps every internal colon. This matters for
+        Azure SQL — connection strings contain colons (e.g. Server=tcp:host)
+        that a naive split would shred.
+
+        Azure Data Lake: azure-datalake:name:account_name[:key]
         Azure SQL (conn string): azure-sql:name:connection_string
-        Azure SQL (OBO): azure-sql-obo:name:tenant_id:client_id:client_secret:scope:server:database
+        Azure SQL (OBO): azure-sql-obo:name:tenant:client:secret:scope:server:database
         """
         for i in range(1, 10):
             config_str = os.getenv(f"DATA_SOURCE_{i}")
@@ -37,39 +42,56 @@ class DataAccessModule:
                 continue
 
             try:
-                parts = config_str.split(":")
-                source_type = parts[0]
-                name = parts[1]
+                head = config_str.split(":", 2)
+                if len(head) < 3:
+                    raise ValueError(
+                        "expected 'type:name:config_blob' (at least 3 "
+                        "colon-separated parts)"
+                    )
+                source_type, name, config_blob = head
 
                 if source_type == "azure-datalake":
+                    # config_blob is account_name[:key]; neither contains a
+                    # colon, so a single maxsplit recovers both.
+                    dl_parts = config_blob.split(":", 1)
                     config = {
                         "source_id": name,
                         "name": name,
-                        "account_name": parts[2],
-                        "key": parts[3] if len(parts) > 3 else None,
+                        "account_name": dl_parts[0],
+                        "key": dl_parts[1] if len(dl_parts) > 1 else None,
                     }
                     adapter = AzureDataLakeAdapter(config)
 
                 elif source_type == "azure-sql":
+                    # config_blob is the full ODBC connection string,
+                    # colons and all.
                     config = {
                         "source_id": name,
                         "name": name,
-                        "connection_string": parts[2],
+                        "connection_string": config_blob,
                     }
                     adapter = AzureSQLAdapter(config)
 
                 elif source_type == "azure-sql-obo":
+                    # Interim client_credentials flow — true on-behalf-of and
+                    # a colon-safe config format are a separate follow-up.
+                    obo = config_blob.split(":")
+                    if len(obo) < 6:
+                        raise ValueError(
+                            "azure-sql-obo expects "
+                            "tenant:client:secret:scope:server:database"
+                        )
                     config = {
                         "source_id": name,
                         "name": name,
                         "use_obo": True,
                         "obo_config": {
-                            "tenant_id": parts[2],
-                            "client_id": parts[3],
-                            "client_secret": parts[4],
-                            "scope": parts[5],
-                            "server": parts[6],
-                            "database": parts[7],
+                            "tenant_id": obo[0],
+                            "client_id": obo[1],
+                            "client_secret": obo[2],
+                            "scope": obo[3],
+                            "server": obo[4],
+                            "database": obo[5],
                         },
                     }
                     adapter = AzureSQLAdapter(config)

--- a/testing/tools/data-access-sql-filter-rejected.yaml
+++ b/testing/tools/data-access-sql-filter-rejected.yaml
@@ -1,0 +1,23 @@
+## Tool Test: Data Access MCP - filter_expr injection guard (live)
+## Verifies read_data rejects a filter_expr that tries to break out of the
+## WHERE clause. The guard runs before the DB connection is opened, so this
+## passes even if the Synapse endpoint is unreachable — it only needs an
+## azure-sql source named "synapsedwh" to be configured.
+
+tool-test:
+  name: data-access-sql-filter-rejected
+  description: "read_data rejects a filter_expr containing a statement terminator"
+  tags: [data-access, mcp, azure-sql, error-handling, security, live]
+
+  chain:
+    - agent: router
+      tool: dataaccess:read_data
+      arguments:
+        source_id: "synapsedwh"
+        data_id: "dbo.anytable"
+        filter_expr: "1=1; DROP TABLE dbo.anytable"
+      assert:
+        result:
+          - json_parseable
+          - {matches: "\"success\"\\s*:\\s*false"}
+          - {contains: "WHERE-clause"}

--- a/testing/tools/data-access-sql-list-tables.yaml
+++ b/testing/tools/data-access-sql-list-tables.yaml
@@ -1,0 +1,21 @@
+## Tool Test: Data Access MCP - list_available_data against Azure SQL (live)
+## Verifies list_available_data enumerates tables from
+## INFORMATION_SCHEMA.TABLES on the configured Azure SQL source.
+## Requires DATA_SOURCE_N=azure-sql:synapsedwh:<connection-string>.
+
+tool-test:
+  name: data-access-sql-list-tables
+  description: "list_available_data lists tables from the configured Azure SQL source"
+  tags: [data-access, mcp, azure-sql, live]
+
+  chain:
+    - agent: router
+      tool: dataaccess:list_available_data
+      arguments:
+        source_id: "synapsedwh"
+      assert:
+        result:
+          - json_parseable
+          - {matches: "\"success\"\\s*:\\s*true"}
+          - {contains: "data_items"}
+          - {contains: "count"}

--- a/testing/tools/data-access-sql-test-connection.yaml
+++ b/testing/tools/data-access-sql-test-connection.yaml
@@ -1,0 +1,20 @@
+## Tool Test: Data Access MCP - test_connection against Azure SQL (live)
+## Verifies test_connection actually reaches an Azure SQL / Synapse
+## serverless endpoint configured as an azure-sql DATA_SOURCE_N.
+## Requires DATA_SOURCE_N=azure-sql:synapsedwh:<connection-string>.
+
+tool-test:
+  name: data-access-sql-test-connection
+  description: "test_connection against the configured Azure SQL source returns success"
+  tags: [data-access, mcp, azure-sql, live]
+
+  chain:
+    - agent: router
+      tool: dataaccess:test_connection
+      arguments:
+        source_id: "synapsedwh"
+      assert:
+        result:
+          - json_parseable
+          - {matches: "\"success\"\\s*:\\s*true"}
+          - {contains: "Successfully connected"}


### PR DESCRIPTION
## Summary

Follow-up to #198 (data-access MCP), which shipped **only Azure Data Lake**.
The `AzureSQLAdapter` was written but unusable. This PR makes the
**connection-string / service-principal** path work against an Azure SQL or
**Synapse serverless** endpoint, and fixes the blockers a code read turned up.

> **Scope:** this PR delivers Azure SQL via service-principal /
> connection-string auth. **True per-user on-behalf-of** auth (replacing the
> interim `azure-sql-obo` `client_credentials` flow) remains a **separate
> follow-up** — the `azure-sql-obo` path is left functional and labelled
> interim in the docs.

## Blockers fixed

| # | Blocker | Fix |
|---|---|---|
| 1 | **Config parsing shredded connection strings** — `_load_data_sources` split the whole `DATA_SOURCE_N` value on *every* colon, so an ODBC string (`Server=tcp:host,1433;…`) lost everything after the first inner colon. | Split only `type:name` off the front (`split(":", 2)`); the `config_blob` keeps its colons. Data Lake parsing unchanged. |
| 2 | **No ODBC driver in the image** — every `pyodbc.connect()` failed with "driver not found". | `Dockerfile` adds Microsoft's bookworm prod repo and installs `msodbcsql18`. |
| 3 | **`test_connection` silently lied for SQL** — the base impl awaits `_ensure_connection()`, which `AzureSQLAdapter` never overrode, so it hit the base no-op and reported success without connecting. | Added `_ensure_connection()` that opens a connection and runs `SELECT 1`. |
| 4 | **`read_data` / `download_data` unbounded** — a large Synapse table would OOM the container. | `read_data` caps an unlimited query at 1000 rows (`warnings[]` + `metadata.capped`); `download_data` streams to CSV in 5000-row batches with a 1,000,000-row hard ceiling. |
| 5 | **`filter_expr` raw-interpolated** into `WHERE {…}`. | `_validate_filter` rejects statement terminators, comment markers, batch separators and stored-procedure calls before the fragment is appended; the SQL principal should also be `db_datareader` only (documented). |

## Also included

- **3 azure-sql tool tests** (tagged `live` + `azure-sql`):
  `test_connection`, `list_available_data`, and filter-injection rejection.
  The last passes even against an unreachable endpoint — the guard runs
  pre-connect.
- **Docs** — `docs/MCP/data-access.md` gains an "Azure SQL setup (Synapse
  serverless)" section: workspace, service principal, `db_datareader` grant,
  storage access, firewall, and the connection-string format; plus the
  row-cap notes and the `filter_expr` security boundary.

## Test plan

| Check | Result |
|---|---|
| Image builds with `msodbcsql18` | ✅ `odbcinst -q -d` → `[ODBC Driver 18 for SQL Server]` |
| Config parser — `azure-sql` with a colon-laden connection string | ✅ loads, appears in `list_sources` as `auth_type: connection_string` |
| Data Lake regression (7 env-agnostic tool tests) | ✅ 7/7 pass — `split(":", 2)` didn't disturb Data Lake parsing |
| `filter_expr` injection (`1=1; DROP TABLE …`) | ✅ rejected pre-connect with a "WHERE-clause fragment" error |
| `test_connection` against an unreachable endpoint | ✅ fails honestly (ODBC login timeout) instead of falsely succeeding |

**Not tested:** live happy-path tools (`get_schema`, `read_data`,
`download_data` against real tables) — these need a provisioned Synapse
serverless instance. The 3 `live`-tagged SQL tests are runnable once
`DATA_SOURCE_N=azure-sql:synapsedwh:…` is set; see the new docs section for
provisioning steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)