### PR TITLE
feat(data-access): Azure SQL via service-principal auth + free-form execute_query

### DIFF
--- a/docs/MCP/data-access.md
+++ b/docs/MCP/data-access.md
@@ -16,28 +16,76 @@ tools. Replaces the standalone `module-azure-datalake` MCP.
 ## Configuration
 
 Data sources are declared via `DATA_SOURCE_1` … `DATA_SOURCE_9` in `.env`.
-Each entry is a single colon-delimited string: `type:name:config_parts...`.
-The MCP loads them at container startup (see
-`v1/module.py::_load_data_sources`); changes require a `docker compose up -d
---force-recreate --no-deps module-data-access` — a plain `restart` does not
-re-read `.env`.
+Each entry is a colon-delimited string `type:name:config_blob`. Only the
+leading `type` and `name` are split off (`split(":", 2)`); the remaining
+`config_blob` keeps every internal colon, so an ODBC connection string
+(`Server=tcp:host,1433;…`) survives intact. The MCP loads them at container
+startup (see `v1/module.py::_load_data_sources`); changes require a
+`docker compose up -d --force-recreate --no-deps module-data-access` — a
+plain `restart` does not re-read `.env`.
 
 | Source type | Format |
 |---|---|
 | Azure Data Lake (key) | `azure-datalake:<source_id>:<account_name>:<storage_key>` |
 | Azure Data Lake (public) | `azure-datalake:<source_id>:<account_name>` |
-| Azure SQL (connection string) | `azure-sql:<source_id>:<connection_string>` |
-| Azure SQL (OBO token) | `azure-sql-obo:<source_id>:<tenant_id>:<client_id>:<client_secret>:<scope>:<server>:<database>` |
+| Azure SQL (connection string) | `azure-sql:<source_id>:<odbc_connection_string>` |
+| Azure SQL (OBO token — interim) | `azure-sql-obo:<source_id>:<tenant_id>:<client_id>:<client_secret>:<scope>:<server>:<database>` |
 
-`<source_id>` is the handle agents pass back to every other tool. OBO tokens
-are fetched fresh per request and are **never** cached or persisted (see
-`adapter/base.py`).
+`<source_id>` is the handle agents pass back to every other tool.
 
-Example:
+> **Auth status.** `azure-datalake` (key / public) and `azure-sql`
+> (connection string, incl. service-principal auth) are supported and
+> tested. `azure-sql-obo` is **interim**: it currently runs an OAuth
+> `client_credentials` grant (one shared service identity), not a true
+> per-user on-behalf-of exchange — true OBO is a separate follow-up.
+
+Examples:
 
 ```dotenv
 DATA_SOURCE_1=azure-datalake:dlspublichhrhhskexp01:dlspublichhrhhskexp01:<base64-storage-key>
+DATA_SOURCE_3=azure-sql:synapsedwh:Driver={ODBC Driver 18 for SQL Server};Server=<ws>-ondemand.sql.azuresynapse.net;Database=<db>;Authentication=ActiveDirectoryServicePrincipal;UID=<client-id>;PWD=<client-secret>;Encrypt=yes;TrustServerCertificate=no;
 ```
