### PR TITLE
feat(api): add GET /api/test-health-check endpoint

### DIFF
--- a/druppie/api/main.py
+++ b/druppie/api/main.py
@@ -5,6 +5,7 @@ Main entry point for the API.
 
 import os
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -286,6 +287,15 @@ def create_app() -> FastAPI:
             "agents_count": len(agents),
             "llm_provider": llm_provider,
             "llm_profiles": llm_profiles,
+        }
+
+    @app.get("/api/test-health-check")
+    async def test_health_check():
+        """Test health check endpoint for verifying Druppie service status."""
+        return {
+            "status": "ok",
+            "service": "druppie",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
     @app.get("/")


### PR DESCRIPTION
## Summary

Adds a new `GET /api/test-health-check` endpoint that returns service health status with a timestamp.

### Endpoint Response
```json
{
  "status": "ok",
  "service": "druppie",
  "timestamp": "2025-01-01T00:00:00+00:00"
}
```

### Changes
- Added `GET /api/test-health-check` endpoint in `druppie/api/main.py`
- Imported `datetime` and `timezone` from the `datetime` module
- Follows existing health endpoint patterns (plain dict response, async def, no auth)

### Testing
- No test framework detected in the project
- Implementation follows existing patterns from `/health`, `/health/ready`, and `/api/status` endpoints