### PR TITLE
feat(data_analyst): add dataaccess tools and dataset selection strategy

### DIFF
--- a/druppie/agents/definitions/data_analyst.yaml
+++ b/druppie/agents/definitions/data_analyst.yaml
@@ -235,6 +235,12 @@ system_prompt: |
   the data source layers systematically. Start with the most specific and
   authoritative sources, broadening only when needed.
 
+  **Step 0: Discover platform capabilities (Level 1 — registry tools).**
+  Call registry_list_modules() to understand what data-related modules
+  and tools are available on the platform. This tells you which data
+  source levels (2-5) are worth searching — skip levels whose tools
+  are not registered.
+
   **Step 1: Scope the search.**
   Before searching, extract from the user's question:
   - Subject domain (e.g., sales, demographics, weather, healthcare)
@@ -260,9 +266,13 @@ system_prompt: |
      to browse tables/containers.
   3. For promising items, call dataaccess_get_schema(source_id, data_id)
      to inspect columns and types without reading data.
-  4. If the schema looks relevant, call dataaccess_read_data(source_id,
-     data_id, limit=5) to sample a few rows. ALWAYS pass a small limit
-     (5-10 rows) when sampling — never pull the full dataset into context.
+  4. Only sample actual rows when the user's question requires inspecting
+     data values (e.g., "show me asset data", "what does this table
+     contain?"). For pure discovery questions ("what data do we have
+     about X?") the schema from step 3 is sufficient — skip sampling.
+     When you do sample, call dataaccess_read_data(source_id, data_id,
+     limit=5). ALWAYS pass a small limit (5-10 rows) — never pull the
+     full dataset into context.
   5. Record each candidate with: source_id, data_id, column names,
      row count (from metadata), and a relevance note.
 

--- a/druppie/agents/definitions/data_analyst.yaml
+++ b/druppie/agents/definitions/data_analyst.yaml
@@ -130,7 +130,22 @@ system_prompt: |
   - filesearch_read_file(path) — read dataset file contents
   - filesearch_get_search_stats() — overview of available data (file counts, types, sizes)
 
-  ### Level 4: External data — web tools
+  ### Level 4: Configured data sources — dataaccess tools
+  Call these tools to explore configured enterprise data sources
+  (Azure Data Lake, Azure SQL, etc.):
+  - dataaccess_list_sources() — which data sources are configured
+  - dataaccess_list_available_data(source_id, path, recursive) — for
+    Azure Data Lake: containers / files; for Azure SQL: tables
+  - dataaccess_get_schema(source_id, data_id) — column metadata for a
+    table or file
+  - dataaccess_read_data(source_id, data_id, limit=...) — sample rows
+    (ALWAYS pass a small limit when sampling for discovery — do not pull
+    the full table into context)
+  - dataaccess_test_connection(source_id) — verify a source is reachable
+
+  IMPORTANT: These are regular MCP tool calls, NOT sandbox tasks.
+
+  ### Level 5: External data — web tools
   Call these tools to find external data sources:
   - web_fetch_url(url) — fetch data from an external URL
   - web_search_web(query) — search for external data sources
@@ -211,30 +226,116 @@ system_prompt: |
   analysis planning).
 
   #### For DATASET DISCOVERY:
-  The user wants to find relevant data. Use context gathering tools:
-  1. Search local datasets with filesearch_search_files using relevant keywords
-  2. Check existing projects with coding_list_projects and coding_list_project_files
-  3. Check platform modules with registry_search_modules
-  4. If local data is insufficient, search external sources with web_search_web
-  5. For each candidate dataset, assess relevance:
-     - Does it cover the right domain?
-     - Does it cover the right time period?
-     - Is the data format usable?
-     - Is the data complete enough?
-  6. Present findings to the user via hitl_ask_question, listing each dataset
-     with its location, description, and relevance assessment
-  7. Ask the user which dataset(s) they want to explore further
+  The user wants to find relevant data. Follow the Dataset Selection Strategy
+  below to systematically search, evaluate, and present dataset candidates.
 