+
+See [Azure SQL setup (Synapse serverless)](#azure-sql-setup-synapse-serverless)
+below for how to provision the endpoint and service principal.
+
+## Azure SQL setup (Synapse serverless)
+
+The `azure-sql` source type connects through `pyodbc` + the Microsoft
+**ODBC Driver 18** (installed in the MCP image — see `Dockerfile`). Steps to
+provision a serverless endpoint and a service principal for it:
+
+1. **Synapse workspace.** Create an Azure Synapse Analytics workspace (or
+   reuse one). The *serverless* SQL pool is built in; its endpoint is
+   `<workspace-name>-ondemand.sql.azuresynapse.net`.
+2. **Service principal.** In Microsoft Entra ID, register an application,
+   then create a client secret. Record the **tenant id**, **client (app)
+   id**, and **secret value**.
+3. **Database + grant.** In the serverless pool create a database, then
+   grant the service principal read access:
+   ```sql
+   -- run on the serverless endpoint, master context
+   CREATE LOGIN [<sp-display-name>] FROM EXTERNAL PROVIDER;
+   -- run in the target database
+   CREATE USER  [<sp-display-name>] FROM LOGIN [<sp-display-name>];
+   ALTER ROLE   db_datareader ADD MEMBER [<sp-display-name>];
+   ```
+   Grant **`db_datareader` only** — read-only is also what bounds the
+   `filter_expr` injection surface (see [Security boundaries](#security-boundaries)).
+4. **Storage access.** If the serverless pool reads lake data via
+   `OPENROWSET` / external tables, give the service principal
+   **Storage Blob Data Reader** on the backing ADLS account.
+5. **Firewall.** On the Synapse workspace, allow the Druppie host's IP (or
+   enable "Allow Azure services").
+6. **Configure the source.** Add to `.env` (single line):
+   ```dotenv
+   DATA_SOURCE_3=azure-sql:synapsedwh:Driver={ODBC Driver 18 for SQL Server};Server=<ws>-ondemand.sql.azuresynapse.net;Database=<db>;Authentication=ActiveDirectoryServicePrincipal;UID=<client-id>;PWD=<client-secret>;Encrypt=yes;TrustServerCertificate=no;
+   ```
+   `Authentication=ActiveDirectoryServicePrincipal` lets ODBC Driver 18 do
+   the token exchange — no manual token code runs for this path. Recreate
+   the container (`docker compose up -d --force-recreate --no-deps
+   module-data-access`) and confirm the startup log shows
+   `Loaded data source: synapsedwh (azure-sql)`.
 
 ## Tools
 
@@ -73,8 +121,21 @@ Builder when consuming sample data, most likely).
 - Azure SQL: empty path → tables; schema path → table list filtered.
 
 `read_data` filter syntax:
-- Azure SQL: SQL `WHERE` clause fragment.
+- Azure SQL: a SQL `WHERE`-clause **fragment** only (e.g. `Status = 'open'
+  AND Year >= 2020`). Statement terminators, comment markers and
+  stored-procedure calls are rejected — see [Security boundaries](#security-boundaries).
 - Azure Data Lake: pandas `DataFrame.query()` expression.
+
+### Azure SQL row caps
+
+`read_data` against Azure SQL caps unbounded reads so an agent cannot pull a
+whole Synapse table into the LLM context:
+
+- With no `limit`, the result is capped at **1000 rows**; `metadata.capped`
+  is `true` and `warnings[]` says so. Pass an explicit `limit` to read more.
+- `download_data` streams the full table to CSV in 5000-row batches (no
+  in-memory materialisation) with a hard **1,000,000-row** ceiling; if hit,
+  the CSV is truncated and `warnings[]` reports it.
 
 ### CSV robustness
 
@@ -103,17 +164,24 @@ Builder when consuming sample data, most likely).
   guard fires before the adapter is touched, so it does not depend on the
   source being reachable. Pinned by
   `testing/tools/data-access-download-data-path-traversal.yaml`.
+- **`filter_expr` is a WHERE-clause fragment, not arbitrary SQL.** The
+  Azure SQL adapter rejects a `filter_expr` containing statement
+  terminators (`;`), comment markers (`--`, `/*`), batch separators
+  (`GO`) or stored-procedure calls (`xp_`, `sp_`, `EXEC`) before it is
+  appended to the query (`AzureSQLAdapter._validate_filter`). Defence in
+  depth — the configured SQL principal should also be `db_datareader`
+  only, which bounds anything that slips through to read-only.
 - **No OBO token caching**. Azure SQL OBO adapters obtain a fresh token per
   call. There is no persistence layer or in-memory cache. Reviewers should
   treat any change to that behavior as a security-sensitive diff.
 - **Secrets in `.env`**. Storage keys and client secrets live only in the
   process environment; they are not stored in the database or surfaced to
-  agents. `list_sources` returns `auth_type` (`key`, `connection-string`,
+  agents. `list_sources` returns `auth_type` (`key`, `connection_string`,
   `obo`) but not the credential itself.
 
 ## Testing
 
-The MCP is covered by 13 YAML tool tests in `testing/tools/data-access-*.yaml`.
+The MCP is covered by 16 YAML tool tests in `testing/tools/data-access-*.yaml`.
 Run them via the evaluations endpoint (admin token required):
 
 ```bash
@@ -151,6 +219,19 @@ Azure Data Lake account, with the seeded `dwhpublic/HHR/` content present.
 | `data-access-get-schema-csv` | Schema for `VW_HHR_Fudura_MeteringPoints.csv` exposes `meteringPointId`, `channelId`, etc. |
 | `data-access-read-data-with-limit` | `limit: 2` returns 2 rows with `"limited": true` and the column metadata. |
 | `data-access-download-data-success` | The CSV lands in `/workspaces/default/<project_id>/<session_id>/data/metering-points.csv` with non-zero `size_bytes`. |
+
+### Azure SQL (3, tagged `live` + `azure-sql`)
+
+These need an `azure-sql` source named `synapsedwh` configured via
+`DATA_SOURCE_N` (see [Azure SQL setup](#azure-sql-setup-synapse-serverless)).
+`data-access-sql-filter-rejected` passes even if the endpoint is
+unreachable — the filter guard runs before the connection is opened.
+
+| Test | What it pins |
+|---|---|
+| `data-access-sql-test-connection` | `test_connection` actually reaches the SQL endpoint and runs `SELECT 1`. |
+| `data-access-sql-list-tables` | `list_available_data` enumerates tables from `INFORMATION_SCHEMA.TABLES`. |
+| `data-access-sql-filter-rejected` | `read_data` rejects a `filter_expr` containing `;` with a `WHERE-clause` error. |
 
 All assertions use `{matches: "\"success\"\\s*:\\s*(true|false)"}` so they
 remain robust to JSON whitespace.

--- a/docs/MCP/data-access.md
+++ b/docs/MCP/data-access.md
@@ -100,6 +100,7 @@ tests can assert on it.
 | `list_available_data` | `source_id`, `path?`, `recursive?` | `{success, data_items: [{item_id, name, type, metadata}], count, level, container?, path?}` |
 | `get_schema` | `source_id`, `data_id` | `{success, schema: {columns: [{name, type}], metadata}}` |
 | `read_data` | `source_id`, `data_id`, `filter_expr?`, `limit?`, `offset?` | `{success, data: [...], row_count, columns, metadata}` |
+| `execute_query` | `source_id`, `query`, `limit?` | `{success, data: [...], row_count, columns, warnings, metadata}` |
 | `download_data` | `source_id`, `data_id`, `destination`, `session_id*`, `project_id*` | `{success, destination, size_bytes}` |
 
 `*` `session_id` and `project_id` on `download_data` are auto-injected by
@@ -125,6 +126,20 @@ Builder when consuming sample data, most likely).
   AND Year >= 2020`). Statement terminators, comment markers and
   stored-procedure calls are rejected — see [Security boundaries](#security-boundaries).
 - Azure Data Lake: pandas `DataFrame.query()` expression.
+
+`execute_query` (Azure SQL only):
+- Accepts a **single** read-only statement that must start with `SELECT`
+  or `WITH` (CTE). DML/DDL verbs, comments, batch separators (`GO`),
+  stored-proc calls and additional `;` separators are rejected before the
+  query reaches the database. The configured `db_datareader` principal is
+  the real hard line; this validator just makes the contract explicit.
+- Same 1000-row default cap as `read_data`. The cap is enforced by
+  fetching one extra row from the cursor — if the query produced more,
+  `metadata.truncated` is `true` and `warnings[]` says so. Paginate via
+  `ORDER BY ... OFFSET ... ROWS FETCH NEXT ... ROWS ONLY` in the query
+  itself.
+- For file-based sources (Azure Data Lake) the tool returns a clear
+  "unsupported" error — use `read_data` instead.
 
 ### Azure SQL row caps
 
@@ -232,6 +247,8 @@ unreachable — the filter guard runs before the connection is opened.
 | `data-access-sql-test-connection` | `test_connection` actually reaches the SQL endpoint and runs `SELECT 1`. |
 | `data-access-sql-list-tables` | `list_available_data` enumerates tables from `INFORMATION_SCHEMA.TABLES`. |
 | `data-access-sql-filter-rejected` | `read_data` rejects a `filter_expr` containing `;` with a `WHERE-clause` error. |
+| `data-access-sql-execute-query` | `execute_query` runs a `SELECT` and returns rows. |
+| `data-access-sql-execute-query-rejected` | `execute_query` rejects a non-SELECT statement with a `SELECT or WITH` error. |
 
 All assertions use `{matches: "\"success\"\\s*:\\s*(true|false)"}` so they
 remain robust to JSON whitespace.

--- a/druppie/mcp-servers/module-data-access/Dockerfile
+++ b/druppie/mcp-servers/module-data-access/Dockerfile
@@ -2,10 +2,16 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
-    unixodbc-dev \
-    gcc \
-    curl \
+# Microsoft ODBC Driver 18 is required by pyodbc for Azure SQL / Synapse.
+# python:3.11-slim is Debian 12 (bookworm), so use the bookworm prod repo.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        unixodbc-dev gcc curl gnupg ca-certificates \
+    && curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+        | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" \
+        > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update \
+    && ACCEPT_EULA=Y apt-get install -y --no-install-recommends msodbcsql18 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY module-data-access/requirements.txt .

--- a/druppie/mcp-servers/module-data-access/v1/adapter/azure_sql.py
+++ b/druppie/mcp-servers/module-data-access/v1/adapter/azure_sql.py
@@ -4,6 +4,7 @@ Supports OBO token authentication via Keycloak.
 """
 
 import logging
+import re
 from typing import Any
 
 import pyodbc
@@ -11,6 +12,26 @@ import pyodbc
 from .base import BaseDataSourceAdapter, DataSourceInfo, DataItem, SchemaInfo
 
 logger = logging.getLogger("dataaccess-mcp")
+
+# When read_data is called without an explicit limit, cap the result so an
+# agent can't pull an entire Synapse table into the LLM context by accident.
+DEFAULT_ROW_CAP = 1000
+
+# Hard ceiling for download_data so a runaway table can't exhaust memory /
+# disk in the MCP container.
+DOWNLOAD_ROW_CAP = 1_000_000
+
+# Rows fetched per round-trip while streaming a download.
+DOWNLOAD_BATCH_SIZE = 5000
+
+# filter_expr is a WHERE-clause fragment, not arbitrary SQL. Reject tokens
+# that would let it break out of the clause (statement terminators, comment
+# markers, batch separators, extended stored procedures). Defence in depth —
+# the configured SQL principal should also be db_datareader only.
+_FILTER_FORBIDDEN = re.compile(
+    r";|--|/\*|\*/|\bxp_|\bsp_|\bexec\b|\bexecute\b|\bgo\b",
+    re.IGNORECASE,
+)
 
 
 class AzureSQLAdapter(BaseDataSourceAdapter):
@@ -63,6 +84,32 @@ class AzureSQLAdapter(BaseDataSourceAdapter):
 
         self._connection = pyodbc.connect(conn_str)
         return self._connection
+
+    async def _ensure_connection(self):
+        """Prove connectivity for the inherited test_connection().
+
+        The base class test_connection() only awaits _ensure_connection();
+        without this override it would hit the base no-op and report success
+        even when the database is unreachable. Open a real connection and run
+        a trivial query so a failure surfaces honestly.
+        """
+        conn = await self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT 1")
+        cursor.fetchone()
+
+    @staticmethod
+    def _validate_filter(filter_expr: str) -> None:
+        """Reject a filter_expr that tries to break out of the WHERE clause.
+
+        Raises ValueError on a forbidden token.
+        """
+        if _FILTER_FORBIDDEN.search(filter_expr):
+            raise ValueError(
+                "filter_expr must be a plain WHERE-clause fragment — "
+                "statement terminators, comments and stored-procedure "
+                "calls are not allowed"
+            )
 
     async def _fetch_obo_token(self) -> str:
         """Fetch fresh OBO token from Keycloak.
@@ -179,48 +226,61 @@ class AzureSQLAdapter(BaseDataSourceAdapter):
         limit: int | None = None,
         offset: int | None = None,
     ) -> dict:
-        """Read data from a table with optional filtering and limiting."""
+        """Read data from a table with optional filtering and limiting.
+
+        When no limit is given the result is capped at DEFAULT_ROW_CAP so an
+        agent cannot accidentally pull an entire table into context; the cap
+        is reported in warnings[] and metadata.capped.
+        """
         try:
             schema, table_name = data_id.split(".", 1)
+            if filter_expr:
+                self._validate_filter(filter_expr)
+
+            warnings: list[str] = []
+            capped = limit is None
+            effective_limit = limit if limit is not None else DEFAULT_ROW_CAP
+
             conn = await self._get_connection()
             cursor = conn.cursor()
 
             query = f"SELECT * FROM [{schema}].[{table_name}]"
-            params = []
+            params: list = []
 
             if filter_expr:
                 query += f" WHERE {filter_expr}"
 
-            if limit is not None:
-                if offset is not None:
-                    query += f" ORDER BY (SELECT NULL) OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
-                    params.extend([offset, limit])
-                else:
-                    query += f" ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY"
-                    params.append(limit)
-            elif offset is not None:
-                query += f" ORDER BY (SELECT NULL) OFFSET ? ROWS"
-                params.append(offset)
+            query += " ORDER BY (SELECT NULL) OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+            params.extend([offset or 0, effective_limit])
 
             cursor.execute(query, params)
 
             columns = [desc[0] for desc in cursor.description]
             rows = cursor.fetchall()
-
             data = [{col: value for col, value in zip(columns, row)} for row in rows]
+
+            if capped and len(data) == effective_limit:
+                warnings.append(
+                    f"No limit was given — result capped at {DEFAULT_ROW_CAP} "
+                    "rows. Pass an explicit 'limit' to read more."
+                )
 
             return {
                 "success": True,
                 "data": data,
                 "row_count": len(data),
                 "columns": columns,
+                "warnings": warnings,
                 "metadata": {
                     "table": f"{schema}.{table_name}",
                     "filtered": filter_expr is not None,
                     "limited": limit is not None,
                     "offset": offset,
+                    "capped": capped and len(data) == effective_limit,
                 },
             }
+        except ValueError as e:
+            return {"success": False, "error": str(e)}
         except Exception as e:
             return {"success": False, "error": str(e)}
 
@@ -229,24 +289,51 @@ class AzureSQLAdapter(BaseDataSourceAdapter):
         data_id: str,
         destination_path: str,
     ) -> dict:
