### PR TITLE
Wire up surfaced file writes in chat timeline

### DIFF
--- a/frontend/src/components/chat/ChatHelpers.jsx
+++ b/frontend/src/components/chat/ChatHelpers.jsx
@@ -418,7 +418,7 @@ export const extractSurfacedFileWrites = (agentRun) => {
       const toolName = tc.tool_name || ''
       const args = tc.arguments || {}
 
-      if (toolName.includes('write_file') && !toolName.includes('batch')) {
+      if ((toolName.includes('write_file') || toolName.includes('make_design')) && !toolName.includes('batch')) {
         if (args.path && args.content) {
           files.push({ path: args.path, content: args.content })
         }

--- a/frontend/src/components/chat/ChatHelpers.jsx
+++ b/frontend/src/components/chat/ChatHelpers.jsx
@@ -418,7 +418,7 @@ export const extractSurfacedFileWrites = (agentRun) => {
       const toolName = tc.tool_name || ''
       const args = tc.arguments || {}
 
-      if ((toolName.includes('write_file') || toolName.includes('make_design')) && !toolName.includes('batch')) {
+      if ((toolName.includes('write_file') || toolName === 'make_design' || toolName.endsWith(':make_design')) && !toolName.includes('batch')) {
         if (args.path && args.content) {
           files.push({ path: args.path, content: args.content })
         }

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -308,13 +308,39 @@ const TimelineQuestion = ({ tc, agentId, sessionId }) => {
 
 // --- Agent Run ---
 
+const SurfacedFileCard = ({ files }) => {
+  const [showPreview, setShowPreview] = useState(false)
+  if (!files || files.length === 0) return null
+
+  const label = files.length === 1
+    ? files[0].path.split('/').pop()
+    : `${files.length} files`
+
+  return (
+    <div className="mt-2 pl-8">
+      <button
+        onClick={() => setShowPreview(true)}
+        className="flex items-center gap-2 px-3 py-2 text-sm rounded-lg border border-gray-200 bg-white hover:bg-gray-50 hover:border-gray-300 transition-colors text-gray-700"
+      >
+        <FileCode className="w-4 h-4 text-blue-500 flex-shrink-0" />
+        <span className="truncate">{label}</span>
+        <ExternalLink className="w-3 h-3 text-gray-400 flex-shrink-0" />
+      </button>
+      {showPreview && (
+        <FilePreviewModal files={files} onClose={() => setShowPreview(false)} />
+      )}
+    </div>
+  )
+}
+
 const AgentRunItem = ({ run, timelineIndex, sessionId, hasFollowingMessage, sessionUserId }) => {
   const orderedItems = extractOrderedItems(run, hasFollowingMessage)
+  const surfacedFiles = extractSurfacedFileWrites(run)
 
   // Show agent trace for completed runs that have no following message
   const showAgentTrace = !hasFollowingMessage && run.status !== 'running'
 
-  if (!showAgentTrace && orderedItems.length === 0) return null
+  if (!showAgentTrace && orderedItems.length === 0 && surfacedFiles.length === 0) return null
 
   const config = getAgentConfig(run.agent_id)
   const AgentIcon = config.icon
@@ -363,6 +389,9 @@ const AgentRunItem = ({ run, timelineIndex, sessionId, hasFollowingMessage, sess
         }
         return null
       })}
+      {surfacedFiles.length > 0 && (
+        <SurfacedFileCard files={surfacedFiles} />
+      )}
     </div>
   )
 }
@@ -1041,9 +1070,10 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
 
                 const hasFollowingMessage = runsWithMessages.has(i)
                 const orderedItems = extractOrderedItems(entry.agent_run, hasFollowingMessage)
+                const surfacedFiles = extractSurfacedFileWrites(entry.agent_run)
                 // Show completed runs without a following message (e.g. architect)
                 const isCompletedWithoutMessage = !hasFollowingMessage && entry.agent_run.status !== 'running'
-                if (orderedItems.length === 0 && !isCompletedWithoutMessage) {
+                if (orderedItems.length === 0 && surfacedFiles.length === 0 && !isCompletedWithoutMessage) {
                   return null
                 }
                 return (

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -28,6 +28,7 @@ import {
   findPendingQuestion,
   ProjectRepoContext,
 } from './ChatHelpers'
+import SurfacedFileCard from './SurfacedFileCard'
 import TestResultCard from './TestResultCard'
 import SandboxEventCard, {
   processEvents,
@@ -308,39 +309,13 @@ const TimelineQuestion = ({ tc, agentId, sessionId }) => {
 
 // --- Agent Run ---
 
-const SurfacedFileCard = ({ files }) => {
-  const [showPreview, setShowPreview] = useState(false)
-  if (!files || files.length === 0) return null
-
-  const label = files.length === 1
-    ? files[0].path.split('/').pop()
-    : `${files.length} files`
-
-  return (
-    <div className="mt-2 pl-8">
-      <button
-        onClick={() => setShowPreview(true)}
-        className="flex items-center gap-2 px-3 py-2 text-sm rounded-lg border border-gray-200 bg-white hover:bg-gray-50 hover:border-gray-300 transition-colors text-gray-700"
-      >
-        <FileCode className="w-4 h-4 text-blue-500 flex-shrink-0" />
-        <span className="truncate">{label}</span>
-        <ExternalLink className="w-3 h-3 text-gray-400 flex-shrink-0" />
-      </button>
-      {showPreview && (
-        <FilePreviewModal files={files} onClose={() => setShowPreview(false)} />
-      )}
-    </div>
-  )
-}
-
-const AgentRunItem = ({ run, timelineIndex, sessionId, hasFollowingMessage, sessionUserId }) => {
+const AgentRunItem = ({ run, timelineIndex, sessionId, hasFollowingMessage, sessionUserId, surfacedFiles }) => {
   const orderedItems = extractOrderedItems(run, hasFollowingMessage)
-  const surfacedFiles = extractSurfacedFileWrites(run)
 
   // Show agent trace for completed runs that have no following message
   const showAgentTrace = !hasFollowingMessage && run.status !== 'running'
 
-  if (!showAgentTrace && orderedItems.length === 0 && surfacedFiles.length === 0) return null
+  if (!showAgentTrace && orderedItems.length === 0 && (!surfacedFiles || surfacedFiles.length === 0)) return null
 
   const config = getAgentConfig(run.agent_id)
   const AgentIcon = config.icon
@@ -1084,6 +1059,7 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
                       sessionId={sessionId}
                       hasFollowingMessage={hasFollowingMessage}
                       sessionUserId={data?.user_id}
+                      surfacedFiles={surfacedFiles}
                     />
                     {renderAnnotation(i)}
                   </div>

--- a/frontend/src/components/chat/SurfacedFileCard.jsx
+++ b/frontend/src/components/chat/SurfacedFileCard.jsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import { FileCode, ExternalLink } from 'lucide-react'
+import { FilePreviewModal } from './ApprovalCard'
+
+const SurfacedFileCard = ({ files }) => {
+  const [showPreview, setShowPreview] = useState(false)
+  if (!files || files.length === 0) return null
+
+  const label = files.length === 1
+    ? files[0].path.split('/').pop()
+    : `${files.length} bestanden`
+
+  return (
+    <div className="mt-2 pl-8">
+      <button
+        onClick={() => setShowPreview(true)}
+        className="flex items-center gap-2 px-3 py-2 text-sm rounded-lg border border-gray-200 bg-white hover:bg-gray-50 hover:border-gray-300 transition-colors text-gray-700"
+      >
+        <FileCode className="w-4 h-4 text-blue-500 flex-shrink-0" />
+        <span className="truncate">{label}</span>
+        <ExternalLink className="w-3 h-3 text-gray-400 flex-shrink-0" />
+      </button>
+      {showPreview && (
+        <FilePreviewModal files={files} onClose={() => setShowPreview(false)} />
+      )}
+    </div>
+  )
+}
+
+export default SurfacedFileCard

--- a/frontend/src/utils/agentConfig.js
+++ b/frontend/src/utils/agentConfig.js
@@ -17,8 +17,8 @@ import {
 export const AGENT_CONFIG = {
   router: { name: 'Router', icon: Brain, color: 'purple', description: 'Intent analysis', thinkingLabel: 'Analyzing intent...' },
   planner: { name: 'Planner', icon: Clock, color: 'blue', description: 'Execution planning', thinkingLabel: 'Planning execution...' },
-  business_analyst: { name: 'Business Analyst', icon: ClipboardList, color: 'teal', description: 'Requirements gathering', thinkingLabel: 'Creating functional design...' },
-  architect: { name: 'Architect', icon: Brain, color: 'indigo', description: 'System design', thinkingLabel: 'Creating technical design...' },
+  business_analyst: { name: 'Business Analyst', icon: ClipboardList, color: 'teal', description: 'Requirements gathering', thinkingLabel: 'Creating functional design...', surfaceFileWrites: true },
+  architect: { name: 'Architect', icon: Brain, color: 'indigo', description: 'System design', thinkingLabel: 'Creating technical design...', surfaceFileWrites: true },
   developer: { name: 'Developer', icon: FileCode, color: 'green', description: 'Code generation', thinkingLabel: 'Writing code...' },
   code_generator: { name: 'Code Generator', icon: FileCode, color: 'green', description: 'Code generation', thinkingLabel: 'Writing code...' },
   devops: { name: 'DevOps', icon: Hammer, color: 'orange', description: 'Build & deploy', thinkingLabel: 'Preparing deployment...' },

--- a/frontend/src/utils/agentConfig.js
+++ b/frontend/src/utils/agentConfig.js
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react'
 
 // Agent name formatting and icons
+// surfaceFileWrites: show file-write cards in chat for non-gated agents (no approval step)
 export const AGENT_CONFIG = {
   router: { name: 'Router', icon: Brain, color: 'purple', description: 'Intent analysis', thinkingLabel: 'Analyzing intent...' },
   planner: { name: 'Planner', icon: Clock, color: 'blue', description: 'Execution planning', thinkingLabel: 'Planning execution...' },


### PR DESCRIPTION
## Summary

- Wires up the previously dead `extractSurfacedFileWrites` function and `FilePreviewModal` in the chat timeline, so agents with `surfaceFileWrites: true` show clickable file cards for non-approval-gated writes
- Adds `SurfacedFileCard` component — a compact inline card that opens the full `FilePreviewModal` with markdown preview/raw toggle on click
- Extends `extractSurfacedFileWrites` to also match `make_design` tool calls (alongside `write_file`/`batch_write_files`)
- Enables `surfaceFileWrites` flag on `business_analyst` and `architect` agent configs as future-proofing

## Context on #48

The original issue was filed when the approval gate was removed from BA/architect's `make_design` tool — at that point the FD file was no longer visible in the UI. The approval gate has since been **re-added** (`required_role: session_owner`), so the file is already visible again through the approval card's built-in file preview.

This PR provides a safety net: if the approval gate is ever removed again, the `surfaceFileWrites` flag ensures the file remains visible. The primary immediate beneficiary is `builder_planner`, which uses plain `write_file` without an approval gate and already had the flag enabled but the rendering code was dead.

Closes #48

## Test plan

- [x] Ran `ba-cooperative-full-fd` evaluation test — verified BA writes FD via `make_design` with approval gate, file is visible through approval card
- [x] Confirmed no duplication: approval-gated writes are shown only in the approval card, not duplicated by the surfaced file card
- [x] Verified syntax with esbuild transform check

🤖 Generated with [Claude Code](https://claude.com/claude-code)