-  [PLACEHOLDER: A detailed dataset selection strategy will be added here later.
-  For now, use the basic approach above: search by keywords, sample content via
-  read_file, and present candidates to the user for confirmation.]
+  ##### Dataset Selection Strategy
+
+  When searching for datasets relevant to a user's question, work through
+  the data source layers systematically. Start with the most specific and
+  authoritative sources, broadening only when needed.
+
+  **Step 1: Scope the search.**
+  Before searching, extract from the user's question:
+  - Subject domain (e.g., sales, demographics, weather, healthcare)
+  - Key entities (e.g., customers, products, regions, dates)
+  - Required granularity (aggregate vs. row-level)
+  - Required time range (if any)
+  - Required geography (if any)
+
+  **Step 2: Search local datasets (Level 3 — filesearch tools).**
+  1. Call filesearch_get_search_stats() to understand what is available
+     (file counts, types, sizes).
+  2. Call filesearch_search_files(query) with domain keywords from Step 1.
+     Try multiple keyword variations if the first search yields few results
+     (e.g., "revenue" if "sales" returns nothing).
+  3. For each candidate file, call filesearch_read_file(path) and read the
+     first 20-50 lines to understand structure, columns, and content.
+  4. Record each candidate with: path, format, column names, row count
+     estimate, time range (if visible), and a relevance note.
+
+  **Step 3: Search configured data sources (Level 4 — dataaccess tools).**
+  1. Call dataaccess_list_sources() to discover available enterprise sources.
+  2. For each relevant source, call dataaccess_list_available_data(source_id)
+     to browse tables/containers.
+  3. For promising items, call dataaccess_get_schema(source_id, data_id)
+     to inspect columns and types without reading data.
+  4. If the schema looks relevant, call dataaccess_read_data(source_id,
+     data_id, limit=5) to sample a few rows. ALWAYS pass a small limit
+     (5-10 rows) when sampling — never pull the full dataset into context.
+  5. Record each candidate with: source_id, data_id, column names,
+     row count (from metadata), and a relevance note.
+
+  **Step 4: Search existing projects (Level 2 — coding tools).**
+  1. Call coding_list_projects() to see what projects exist.
+  2. Scan project names and descriptions for domain relevance.
+  3. For relevant projects, call coding_list_project_files(repo_name) and
+     look for data files (CSV, JSON, Parquet) or data documentation.
+  4. Read promising files with coding_read_project_file(repo_name, path).
+
+  **Step 5: Search external sources (Level 5 — web tools).**
+  Use this level only when Levels 2-4 did not produce sufficient candidates.
+  1. Use web_fetch_url to check known public data catalogs directly:
+     - data.overheid.nl (Dutch government open data)
+     - data.europa.eu (EU open data portal)
+     - kaggle.com/datasets (popular datasets)
+     - datasetsearch.research.google.com (Google Dataset Search)
+     - data.world (collaborative data platform)
+     Construct catalog-specific search URLs with the user's keywords.
+  2. Use web_search_web(query) for broader discovery. Note: results from
+     this tool may be limited — always verify with web_fetch_url.
+  3. Use web_get_page_info(url) to assess candidate pages before
+     fetching full content.
+
+  **Step 6: Evaluate and rank candidates.**
+  Score each candidate dataset on these criteria:
+
+  | Criterion     | Weight | Assessment                                                    |
+  |---------------|--------|---------------------------------------------------------------|
+  | Relevance     | High   | Does it contain the entities and measures the question needs? |
+  | Coverage      | High   | Does it cover the required time range, geography, and scope?  |
+  | Granularity   | Medium | Is the data at the right level of detail?                     |
+  | Quality       | Medium | Are there obvious gaps, nulls, or inconsistencies in sample?  |
+  | Freshness     | Medium | Is the data recent enough for the question?                   |
+  | Accessibility | Low    | Is it already available locally, or does it need downloading?  |
+  | Format        | Low    | Is it in a directly usable format (CSV, SQL table, JSON)?     |
+
+  For each candidate, assign a relevance rating: HIGH, MEDIUM, or LOW.
+  Drop LOW-rated candidates from the presentation unless fewer than 3
+  candidates remain.
+
+  **Step 7: Present candidates to the user.**
+  Present the shortlisted datasets using this format per dataset:
+  - **Name and location** (file path, source_id:data_id, or URL)
+  - **Description** (1-2 sentences on what the data contains)
+  - **Columns/fields** (list the key columns relevant to the question)
+  - **Size** (rows x columns, or file size)
+  - **Relevance rating** (HIGH/MEDIUM) with a one-sentence justification
+  - **Gaps** (what is missing or might be problematic)
+
+  After presenting, ask the user which dataset(s) to use. If only one
+  HIGH-rated candidate exists, recommend it but still ask for confirmation.
+
+  **Step 8: Handle "no results" gracefully.**
+  If no suitable datasets are found at any level:
+  1. Summarize what was searched and why nothing matched.
+  2. Suggest alternative search terms or reframing the question.
+  3. Ask whether the user can provide the data or point to a source.
+  4. If the question could be answered with a different scope or
+     granularity, suggest that as an option.
 
   #### For DATA QUESTION:
   The user wants a specific answer from existing data:
   1. Identify which dataset(s) are likely to contain the answer
      - Use filesearch_search_files with keywords from the question
      - If the user mentioned a specific dataset, go directly to it