-        """Download table data as CSV."""
+        """Download a full table to CSV, streaming in batches.
+
+        Rows are fetched DOWNLOAD_BATCH_SIZE at a time and written
+        incrementally so a large table does not have to be materialised in
+        memory. A hard DOWNLOAD_ROW_CAP guards against a runaway table.
+        """
         try:
             import csv
 
-            result = await self.read_data(data_id)
+            schema, table_name = data_id.split(".", 1)
+            conn = await self._get_connection()
+            cursor = conn.cursor()
+            cursor.execute(f"SELECT * FROM [{schema}].[{table_name}]")
 
-            if not result["success"]:
-                return result
+            columns = [desc[0] for desc in cursor.description]
+            row_count = 0
+            truncated = False
+            warnings: list[str] = []
 
             with open(destination_path, "w", newline="") as f:
-                writer = csv.DictWriter(f, fieldnames=result["columns"])
-                writer.writeheader()
-                writer.writerows(result["data"])
+                writer = csv.writer(f)
+                writer.writerow(columns)
+                while True:
+                    batch = cursor.fetchmany(DOWNLOAD_BATCH_SIZE)
+                    if not batch:
+                        break
+                    if row_count + len(batch) > DOWNLOAD_ROW_CAP:
+                        batch = batch[: DOWNLOAD_ROW_CAP - row_count]
+                        truncated = True
+                    writer.writerows(batch)
+                    row_count += len(batch)
+                    if truncated:
+                        break
+
+            if truncated:
+                warnings.append(
+                    f"Table exceeded the {DOWNLOAD_ROW_CAP}-row download cap; "
+                    "the CSV is truncated."
+                )
 
             return {
                 "success": True,
                 "destination": destination_path,
-                "row_count": result["row_count"],
+                "row_count": row_count,
+                "warnings": warnings,
             }
         except Exception as e:
             return {"success": False, "error": str(e)}