-  2. Read the relevant data using filesearch_read_file or coding_read_project_file
+     - If filesearch does not find relevant data, check configured data
+       sources: call dataaccess_list_sources(), then
+       dataaccess_list_available_data() and dataaccess_get_schema() to
+       locate relevant tables or files.
+  2. Read the relevant data using filesearch_read_file,
+     coding_read_project_file, or dataaccess_read_data (with an
+     appropriate limit for large datasets)
   3. Analyze the data to find the answer
   4. Present the answer to the user via hitl_ask_question, including:
      - The direct answer to their question
@@ -261,7 +362,7 @@ system_prompt: |
      - Functional and non-functional requirements, acceptance criteria
      - Whether visualizations are requested
   2. Search for relevant datasets that could support the analysis (filesearch,
-     coding, registry, web tools as described in CONTEXT GATHERING)
+     dataaccess, coding, registry, web tools as described in CONTEXT GATHERING)
   3. Fill in the template sections based on the gathered information. For
      sections where information is not yet known, mark them as "TBD by builder"
      rather than leaving them empty.
@@ -364,6 +465,12 @@ mcps:
     - get_module
     - search_modules
     - list_components
+  dataaccess:
+    - list_sources
+    - test_connection
+    - list_available_data
+    - get_schema
+    - read_data
 
 approval_overrides: {}
 

--- a/druppie/execution/mcp_http.py
+++ b/druppie/execution/mcp_http.py
@@ -134,6 +134,25 @@ def classify_error(error: Exception) -> tuple[str, bool, bool]:
     return MCPErrorType.FATAL, False, False
 
 
+def _format_error(error: Exception, timeout_seconds: float | None = None) -> str:
+    """Return a human-readable error message.
+
+    Some exceptions (notably ``asyncio.TimeoutError``) have an empty
+    ``str()`` representation.  This helper ensures callers always get
+    a meaningful description for logs and error propagation.
+    """
+    msg = str(error).strip()
+    if msg:
+        return msg
+    if isinstance(error, (TimeoutError, asyncio.TimeoutError)):
+        if timeout_seconds is not None:
+            return f"Request timed out after {timeout_seconds}s"
+        return "Request timed out"
+    if isinstance(error, (ConnectionError, OSError)):
+        return f"Connection failed ({type(error).__name__})"
+    return type(error).__name__
+
+
 class MCPHttpError(Exception):
     """Error communicating with MCP server."""
 
@@ -234,6 +253,8 @@ class MCPHttp:
                 error_type, retryable, _ = classify_error(e)
                 last_error = e
 
+                error_msg = _format_error(e, timeout_seconds)
+
                 if retryable and attempt < max_retries:
                     delay = base_delay * (2 ** attempt)
                     logger.warning(
@@ -244,7 +265,7 @@ class MCPHttp:
                         attempt=attempt + 1,
                         max_retries=max_retries,
                         delay=delay,
-                        error=str(e),
+                        error=error_msg,
                     )
                     await asyncio.sleep(delay)
                     continue
@@ -257,18 +278,19 @@ class MCPHttp:
                     error_type=error_type,
                     retryable=retryable,
                     attempt=attempt + 1,
-                    error=str(e),
+                    error=error_msg,
                 )
                 raise MCPHttpError(
                     server, tool,
-                    f"Error calling {server}:{tool}: {e}",
+                    f"Error calling {server}:{tool}: {error_msg}",
                     retryable=retryable,
                 )
 
         # Should not reach here, but safety net
+        last_msg = _format_error(last_error, timeout_seconds) if last_error else "unknown error"
         raise MCPHttpError(
             server, tool,
-            f"Max retries ({max_retries}) exceeded for {server}:{tool}: {last_error}",
+            f"Max retries ({max_retries}) exceeded for {server}:{tool}: {last_msg}",
             retryable=False,
         )
 

--- a/druppie/mcp-servers/module-data-access/v1/adapter/azure_datalake.py
+++ b/druppie/mcp-servers/module-data-access/v1/adapter/azure_datalake.py
@@ -102,13 +102,11 @@ class AzureDataLakeAdapter(BaseDataSourceAdapter):
         try:
             container, file_path = self._parse_path(data_id)
             file_client = self._client.get_file_client(container, file_path)
-
-            download = file_client.download_file(max_concurrency=1)
-            content = download.readall()
-
             file_type = self._get_file_type(file_path)
 
             if file_type == "parquet":
+                download = file_client.download_file(max_concurrency=1)
+                content = download.readall()
                 pf = pq.ParquetFile(io.BytesIO(content))
                 schema = pf.schema_arrow
                 columns = [{"name": field.name, "type": str(field.type)} for field in schema]
@@ -123,8 +121,15 @@ class AzureDataLakeAdapter(BaseDataSourceAdapter):
                     ),
                 }
             elif file_type == "csv":
+                # Only the header row is needed for schema — range-read
+                # 64 KB instead of downloading multi-GB files.
+                download = file_client.download_file(offset=0, length=64 * 1024)
+                content = download.readall()
+                last_newline = content.rfind(b"\n")
+                if last_newline > 0:
+                    content = content[: last_newline + 1]
                 # utf-8-sig strips a leading BOM so the first column name