--- a/druppie/mcp-servers/module-data-access/v1/adapter/azure_sql.py
+++ b/druppie/mcp-servers/module-data-access/v1/adapter/azure_sql.py
@@ -33,6 +33,19 @@ _FILTER_FORBIDDEN = re.compile(
     re.IGNORECASE,
 )
 
+# execute_query accepts a single read-only statement. It must START with
+# SELECT or WITH (after whitespace) and must not contain any of the tokens
+# below — comments, batch separators, stored-proc markers, or DML/DDL
+# verbs. The configured db_datareader principal is the real hard line;
+# this validator just makes the contract explicit at the boundary.
+_QUERY_LEADING_KEYWORD = re.compile(r"^\s*(select|with)\b", re.IGNORECASE)
+_QUERY_FORBIDDEN = re.compile(
+    r"--|/\*|\*/|\bxp_|\bsp_|\bexec\b|\bexecute\b|\bgo\b|"
+    r"\binsert\b|\bupdate\b|\bdelete\b|\bmerge\b|\bdrop\b|"
+    r"\balter\b|\bcreate\b|\btruncate\b|\bgrant\b|\brevoke\b",
+    re.IGNORECASE,
+)
+
 
 class AzureSQLAdapter(BaseDataSourceAdapter):
     """Adapter for Azure SQL Database.
@@ -110,6 +123,32 @@ class AzureSQLAdapter(BaseDataSourceAdapter):
                 "statement terminators, comments and stored-procedure "
                 "calls are not allowed"
             )
+
+    @staticmethod
+    def _validate_query(query: str) -> str:
+        """Validate and normalise a free-form SELECT/WITH query.
+
+        Strips a single trailing semicolon (a common harmless habit) and
+        then rejects the query if it contains any forbidden token or does
+        not start with SELECT/WITH. Returns the normalised query.
+        """
+        normalised = query.strip().rstrip(";").strip()
+        if not _QUERY_LEADING_KEYWORD.match(normalised):
+            raise ValueError(
+                "query must start with SELECT or WITH — execute_query is "
+                "read-only"
+            )
+        if ";" in normalised:
+            raise ValueError(
+                "query must be a single statement — additional ';' "
+                "separators are not allowed"
+            )
+        if _QUERY_FORBIDDEN.search(normalised):
+            raise ValueError(
+                "query contains a forbidden token (DML/DDL verb, comment, "
+                "batch separator or stored-procedure call)"
+            )
+        return normalised
 
     async def _fetch_obo_token(self) -> str:
         """Fetch fresh OBO token from Keycloak.
@@ -277,6 +316,68 @@ class AzureSQLAdapter(BaseDataSourceAdapter):
                     "limited": limit is not None,
                     "offset": offset,
                     "capped": capped and len(data) == effective_limit,
+                },
+            }
+        except ValueError as e:
+            return {"success": False, "error": str(e)}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    async def execute_query(
+        self,
+        query: str,
+        limit: int | None = None,
+    ) -> dict:
+        """Run a read-only SELECT/WITH query against the source.
+
+        The query is validated and capped at DEFAULT_ROW_CAP rows when no
+        explicit limit is given; one extra row is fetched to detect
+        truncation so callers can paginate via their own ORDER BY/OFFSET.
+        """
+        try:
+            normalised = self._validate_query(query)
+
+            warnings: list[str] = []
+            capped_by_default = limit is None
+            effective_limit = limit if limit is not None else DEFAULT_ROW_CAP
+
+            conn = await self._get_connection()
+            cursor = conn.cursor()
+            cursor.execute(normalised)
+
+            if cursor.description is None:
+                return {
+                    "success": False,
+                    "error": "query returned no result set",
+                }
+
+            columns = [desc[0] for desc in cursor.description]
+            rows = cursor.fetchmany(effective_limit + 1)
+            truncated = len(rows) > effective_limit
+            rows = rows[:effective_limit]
+            data = [{col: value for col, value in zip(columns, row)} for row in rows]
+
+            if truncated:
+                msg = (
+                    f"Result truncated at {effective_limit} rows; pass a "
+                    "larger 'limit' or paginate via ORDER BY/OFFSET."
+                )
+                if capped_by_default:
+                    msg = (
+                        f"No limit was given — result capped at "
+                        f"{DEFAULT_ROW_CAP} rows. " + msg
+                    )
+                warnings.append(msg)
+
+            return {
+                "success": True,
+                "data": data,
+                "row_count": len(data),
+                "columns": columns,
+                "warnings": warnings,
+                "metadata": {
+                    "limited": limit is not None,
+                    "truncated": truncated,
                 },
             }
         except ValueError as e:

--- a/druppie/mcp-servers/module-data-access/v1/adapter/base.py
+++ b/druppie/mcp-servers/module-data-access/v1/adapter/base.py
@@ -135,6 +135,25 @@ class BaseDataSourceAdapter(ABC):
         """
         pass
 
+    async def execute_query(
+        self,
+        query: str,
+        limit: int | None = None,
+    ) -> dict:
+        """Run a free-form read-only query.
+
+        Default implementation reports the operation as unsupported; SQL
+        adapters override this. File-based adapters cannot satisfy a SQL
+        query and must not silently succeed.
+        """
+        return {
+            "success": False,
+            "error": (
+                f"execute_query is not supported for source type "
+                f"'{self.source_info.source_type}' — use read_data instead"
+            ),
+        }
+
     async def test_connection(self) -> dict:
         """Test connection to the data source.
 