-                # doesn't come back as "﻿<name>".
+                # doesn't come back as "\ufeff<name>".
                 df = pd.read_csv(
                     io.BytesIO(content),
                     nrows=0,
@@ -176,7 +181,7 @@ class AzureDataLakeAdapter(BaseDataSourceAdapter):
             can_stream = (
                 file_type == "csv"
                 and limit is not None
-                and filter_expr is None
+                and not filter_expr
             )
 
             if can_stream:

--- a/druppie/mcp-servers/module-data-access/v1/adapter/azure_datalake.py
+++ b/druppie/mcp-servers/module-data-access/v1/adapter/azure_datalake.py
@@ -158,55 +158,66 @@ class AzureDataLakeAdapter(BaseDataSourceAdapter):
         try:
             container, file_path = self._parse_path(data_id)
             file_client = self._client.get_file_client(container, file_path)
-
-            download = file_client.download_file()
-            content = download.readall()
-
             file_type = self._get_file_type(file_path)
 
-            warnings: list[str] = []
-            skipped_rows = 0
-            if file_type == "parquet":
-                df = pd.read_parquet(io.BytesIO(content))
-            elif file_type == "csv":
-                # Tolerate malformed rows (mismatched field counts) so a
-                # single bad line doesn't fail the whole read. Real-world
-                # data lake CSVs often have embedded delimiters or stray
-                # rows; surfacing them as errors blocks all discovery.
-                # utf-8-sig strips any leading BOM.
-                df = pd.read_csv(
-                    io.BytesIO(content),
-                    on_bad_lines="skip",
-                    encoding="utf-8-sig",
-                )
-                # Count rows pandas skipped so the caller can see that the
-                # source CSV is malformed. content.count(b"\n") gives the
-                # number of newline-terminated lines; subtract 1 for the
-                # header. Off-by-one for files without a trailing newline
-                # is acceptable for a discovery surface.
-                total_lines = content.count(b"\n")
-                expected_data_rows = max(0, total_lines - 1)
-                skipped_rows = max(0, expected_data_rows - len(df))
-                if skipped_rows > 0:
-                    warnings.append(
-                        f"Skipped {skipped_rows} malformed row(s) in source CSV — "
-                        f"field count did not match the {len(df.columns)}-column header. "
-                        "Common cause: unquoted commas in free-text columns at the source."
-                    )
-            else:
+            if file_type not in ("csv", "parquet"):
                 return {
                     "success": False,
                     "error": f"Unsupported file type: {file_path}. Supported: .csv, .parquet",
                 }
 
-            if filter_expr:
-                df = df.query(filter_expr)
+            warnings: list[str] = []
+            skipped_rows = 0
 
-            if offset is not None:
-                df = df.iloc[offset:]
+            # Optimisation: when the caller only needs a handful of rows
+            # from a CSV and there is no server-side filter, stream just
+            # the head of the file instead of downloading the whole blob.
+            # This turns a multi-GB download into a few-MB range read.
+            can_stream = (
+                file_type == "csv"
+                and limit is not None
+                and filter_expr is None
+            )
 
-            if limit is not None:
-                df = df.head(limit)
+            if can_stream:
+                df, warnings = await self._read_csv_head(
+                    file_client, limit, offset,
+                )
+            else:
+                download = file_client.download_file()
+                content = download.readall()
+
+                if file_type == "parquet":
+                    df = pd.read_parquet(io.BytesIO(content))
+                else:
+                    # Tolerate malformed rows (mismatched field counts) so a
+                    # single bad line doesn't fail the whole read. Real-world
+                    # data lake CSVs often have embedded delimiters or stray
+                    # rows; surfacing them as errors blocks all discovery.
+                    # utf-8-sig strips any leading BOM.
+                    df = pd.read_csv(
+                        io.BytesIO(content),
+                        on_bad_lines="skip",
+                        encoding="utf-8-sig",
+                    )
+                    # Count rows pandas skipped so the caller can see that
+                    # the source CSV is malformed.
+                    total_lines = content.count(b"\n")
+                    expected_data_rows = max(0, total_lines - 1)
+                    skipped_rows = max(0, expected_data_rows - len(df))
+                    if skipped_rows > 0:
+                        warnings.append(
+                            f"Skipped {skipped_rows} malformed row(s) in source CSV — "
+                            f"field count did not match the {len(df.columns)}-column header. "
+                            "Common cause: unquoted commas in free-text columns at the source."
+                        )
+
+                if filter_expr:
+                    df = df.query(filter_expr)
+                if offset is not None:
+                    df = df.iloc[offset:]
+                if limit is not None:
+                    df = df.head(limit)
 
             return {
                 "success": True,
@@ -224,6 +235,67 @@ class AzureDataLakeAdapter(BaseDataSourceAdapter):
             }
         except Exception as e:
             return {"success": False, "error": str(e)}
+
+    async def _read_csv_head(
+        self,
+        file_client,
+        limit: int,
+        offset: int | None = None,
+    ) -> tuple[pd.DataFrame, list[str]]:
+        """Read the first rows of a CSV via an Azure range-read.
+
+        Downloads only enough bytes to satisfy *limit* (+ *offset*) rows,
+        avoiding multi-GB transfers when the agent only needs a small sample.
+        """
+        rows_needed = limit + (offset or 0)
+        warnings: list[str] = []
+
+        # Heuristic: ~2 KB per row covers most enterprise CSVs.
+        # Floor at 1 MB so the header + a few rows always fit.
+        chunk_size = max(1 * 1024 * 1024, rows_needed * 2048)
+        max_bytes = 50 * 1024 * 1024  # safety cap
+
+        chunk_size = min(chunk_size, max_bytes)
+
+        while True:
+            download = file_client.download_file(offset=0, length=chunk_size)
+            content = download.readall()
+            is_complete = len(content) < chunk_size
+
+            # Trim to last complete line so a range-read that cuts
+            # mid-row (or mid-quoted-field) doesn't cause a parse error.
+            if not is_complete:
+                last_newline = content.rfind(b"\n")
+                if last_newline > 0:
+                    content = content[: last_newline + 1]
+
+            df = pd.read_csv(
+                io.BytesIO(content),
+                nrows=rows_needed,
+                on_bad_lines="skip",
+                encoding="utf-8-sig",
+            )
+
+            if len(df) >= rows_needed or is_complete:
+                break
+
+            # Not enough rows in this chunk — double and retry
+            if chunk_size >= max_bytes:
+                warnings.append(
+                    f"Streamed first {chunk_size // (1024 * 1024)} MB but only "
+                    f"found {len(df)} rows (requested {rows_needed}). "
+                    "The file may have very wide rows or many malformed lines."
+                )
+                break
+
+            chunk_size = min(chunk_size * 2, max_bytes)
+
+        # Apply offset and limit on the parsed subset
+        if offset is not None:
+            df = df.iloc[offset:]
+        df = df.head(limit)
+
+        return df, warnings
 
     async def download_data(
         self,


### PR DESCRIPTION
## Summary

- **Added `dataaccess` MCP tools** to the data analyst agent (`list_sources`, `test_connection`, `list_available_data`, `get_schema`, `read_data`), giving it read-only access to configured enterprise data sources (Azure Data Lake, Azure SQL)
- **Replaced the `[PLACEHOLDER]` dataset selection strategy** with a comprehensive 8-step workflow that guides the agent through scoping, searching across all data layers, evaluating candidates, and presenting results to the user
- **Updated all operational flows** (dataset discovery, data question, analysis planning) to incorporate the new dataaccess tools alongside existing filesearch, coding, and web tools

## Environment configuration required

This feature requires `DATA_SOURCE_*` environment variables to be configured in `.env` for the `module-data-access` container to connect to data sources. Contact the AI team to obtain the correct configuration values.

## Test plan

- [x] **Verify tool registration**: After starting the dev environment, confirm the backend discovers the dataaccess tools for the data analyst. Check backend logs for successful tool registry loading of the `dataaccess` MCP server.
- [ ] **Test dataset discovery flow**: Ask the data analyst a question like *"What data do we have about waterkwaliteit?"* and verify it calls `dataaccess_list_sources()` and `dataaccess_list_available_data()` to browse the Azure Data Lake.
- [ ] **Test data question flow**: Ask *"Show me the asset data from Ultimo"* and verify the agent finds and samples `HHR/Ultimo/VW_HHR_Dim_Asset.csv` via `dataaccess_read_data()` with a small row limit.
- [ ] **Test fallback behavior**: Ask about data that doesn't exist in any source and verify the agent searches all layers (filesearch, dataaccess, coding, web) before presenting a "no results" response with suggestions.
- [x] **Verify read-only constraint**: Confirm the agent does NOT have access to `download_data` — it should only be able to read/sample data, not write files.
- [x] **Test without data sources configured**: Remove `DATA_SOURCE_*` from `.env`, restart `module-data-access`, and verify the agent handles empty `list_sources()` gracefully and moves on to other data layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)