--- a/druppie/mcp-servers/module-data-access/v1/module.py
+++ b/druppie/mcp-servers/module-data-access/v1/module.py
@@ -25,11 +25,16 @@ class DataAccessModule:
     def _load_data_sources(self):
         """Load data sources from environment variables.
 
-        Format: DATA_SOURCE_1=type:name:config_parts...
+        Format: DATA_SOURCE_1=type:name:config_blob
 
-        Azure Data Lake: azure-datalake:name:account_name:key
+        Only the type and name are split off the front (split(":", 2)); the
+        remaining config_blob keeps every internal colon. This matters for
+        Azure SQL — connection strings contain colons (e.g. Server=tcp:host)
+        that a naive split would shred.
+
+        Azure Data Lake: azure-datalake:name:account_name[:key]
         Azure SQL (conn string): azure-sql:name:connection_string
-        Azure SQL (OBO): azure-sql-obo:name:tenant_id:client_id:client_secret:scope:server:database
+        Azure SQL (OBO): azure-sql-obo:name:tenant:client:secret:scope:server:database
         """
         for i in range(1, 10):
             config_str = os.getenv(f"DATA_SOURCE_{i}")
@@ -37,39 +42,56 @@ class DataAccessModule:
                 continue
 
             try:
-                parts = config_str.split(":")
-                source_type = parts[0]
-                name = parts[1]
+                head = config_str.split(":", 2)
+                if len(head) < 3:
+                    raise ValueError(
+                        "expected 'type:name:config_blob' (at least 3 "
+                        "colon-separated parts)"
+                    )
+                source_type, name, config_blob = head
 
                 if source_type == "azure-datalake":
+                    # config_blob is account_name[:key]; neither contains a
+                    # colon, so a single maxsplit recovers both.
+                    dl_parts = config_blob.split(":", 1)
                     config = {
                         "source_id": name,
                         "name": name,
-                        "account_name": parts[2],
-                        "key": parts[3] if len(parts) > 3 else None,
+                        "account_name": dl_parts[0],
+                        "key": dl_parts[1] if len(dl_parts) > 1 else None,
                     }
                     adapter = AzureDataLakeAdapter(config)
 
                 elif source_type == "azure-sql":
+                    # config_blob is the full ODBC connection string,
+                    # colons and all.
                     config = {
                         "source_id": name,
                         "name": name,
-                        "connection_string": parts[2],
+                        "connection_string": config_blob,
                     }
                     adapter = AzureSQLAdapter(config)
 
                 elif source_type == "azure-sql-obo":
+                    # Interim client_credentials flow — true on-behalf-of and
+                    # a colon-safe config format are a separate follow-up.
+                    obo = config_blob.split(":")
+                    if len(obo) < 6:
+                        raise ValueError(
+                            "azure-sql-obo expects "
+                            "tenant:client:secret:scope:server:database"
+                        )
                     config = {
                         "source_id": name,
                         "name": name,
                         "use_obo": True,
                         "obo_config": {
-                            "tenant_id": parts[2],
-                            "client_id": parts[3],
-                            "client_secret": parts[4],
-                            "scope": parts[5],
-                            "server": parts[6],
-                            "database": parts[7],
+                            "tenant_id": obo[0],
+                            "client_id": obo[1],
+                            "client_secret": obo[2],
+                            "scope": obo[3],
+                            "server": obo[4],
+                            "database": obo[5],
                         },
                     }
                     adapter = AzureSQLAdapter(config)

--- a/druppie/mcp-servers/module-data-access/v1/module.py
+++ b/druppie/mcp-servers/module-data-access/v1/module.py
@@ -181,6 +181,19 @@ class DataAccessModule:
         except ValueError as e:
             return {"success": False, "error": str(e)}
 
+    async def execute_query(
+        self,
+        source_id: str,
+        query: str,
+        limit: int | None = None,
+    ) -> dict:
+        """Run a free-form read-only query against a SQL source."""
+        try:
+            adapter = self.get_adapter(source_id)
+            return await adapter.execute_query(query, limit)
+        except ValueError as e:
+            return {"success": False, "error": str(e)}
+
     async def download_data(
         self,
         source_id: str,

--- a/druppie/mcp-servers/module-data-access/v1/tools.py
+++ b/druppie/mcp-servers/module-data-access/v1/tools.py
@@ -125,6 +125,34 @@ async def read_data(
 
 
 @mcp.tool()
+async def execute_query(
+    source_id: str,
+    query: str,
+    limit: int | None = None,
+) -> dict:
+    """Run a free-form read-only SQL query against a SQL data source.
+
+    Only supported for SQL sources (e.g. azure-sql). The query must be a
+    single SELECT or WITH (CTE) statement — DML/DDL, comments, batch
+    separators and stored-procedure calls are rejected. Results are capped
+    at 1000 rows by default; pass an explicit 'limit' to read more, or
+    paginate via ORDER BY/OFFSET in the query itself.
+
+    For file-based sources (Azure Data Lake) this returns a clear
+    'unsupported' error — use read_data instead.
+
+    Args:
+        source_id: Source ID from list_sources()
+        query: Read-only SELECT or WITH statement
+        limit: Optional maximum rows to return
+
+    Returns:
+        Dict with data records, row_count, columns, warnings and metadata.
+    """
+    return await module.execute_query(source_id, query, limit)
+
+
+@mcp.tool()
 async def download_data(
     source_id: str,
     data_id: str,

--- a/testing/tools/data-access-sql-execute-query-rejected.yaml
+++ b/testing/tools/data-access-sql-execute-query-rejected.yaml
@@ -1,0 +1,22 @@
+## Tool Test: Data Access MCP - execute_query read-only guard (live)
+## Verifies execute_query rejects a non-SELECT statement. The guard runs
+## before the DB connection is opened, so this passes even if the Synapse
+## endpoint is unreachable — it only needs an azure-sql source named
+## "synapsedwh" to be configured.
+
+tool-test:
+  name: data-access-sql-execute-query-rejected
+  description: "execute_query rejects a non-SELECT statement"
+  tags: [data-access, mcp, azure-sql, error-handling, security, live]
+
+  chain:
+    - agent: router
+      tool: dataaccess:execute_query
+      arguments:
+        source_id: "synapsedwh"
+        query: "DROP TABLE dbo.fake_users_cetas"
+      assert:
+        result:
+          - json_parseable
+          - {matches: "\"success\"\\s*:\\s*false"}
+          - {contains: "SELECT or WITH"}

--- a/testing/tools/data-access-sql-execute-query.yaml
+++ b/testing/tools/data-access-sql-execute-query.yaml
@@ -1,0 +1,24 @@
+## Tool Test: Data Access MCP - execute_query against Azure SQL (live)
+## Verifies execute_query runs a SELECT against the configured Azure SQL
+## source and returns row data.
+## Requires DATA_SOURCE_N=azure-sql:synapsedwh:<connection-string> and a
+## table reachable from the configured principal.
+
+tool-test:
+  name: data-access-sql-execute-query
+  description: "execute_query runs a SELECT and returns rows from Azure SQL"
+  tags: [data-access, mcp, azure-sql, live]
+
+  chain:
+    - agent: router
+      tool: dataaccess:execute_query
+      arguments:
+        source_id: "synapsedwh"
+        query: "SELECT TOP 3 user_id, first_name FROM dbo.fake_users_cetas ORDER BY user_id"
+      assert:
+        result:
+          - json_parseable
+          - {matches: "\"success\"\\s*:\\s*true"}
+          - {contains: "data"}
+          - {contains: "row_count"}
+          - {contains: "first_name"}

--- a/testing/tools/data-access-sql-filter-rejected.yaml
+++ b/testing/tools/data-access-sql-filter-rejected.yaml
@@ -1,0 +1,23 @@
+## Tool Test: Data Access MCP - filter_expr injection guard (live)
+## Verifies read_data rejects a filter_expr that tries to break out of the
+## WHERE clause. The guard runs before the DB connection is opened, so this
+## passes even if the Synapse endpoint is unreachable — it only needs an
+## azure-sql source named "synapsedwh" to be configured.
+
+tool-test:
+  name: data-access-sql-filter-rejected
+  description: "read_data rejects a filter_expr containing a statement terminator"
+  tags: [data-access, mcp, azure-sql, error-handling, security, live]
+
+  chain:
+    - agent: router
+      tool: dataaccess:read_data
+      arguments:
+        source_id: "synapsedwh"
+        data_id: "dbo.anytable"
+        filter_expr: "1=1; DROP TABLE dbo.anytable"
+      assert:
+        result:
+          - json_parseable
+          - {matches: "\"success\"\\s*:\\s*false"}
+          - {contains: "WHERE-clause"}

--- a/testing/tools/data-access-sql-list-tables.yaml
+++ b/testing/tools/data-access-sql-list-tables.yaml
@@ -1,0 +1,21 @@
+## Tool Test: Data Access MCP - list_available_data against Azure SQL (live)
+## Verifies list_available_data enumerates tables from
+## INFORMATION_SCHEMA.TABLES on the configured Azure SQL source.
+## Requires DATA_SOURCE_N=azure-sql:synapsedwh:<connection-string>.
+
+tool-test:
+  name: data-access-sql-list-tables
+  description: "list_available_data lists tables from the configured Azure SQL source"
+  tags: [data-access, mcp, azure-sql, live]
+
+  chain:
+    - agent: router
+      tool: dataaccess:list_available_data
+      arguments:
+        source_id: "synapsedwh"
+      assert:
+        result:
+          - json_parseable
+          - {matches: "\"success\"\\s*:\\s*true"}
+          - {contains: "data_items"}
+          - {contains: "count"}

--- a/testing/tools/data-access-sql-test-connection.yaml
+++ b/testing/tools/data-access-sql-test-connection.yaml
@@ -1,0 +1,20 @@
+## Tool Test: Data Access MCP - test_connection against Azure SQL (live)
+## Verifies test_connection actually reaches an Azure SQL / Synapse
+## serverless endpoint configured as an azure-sql DATA_SOURCE_N.
+## Requires DATA_SOURCE_N=azure-sql:synapsedwh:<connection-string>.
+
+tool-test:
+  name: data-access-sql-test-connection
+  description: "test_connection against the configured Azure SQL source returns success"
+  tags: [data-access, mcp, azure-sql, live]
+
+  chain:
+    - agent: router
+      tool: dataaccess:test_connection
+      arguments:
+        source_id: "synapsedwh"
+      assert:
+        result:
+          - json_parseable
+          - {matches: "\"success\"\\s*:\\s*true"}
+          - {contains: "Successfully connected"}


### PR DESCRIPTION
Follow-up to PR #198 (Data Lake), which is merged into `colab-dev`. This PR wires up **Azure SQL** end-to-end, verified live against a Synapse serverless endpoint with service-principal auth, and adds a new **`execute_query`** tool for free-form read-only SQL.

## Summary

- Wires up Azure SQL on the existing adapter: config parser, ODBC driver, honest `test_connection`, bounded reads, `filter_expr` injection guard.
- Adds `execute_query` for free-form read-only SQL (joins, aggregates, CTEs, catalog introspection) with a strict SELECT/WITH-only contract.
- Adds five new tool tests under `testing/tools/data-access-sql-*` and a setup section in `docs/MCP/data-access.md`.

Two commits: `322bba73` (SQL plumbing) + `e8de09c8` (`execute_query`).

## Azure SQL plumbing — `322bba73`

- **Config parser** (`module.py`): switched `split(":")` to `split(":", 2)` so connection strings with internal colons survive. Data Lake parsing unchanged.
- **ODBC driver** (`Dockerfile`): adds the Microsoft `bookworm` repo and installs `msodbcsql18`. Without this, every `pyodbc.connect(...)` failed at runtime.
- **Honest `test_connection`** (`azure_sql.py`): overrides `_ensure_connection` to open a connection and run `SELECT 1`. Previously inherited the base no-op and returned `success: true` regardless of reachability.
- **Bounded reads**:
  - `read_data` with no `limit` caps at **1000 rows** (`DEFAULT_ROW_CAP`), reported in `warnings[]` and `metadata.capped`.
  - `download_data` streams in **5000-row batches** with a hard **1,000,000-row** ceiling — no full table materialisation.
- **`filter_expr` injection guard**: `_validate_filter` rejects `;`, `--`, `/*`, `*/`, `xp_`, `sp_`, `exec`, `execute`, `go`. Defence in depth on top of the `db_datareader`-only SP.
- **Three live tests**: `data-access-sql-test-connection`, `data-access-sql-list-tables`, `data-access-sql-filter-rejected`.

## `execute_query` tool — `e8de09c8`

- New MCP tool for **free-form read-only SQL** — joins, aggregates, CTEs, and catalog introspection (`INFORMATION_SCHEMA.*`, `sys.tables`, `sys.columns`, `sys.objects`).
- **Read-only contract**: must start with `SELECT` or `WITH`; rejects any additional `;`, comments (`--`, `/* */`), batch separator (`GO`), stored-proc markers (`xp_`, `sp_`, `exec`, `execute`) and DML/DDL verbs (`insert`, `update`, `delete`, `merge`, `drop`, `alter`, `create`, `truncate`, `grant`, `revoke`). Same 1000-row default cap; fetches one extra row to detect truncation so callers can paginate via `ORDER BY/OFFSET` in their own query.
- **`BaseDataSourceAdapter.execute_query`** default returns `"unsupported for source type 'azure-datalake'"` so file-based sources fail honestly instead of silently no-opping.
- **Two new tests**: `data-access-sql-execute-query`, `data-access-sql-execute-query-rejected`.

## Docs — `docs/MCP/data-access.md`

- New "Azure SQL setup (Synapse serverless)" section: SP login + `db_datareader` grant + connection-string format.
- Tool table lists `execute_query`; new subsection covers the read-only contract, row caps, and the "use `read_data` instead" message for file sources.
- Test table updated with the five new `data-access-sql-*` entries.

## Verified live against Synapse serverless (`synapsedwh` / `dbo.fake_users_cetas`)

| Tool / case | Result |
|---|---|
| `test_connection` | `success: true` |
| `list_available_data` | 1 item: `dbo.fake_users_cetas` |
| `get_schema` | 13 columns, correct types |
| `read_data` limit=5 | 5 rows returned |
| `read_data` malicious `filter_expr` | rejected |
| `execute_query` `SELECT TOP 3 …` | 3 rows |
| `execute_query` CTE (`WITH c AS …`) | aggregate result |
| `execute_query` `DROP TABLE` | rejected — "must start with SELECT or WITH" |
| `execute_query` stacked `SELECT 1; SELECT 2` | rejected — "additional ';' separators" |
| `execute_query` `SELECT 1 -- comment` | rejected — "contains a forbidden token" |
| `execute_query` against Data Lake source | rejected — "unsupported for source type 'azure-datalake'" |
| `execute_query` introspection (`INFORMATION_SCHEMA.TABLES/COLUMNS`, `sys.tables JOIN sys.schemas`, `sys.objects`) | all succeed |

## Out of scope (separate follow-up PR)

**True per-user OBO**: exchanging the logged-in user's Keycloak token for an Azure SQL token (jwt-bearer grant) so queries run as the actual user. Needs the user identity plumbed from the session into the MCP call and a redesigned `azure-sql-obo` config format. The current `azure-sql-obo` client_credentials path stays functional and is documented as interim.

## Test plan

- [ ] CI green
- [ ] Reviewer can run `docker compose up -d --force-recreate --build --no-deps module-data-access` against their own SP / Synapse and confirm the five `data-access-sql-*` tests pass (or just the three guard-only ones if no live endpoint is available)
- [ ] Sanity-check that the existing 13 Data Lake tests from PR #198 still pass — the `split(":", 2)` change must not disturb Data Lake parsing
- [ ] `docs/MCP/data-access.md` setup section is reproducible