### PR TITLE
feat: add module-vectorstore for RAG semantic search

### DIFF
--- a/Dockerfile.platform-knowledge
+++ b/Dockerfile.platform-knowledge
@@ -1,0 +1,17 @@
+# Platform Knowledge Indexer
+# Indexes skills, standards, module specs, agent definitions, and docs
+# into module-vectorstore for agent semantic search.
+# Runs on every startup (idempotent — re-indexes safely via ON CONFLICT).
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir fastmcp>=2.0.0 httpx>=0.25.0
+
+COPY scripts/index_platform_knowledge.py /app/index_platform_knowledge.py
+COPY druppie/ /app/druppie/
+COPY docs/ /app/docs/
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python", "/app/index_platform_knowledge.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -411,6 +411,69 @@ services:
       start_period: 10s
 
   # ===========================================================================
+  # MODULE: VECTOR STORE (RAG) — port 9012
+  # ===========================================================================
+
+  module-vectorstore-db:
+    image: pgvector/pgvector:pg16
+    container_name: druppie-module-vectorstore-db
+    profiles: [infra, dev, prod]
+    environment:
+      POSTGRES_DB: module_vectorstore
+      POSTGRES_USER: module_vectorstore
+      POSTGRES_PASSWORD: ${MODULE_VECTORSTORE_DB_PASSWORD:-module_vectorstore_dev}
+    volumes:
+      - module-vectorstore-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U module_vectorstore"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - druppie-new-network
+
+  module-vectorstore:
+    build:
+      context: ./druppie/mcp-servers
+      dockerfile: module-vectorstore/Dockerfile
+    container_name: druppie-module-vectorstore
+    profiles: [infra, dev, prod]
+    environment:
+      MCP_PORT: "9012"
+      MODULE_DB_URL: postgresql://module_vectorstore:${MODULE_VECTORSTORE_DB_PASSWORD:-module_vectorstore_dev}@module-vectorstore-db:5432/module_vectorstore
+      MODULE_LLM_URL: http://module-llm:9008
+    ports:
+      - "${MCP_VECTORSTORE_PORT:-9012}:9012"
+    networks:
+      - druppie-new-network
+    depends_on:
+      module-vectorstore-db:
+        condition: service_healthy
+      module-llm:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9012/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  # Platform knowledge indexer — indexes skills, standards, module specs,
+  # agent definitions, and docs into module-vectorstore on every startup.
+  platform-knowledge-init:
+    build:
+      context: .
+      dockerfile: Dockerfile.platform-knowledge
+    container_name: druppie-platform-knowledge-init
+    profiles: [init, dev, prod]
+    networks:
+      - druppie-new-network
+    depends_on:
+      module-vectorstore:
+        condition: service_healthy
+    restart: "no"
+
+  # ===========================================================================
   # SANDBOX INFRASTRUCTURE (background-agents)
   # ===========================================================================
 
@@ -991,6 +1054,8 @@ volumes:
     name: druppie_sandbox_snapshots
   sandbox_dep_cache:
     name: druppie_sandbox_dep_cache
+  module-vectorstore-db-data:
+    name: druppie_module_vectorstore_db_data
   cache_scan_results:
     name: druppie_cache_scan_results
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -506,10 +506,87 @@ The Builder and Reviewer agents use skills to enforce project-specific coding st
 | `project-coding-standards` | Builder, Reviewer | Python/React code style, naming conventions, formatting rules, import conventions, and critical project rules |
 | `fullstack-architecture` | Builder | Clean architecture patterns (Summary/Detail, Repository, Service, Route) and code templates for all component types |
 | `standards-validation` | Reviewer | Structured validation checklist for architecture compliance and standards compliance |
+| `rag-patterns` | Architect | RAG design decision guide — when to use RAG, pattern catalog, chunking strategies, retrieval patterns, citation tracking |
+| `vectorstore-usage` | Architect | Operational guide for module-vectorstore tools — tool signatures, citation format, search tips |
 
 **Builder behavior**: Before writing code for the Druppie codebase, the Builder invokes `fullstack-architecture` and `project-coding-standards` to load the architecture patterns and coding standards. New components are scaffolded from embedded templates (domain models with Summary/Detail pattern, repositories extending BaseRepository, services with constructor injection, thin API routes with Depends injection, and React pages with React Query).
 
 **Reviewer behavior**: Before reviewing code, the Reviewer invokes `project-coding-standards` and `standards-validation` to load the validation checklist. Reviews include explicit architecture compliance and standards compliance sections, with critical violations (e.g., JSON/JSONB columns, business logic in routes) resulting in an automatic FAIL verdict.
+
+---
+
+## Vector Store / RAG (module-vectorstore)
+
+`module-vectorstore` gives agents semantic search over document collections. It stores text as vector embeddings in PostgreSQL (pgvector) and retrieves relevant chunks by cosine similarity.
+
+### What is stored
+
+Two categories of documents are indexed:
+
+**Platform knowledge** (index: `platform-knowledge`, project: `__platform__`) — indexed automatically on every platform startup by the `platform-knowledge-init` service:
+
+| Source | Directory | What it contains |
+|--------|-----------|-----------------|
+| Skills | `druppie/skills/*/SKILL.md` | Reusable skill instructions (rag-patterns, vectorstore-usage, etc.) |
+| Standards | `druppie/templates/project/docs/*.md` | Platform technical standards, coding standards templates |
+| Module specs | `druppie/mcp-servers/module-*/MODULE.yaml` + `v1/tools.py` | Module metadata and tool definitions |
+| Agent definitions | `druppie/agents/definitions/*.yaml` | Agent system prompts, tool access, skills |
+| Documentation | `docs/**/*.md` | Platform documentation (FEATURES, TECHNICAL, etc.) |
+| MCP config | `druppie/core/mcp_config.yaml` | Tool approval rules, parameter injection, module URLs |
+
+**Project documents** (index: per-project, project-scoped) — indexed by the Architect agent during workflow execution when the functional design references searchable document collections (policy documents, reference material, knowledge bases).
+
+### How data flows in
+
+```
+Source files → collect & chunk (1000 chars, 200 overlap)
+            → embed via module-llm (Z.AI embedding-3 / DeepInfra bge-m3)
+            → store in PostgreSQL with pgvector HNSW index
+```
+
+Each document is split into overlapping text chunks. Each chunk gets an embedding vector from `module-llm`'s `embed` tool and is stored with source metadata (`source_name`, `source_page`, `source_section`) and caller-defined metadata (JSONB) for filtering.
+
+### How agents search
+
+Agents call `vectorstore_search(index_name, query, top_k=5)`. The query is embedded via `module-llm`, then matched against stored chunks using cosine distance. Results include the chunk text, similarity score, and source metadata for citation.
+
+Available tools (5 total):
+
+| Tool | Purpose | Approval |
+|------|---------|----------|
+| `search` | Semantic search over an index | No |
+| `get_chunk` | Retrieve a specific chunk by ID | No |
+| `list_indices` | List all indices for the current project | No |
+| `index_documents` | Index new documents into a collection | No |
+| `delete_index` | Delete an entire index (irreversible) | Yes (developer) |
+
+### Agent access
+
+| Agent | Tools | Purpose |
+|-------|-------|---------|
+| Architect | search, get_chunk, list_indices, index_documents | Search platform knowledge, index project documents |
+
+The Architect uses two skills for guidance: `rag-patterns` (design decision guide) and `vectorstore-usage` (tool usage, citation format, search tips).
+
+### Infrastructure
+
+| Service | Image/Build | Port | Purpose |
+|---------|-------------|------|---------|
+| `module-vectorstore` | `druppie/mcp-servers/module-vectorstore/Dockerfile` | 9012 | MCP server with 5 tools |
+| `module-vectorstore-db` | `pgvector/pgvector:pg16` | internal | PostgreSQL with pgvector extension |
+| `platform-knowledge-init` | `Dockerfile.platform-knowledge` | — | Indexes platform docs on startup |
+
+### Database schema
+
+Three tables in `module_vectorstore` database:
+
+| Table | Purpose | Key columns |
+|-------|---------|-------------|
+| `indices` | Document collections | `project_id` + `name` (unique), `embedding_model`, `dimensions`, `chunk_size` |
+| `documents` | Ingested source docs | `index_id` (FK), `source_name`, `source_type`, `metadata` (JSONB) |
+| `chunks` | Text + vectors | `document_id` (FK), `content`, `embedding` (vector), `source_name`, `source_page`, `source_section` |
+
+All data is scoped to `project_id` — agents can only search indices belonging to their current project. The `platform-knowledge` index uses a special `__platform__` project ID and is readable by all agents.
 
 ---
 

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -502,7 +502,23 @@ ArchiMate model operations. Reads `.archimate` files from a mounted models direc
 | `search_model` | None | Search for elements by query |
 | `export_view` | None | Export an ArchiMate view |
 
-### 6.8 Declarative Parameter Injection
+### 6.8 Vector Store Server (port 9012)
+
+Semantic search over document collections using pgvector embeddings. First module with its own database (`module-vectorstore-db`).
+
+| Tool | Approval | Description |
+|------|----------|-------------|
+| `search` | None | Semantic search over an index — embeds query via module-llm, returns top-k chunks by cosine similarity |
+| `get_chunk` | None | Retrieve a specific chunk by ID with full source metadata |
+| `list_indices` | None | List all indices for the current project |
+| `index_documents` | None | Chunk text, embed via module-llm, store in pgvector with HNSW index |
+| `delete_index` | Developer | Delete an entire index and all its documents/chunks |
+
+Dependencies: `module-llm` (for embeddings), `module-vectorstore-db` (pgvector/pg16).
+
+All data is scoped to `project_id` (injected, hidden from LLM). Platform knowledge uses project ID `__platform__`.
+
+### 6.9 Declarative Parameter Injection
 
 MCP tools can have parameters auto-injected from the session/project context. Injected parameters are marked `hidden: true` and are removed from the LLM-visible tool schema. This prevents the LLM from needing to know internal IDs.
 
@@ -519,7 +535,7 @@ inject:
     tools: [read_file, write_file, list_dir, ...]
 ```
 
-### 6.9 Layered Approval System
+### 6.10 Layered Approval System
 
 Approvals have two layers:
 
@@ -557,6 +573,9 @@ module-filesearch   FastMCP           :9004   File search
 module-web          FastMCP           :9005   Web browsing
 module-archimate    FastMCP           :9006   ArchiMate models
 module-registry     FastMCP           :9007   Platform catalog/discovery
+module-llm          FastMCP           :9008   LLM chat + embeddings
+module-vectorstore  FastMCP           :9012   Semantic search (pgvector)
+module-vectorstore-db  pgvector/pg16  -       Vector store database (internal)
 adminer             Adminer           :8081   DB admin UI
 sandbox-control-plane  Node.js        :8787   Sandbox session/event management
 sandbox-manager     Node.js           :8000   Sandbox container lifecycle

--- a/druppie/agents/definitions/architect.yaml
+++ b/druppie/agents/definitions/architect.yaml
@@ -378,6 +378,25 @@ system_prompt: |
   workspace; coding_read_project_file is only for inspecting OTHER
   projects in Gitea.)
 
+  ### Level 2b: Indexed documents — DIRECT tool calls (instant)
+  If the project has indexed document collections (policy docs, reference
+  material), use the vectorstore tools to search them. Call
+  invoke_skill(skill_name="vectorstore-usage") for the full usage guide
+  including tool signatures, citation format, and search tips.
+
+  Start with vectorstore_list_indices() to see what's available, then
+  vectorstore_search(index_name, query) to find relevant context.
+
+  Use these during Step 1 (intake) and Step 3 (research) when the FD
+  references specific document collections or when you need domain context
+  from indexed sources.
+
+  **Indexing project documents:** When the FD includes source documents
+  that need to be searchable (policy PDFs, reference material, knowledge
+  bases), use vectorstore_index_documents() to index them into a
+  project-scoped collection. Use one index per logical document group,
+  named descriptively (e.g. "policy-docs", "reference-material").
+
   ### Level 3: Druppie codebase exploration — SANDBOX (deep analysis)
   This spawns a separate container to explore Druppie's own source code.
 
@@ -515,6 +534,13 @@ system_prompt: |
   * Evaluate: Do you have enough information to design? If not, or if this
     is a core update → do Level 3 (see CONTEXT GATHERING for rules)
   * Apply the reuse decision framework (see CONTEXT GATHERING) to each capability
+  * RAG detection: If the FD describes document search, knowledge bases,
+    source references, FAQ over large documents, semantic search, or
+    retrieval-augmented generation — invoke
+    invoke_skill(skill_name="rag-patterns") to load the RAG decision
+    guide before proceeding to the research phase. This provides chunking
+    strategies, retrieval patterns, citation tracking, and
+    module-vectorstore configuration defaults.
 
   ### Step 2: Integral Architecture Check
 
@@ -792,6 +818,8 @@ skills:
   - module-convention
   - technical-research-format
   - technical-design-format
+  - rag-patterns
+  - vectorstore-usage
 
 system_prompts:
   - tool_only_communication
@@ -825,6 +853,11 @@ mcps:
     - get_view
     - search_model
     - get_impact
+  vectorstore:
+    - search
+    - get_chunk
+    - list_indices
+    - index_documents
 
 extra_builtin_tools:
   - execute_coding_task

--- a/druppie/core/mcp_config.yaml
+++ b/druppie/core/mcp_config.yaml
@@ -243,6 +243,8 @@ mcps:
     tools:
       - name: chat
         requires_approval: false
+      - name: embed
+        requires_approval: false
 
   vision:
     url: ${MCP_VISION_URL:-http://module-vision:9011}
@@ -304,4 +306,34 @@ mcps:
         requires_approval: false
 
       - name: download_data
+        requires_approval: false
+
+  vectorstore:
+    url: ${MCP_VECTORSTORE_URL:-http://module-vectorstore:9012}
+    type: both
+    inject:
+      user_id:
+        from: session.user_id
+        hidden: true
+      project_id:
+        from: project.id
+        hidden: true
+      session_id:
+        from: session.id
+        hidden: true
+    tools:
+      - name: index_documents
+        requires_approval: false
+
+      - name: search
+        requires_approval: false
+
+      - name: get_chunk
+        requires_approval: false
+
+      - name: delete_index
+        requires_approval: true
+        required_role: developer
+
+      - name: list_indices
         requires_approval: false

--- a/druppie/mcp-servers/module-llm/v1/module.py
+++ b/druppie/mcp-servers/module-llm/v1/module.py
@@ -1,6 +1,6 @@
 """LLM MCP Server - Business Logic Module.
 
-Wraps Z.AI GLM (OpenAI-compatible) API for chat completion.
+Wraps Z.AI GLM (OpenAI-compatible) API for chat completion and embeddings.
 Falls back to DeepInfra if ZAI_API_KEY is not set.
 """
 
@@ -14,10 +14,12 @@ logger = logging.getLogger("llm-mcp")
 # Z.AI GLM defaults
 ZAI_DEFAULT_MODEL = "glm-4.7"
 ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+ZAI_DEFAULT_EMBEDDING_MODEL = "embedding-3"
 
 # DeepInfra fallback
 DEEPINFRA_DEFAULT_MODEL = "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8"
 DEEPINFRA_BASE_URL = "https://api.deepinfra.com/v1/openai"
+DEEPINFRA_DEFAULT_EMBEDDING_MODEL = "BAAI/bge-m3"
 
 
 class LLMModule:
@@ -35,7 +37,8 @@ class LLMModule:
                 base_url=os.environ.get("ZAI_BASE_URL", ZAI_DEFAULT_BASE_URL),
             )
             self._default_model = os.environ.get("ZAI_MODEL") or ZAI_DEFAULT_MODEL
-            logger.info("LLM provider: Z.AI (model=%s)", self._default_model)
+            self._default_embedding_model = os.environ.get("ZAI_EMBEDDING_MODEL") or ZAI_DEFAULT_EMBEDDING_MODEL
+            logger.info("LLM provider: Z.AI (model=%s, embedding=%s)", self._default_model, self._default_embedding_model)
         elif deepinfra_key:
             self._provider = "deepinfra"
             self._client = OpenAI(
@@ -43,12 +46,14 @@ class LLMModule:
                 base_url=DEEPINFRA_BASE_URL,
             )
             self._default_model = DEEPINFRA_DEFAULT_MODEL
-            logger.info("LLM provider: DeepInfra (model=%s)", self._default_model)
+            self._default_embedding_model = DEEPINFRA_DEFAULT_EMBEDDING_MODEL
+            logger.info("LLM provider: DeepInfra (model=%s, embedding=%s)", self._default_model, self._default_embedding_model)
         else:
             self._provider = "none"
             self._client = None
             self._default_model = ""
-            logger.warning("No LLM API key set (ZAI_API_KEY or DEEPINFRA_API_KEY) — chat calls will fail")
+            self._default_embedding_model = ""
+            logger.warning("No LLM API key set (ZAI_API_KEY or DEEPINFRA_API_KEY) — chat/embed calls will fail")
 
     @property
     def provider(self) -> str:
@@ -67,3 +72,14 @@ class LLMModule:
             ],
         )
         return response.choices[0].message.content
+
+    def embed(self, texts: list[str], model: str | None = None) -> list[list[float]]:
+        """Generate embeddings for a list of texts."""
+        if not self._client:
+            raise RuntimeError("No LLM provider configured — set ZAI_API_KEY or DEEPINFRA_API_KEY")
+
+        response = self._client.embeddings.create(
+            model=model or self._default_embedding_model,
+            input=texts,
+        )
+        return [item.embedding for item in response.data]

--- a/druppie/mcp-servers/module-llm/v1/tools.py
+++ b/druppie/mcp-servers/module-llm/v1/tools.py
@@ -1,8 +1,10 @@
 """LLM v1 — MCP Tool Definitions.
 
-Provides chat completion backed by Z.AI GLM or DeepInfra.
+Provides chat completion and embeddings backed by Z.AI GLM or DeepInfra.
 """
 
+import asyncio
+import time
 from fastmcp import FastMCP
 from .module import LLMModule
 
@@ -12,7 +14,7 @@ MODULE_VERSION = "1.0.0"
 mcp = FastMCP(
     "LLM v1",
     version=MODULE_VERSION,
-    instructions="LLM chat completion. Use for text generation, summarization, and question answering.",
+    instructions="LLM chat completion and embeddings. Use for text generation, summarization, question answering, and generating text embeddings for semantic search.",
 )
 
 module = LLMModule()
@@ -37,3 +39,36 @@ async def chat(
     """
     answer = module.chat(prompt=prompt, system=system, model=model)
     return {"answer": answer}
+
+
+@mcp.tool(
+    name="embed",
+    description="Generate text embeddings for semantic search and similarity. Returns a list of embedding vectors.",
+    meta={
+        "module_id": MODULE_ID,
+        "version": MODULE_VERSION,
+        "resource_metrics": {
+            "processing_ms": {"type": "integer", "unit": "milliseconds"},
+        },
+    },
+)
+async def embed(
+    texts: list[str],
+    model: str | None = None,
+) -> dict:
+    start = time.time()
+    embeddings = await asyncio.to_thread(module.embed, texts=texts, model=model)
+    elapsed_ms = int((time.time() - start) * 1000)
+    return {
+        "embeddings": embeddings,
+        "dimensions": len(embeddings[0]) if embeddings else 0,
+        "count": len(embeddings),
+        "_meta": {
+            "module_id": MODULE_ID,
+            "module_version": MODULE_VERSION,
+            "usage": {
+                "cost_cents": 0.0,
+                "resources": {"processing_ms": elapsed_ms},
+            },
+        },
+    }

--- a/druppie/mcp-servers/module-vectorstore/Dockerfile
+++ b/druppie/mcp-servers/module-vectorstore/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install dependencies
+COPY module-vectorstore/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy shared router factory and module code
+COPY module_router.py .
+COPY module-vectorstore/ .
+
+ENV MCP_PORT=9012
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 9012
+
+HEALTHCHECK --interval=10s --timeout=5s --retries=10 --start-period=30s \
+    CMD curl -f http://localhost:9012/health || exit 1
+
+CMD ["python", "server.py"]

--- a/druppie/mcp-servers/module-vectorstore/MODULE.yaml
+++ b/druppie/mcp-servers/module-vectorstore/MODULE.yaml
@@ -1,0 +1,4 @@
+id: vectorstore
+latest_version: "1.0.0"
+versions:
+  - "1.0.0"

--- a/druppie/mcp-servers/module-vectorstore/db.py
+++ b/druppie/mcp-servers/module-vectorstore/db.py
@@ -1,0 +1,62 @@
+"""Vector Store database connection and schema management."""
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+
+import asyncpg
+from pgvector.asyncpg import register_vector
+
+logger = logging.getLogger("vectorstore-mcp.db")
+
+_pool: asyncpg.Pool | None = None
+_pool_lock = asyncio.Lock()
+
+DB_URL = os.getenv(
+    "MODULE_DB_URL",
+    "postgresql://module_vectorstore:module_vectorstore_dev@module-vectorstore-db:5432/module_vectorstore",
+)
+
+SCHEMA_DIR = Path(__file__).parent / "v1" / "schema"
+
+
+async def get_pool() -> asyncpg.Pool:
+    global _pool
+    if _pool is not None:
+        return _pool
+    async with _pool_lock:
+        if _pool is not None:
+            return _pool
+        _pool = await asyncpg.create_pool(
+            DB_URL,
+            min_size=2,
+            max_size=10,
+            init=_init_connection,
+        )
+        await _run_migrations(_pool)
+        logger.info("Database pool created and migrations applied")
+        return _pool
+
+
+async def _init_connection(conn: asyncpg.Connection):
+    """Register pgvector type on each new connection."""
+    await register_vector(conn)
+
+
+async def _run_migrations(pool: asyncpg.Pool):
+    """Apply SQL migration files in order."""
+    migration_files = sorted(SCHEMA_DIR.glob("[0-9]*.sql"))
+    async with pool.acquire() as conn:
+        for migration_file in migration_files:
+            sql = migration_file.read_text()
+            logger.info("Applying migration: %s", migration_file.name)
+            await conn.execute(sql)
+
+
+async def close_pool():
+    global _pool
+    if _pool is not None:
+        await _pool.close()
+        _pool = None
+        logger.info("Database pool closed")

--- a/druppie/mcp-servers/module-vectorstore/requirements.txt
+++ b/druppie/mcp-servers/module-vectorstore/requirements.txt
@@ -1,0 +1,6 @@
+fastmcp>=2.0.0,<3.0.0
+pyyaml>=6.0
+uvicorn>=0.24.0
+starlette>=0.27.0
+asyncpg>=0.29.0
+pgvector>=0.3.0

--- a/druppie/mcp-servers/module-vectorstore/server.py
+++ b/druppie/mcp-servers/module-vectorstore/server.py
@@ -1,0 +1,8 @@
+"""Vector Store MCP Server — Version Router."""
+
+from module_router import create_module_app, run_module
+
+app = create_module_app("vectorstore", default_port=9012)
+
+if __name__ == "__main__":
+    run_module("vectorstore", default_port=9012)

--- a/druppie/mcp-servers/module-vectorstore/v1/module.py
+++ b/druppie/mcp-servers/module-vectorstore/v1/module.py
@@ -1,0 +1,494 @@
+"""Vector Store Module v1 — Public API.
+
+Entry point for v1 business logic. One public method per MCP tool.
+Imported by v1/tools.py for MCP exposure.
+"""
+
+import json
+import logging
+import os
+import re
+import uuid
+from typing import Any
+
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+from db import get_pool
+
+logger = logging.getLogger("vectorstore-mcp.v1")
+
+MODULE_LLM_URL = os.getenv("MODULE_LLM_URL", "http://module-llm:9008")
+EMBEDDING_BATCH_SIZE = int(os.getenv("EMBEDDING_BATCH_SIZE", "100"))
+
+_SAFE_KEY_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+class VectorStoreModule:
+    """v1 business logic for vector storage and retrieval."""
+
+    def __init__(self, llm_url: str = MODULE_LLM_URL):
+        self._llm_url = llm_url
+
+    async def index_documents(
+        self,
+        index_name: str,
+        documents: list[dict[str, Any]],
+        chunk_size: int = 1000,
+        chunk_overlap: int = 200,
+        embedding_model: str = "default",
+        description: str = "",
+        user_id: str = "",
+        project_id: str = "",
+        session_id: str = "",
+        app_id: str = "",
+    ) -> dict[str, Any]:
+        """Index documents by chunking, embedding, and storing in pgvector."""
+        if chunk_overlap >= chunk_size:
+            raise ValueError(
+                f"chunk_overlap ({chunk_overlap}) must be less than chunk_size ({chunk_size})"
+            )
+
+        pool = await get_pool()
+
+        async with pool.acquire() as conn:
+            index_row = await conn.fetchrow(
+                """
+                INSERT INTO indices (project_id, name, description, embedding_model,
+                                     chunk_size, chunk_overlap)
+                VALUES ($1, $2, $3, $4, $5, $6)
+                ON CONFLICT (project_id, name) DO UPDATE
+                    SET description = EXCLUDED.description,
+                        embedding_model = EXCLUDED.embedding_model,
+                        chunk_size = EXCLUDED.chunk_size,
+                        chunk_overlap = EXCLUDED.chunk_overlap,
+                        updated_at = now()
+                RETURNING id, dimensions
+                """,
+                project_id, index_name, description,
+                embedding_model, chunk_size, chunk_overlap,
+            )
+            index_id = index_row["id"]
+            current_dimensions = index_row["dimensions"]
+
+        total_chunks = 0
+        all_chunk_ids: list[uuid.UUID] = []
+        all_texts: list[str] = []
+
+        effective_chunk_size = chunk_size - chunk_overlap
+
+        for doc in documents:
+            content = doc["content"]
+            source_name = doc.get("source_name", "unknown")
+            source_type = doc.get("source_type", "text")
+            doc_metadata = doc.get("metadata", {})
+
+            chunks = self._chunk_text(content, effective_chunk_size, chunk_overlap)
+
+            async with pool.acquire() as conn:
+                doc_row = await conn.fetchrow(
+                    """
+                    INSERT INTO documents (index_id, source_name, source_type,
+                                           chunk_count, metadata)
+                    VALUES ($1, $2, $3, $4, $5::jsonb)
+                    RETURNING id
+                    """,
+                    index_id, source_name, source_type,
+                    len(chunks), _to_json(doc_metadata),
+                )
+                document_id = doc_row["id"]
+
+                for i, chunk_text in enumerate(chunks):
+                    chunk_row = await conn.fetchrow(
+                        """
+                        INSERT INTO chunks (index_id, document_id, chunk_index,
+                                            content, source_name, source_page,
+                                            source_section, metadata)
+                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+                        RETURNING id
+                        """,
+                        index_id, document_id, i, chunk_text,
+                        source_name, doc.get("source_page"),
+                        doc.get("source_section"), _to_json(doc_metadata),
+                    )
+                    all_chunk_ids.append(chunk_row["id"])
+                    all_texts.append(chunk_text)
+
+            total_chunks += len(chunks)
+
+        if all_texts:
+            embeddings = await self._get_embeddings(all_texts, embedding_model)
+            dimensions = len(embeddings[0]) if embeddings else 0
+
+            async with pool.acquire() as conn:
+                if current_dimensions == 0 and dimensions > 0:
+                    await conn.execute(
+                        "UPDATE indices SET dimensions = $1 WHERE id = $2",
+                        dimensions, index_id,
+                    )
+
+                for chunk_id, embedding in zip(all_chunk_ids, embeddings):
+                    await conn.execute(
+                        "UPDATE chunks SET embedding = $1 WHERE id = $2",
+                        str(embedding), chunk_id,
+                    )
+
+                await self._ensure_vector_index(conn, index_id, dimensions)
+
+        return {
+            "index_id": str(index_id),
+            "index_name": index_name,
+            "documents_indexed": len(documents),
+            "chunks_created": total_chunks,
+        }
+
+    async def search(
+        self,
+        index_name: str,
+        query: str,
+        top_k: int = 5,
+        similarity_threshold: float = 0.0,
+        filter_metadata: dict[str, Any] | None = None,
+        user_id: str = "",
+        project_id: str = "",
+        session_id: str = "",
+        app_id: str = "",
+    ) -> dict[str, Any]:
+        """Search for relevant chunks using vector similarity."""
+        if filter_metadata:
+            for key in filter_metadata:
+                if not _SAFE_KEY_RE.match(key):
+                    raise ValueError(
+                        f"Invalid metadata filter key: '{key}'. "
+                        "Keys must be alphanumeric/underscore identifiers."
+                    )
+
+        pool = await get_pool()
+
+        async with pool.acquire() as conn:
+            index_row = await conn.fetchrow(
+                "SELECT id, embedding_model FROM indices WHERE project_id = $1 AND name = $2",
+                project_id, index_name,
+            )
+            if not index_row:
+                raise ValueError(f"Index '{index_name}' not found for this project")
+
+            index_id = index_row["id"]
+            embedding_model = index_row["embedding_model"]
+
+        query_embeddings = await self._get_embeddings([query], embedding_model)
+        if not query_embeddings:
+            raise RuntimeError("Failed to generate query embedding")
+        query_embedding = query_embeddings[0]
+
+        async with pool.acquire() as conn:
+            query_sql = """
+                SELECT c.id, c.content, c.source_name, c.source_page,
+                       c.source_section, c.metadata, c.chunk_index,
+                       1 - (c.embedding <=> $1::vector) AS score
+                FROM chunks c
+                WHERE c.index_id = $2
+                  AND c.embedding IS NOT NULL
+            """
+            params: list[Any] = [str(query_embedding), index_id]
+            param_idx = 3
+
+            if similarity_threshold > 0:
+                query_sql += f" AND 1 - (c.embedding <=> $1::vector) >= ${param_idx}"
+                params.append(similarity_threshold)
+                param_idx += 1
+
+            if filter_metadata:
+                for key, value in filter_metadata.items():
+                    query_sql += f" AND c.metadata->>'{key}' = ${param_idx}"
+                    params.append(str(value))
+                    param_idx += 1
+
+            query_sql += " ORDER BY c.embedding <=> $1::vector LIMIT $" + str(param_idx)
+            params.append(top_k)
+
+            rows = await conn.fetch(query_sql, *params)
+
+        results = [
+            {
+                "chunk_id": str(row["id"]),
+                "content": row["content"],
+                "score": float(row["score"]),
+                "source_name": row["source_name"],
+                "source_page": row["source_page"],
+                "source_section": row["source_section"],
+                "metadata": _from_json(row["metadata"]),
+                "chunk_index": row["chunk_index"],
+            }
+            for row in rows
+        ]
+
+        return {
+            "results": results,
+            "index_name": index_name,
+            "query": query,
+            "result_count": len(results),
+        }
+
+    async def get_chunk(
+        self,
+        chunk_id: str,
+        user_id: str = "",
+        project_id: str = "",
+        session_id: str = "",
+        app_id: str = "",
+    ) -> dict[str, Any]:
+        """Retrieve a specific chunk by ID."""
+        pool = await get_pool()
+
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT c.id, c.content, c.chunk_index, c.source_name,
+                       c.source_page, c.source_section, c.metadata, c.created_at,
+                       d.source_type, i.name AS index_name
+                FROM chunks c
+                JOIN documents d ON c.document_id = d.id
+                JOIN indices i ON c.index_id = i.id
+                WHERE c.id = $1 AND i.project_id = $2
+                """,
+                uuid.UUID(chunk_id), project_id,
+            )
+
+        if not row:
+            raise ValueError(f"Chunk '{chunk_id}' not found")
+
+        return {
+            "chunk_id": str(row["id"]),
+            "content": row["content"],
+            "chunk_index": row["chunk_index"],
+            "source_name": row["source_name"],
+            "source_page": row["source_page"],
+            "source_section": row["source_section"],
+            "source_type": row["source_type"],
+            "metadata": _from_json(row["metadata"]),
+            "index_name": row["index_name"],
+            "created_at": row["created_at"].isoformat(),
+        }
+
+    async def delete_index(
+        self,
+        index_name: str,
+        user_id: str = "",
+        project_id: str = "",
+        session_id: str = "",
+        app_id: str = "",
+    ) -> dict[str, Any]:
+        """Delete an entire index and all its documents and chunks."""
+        pool = await get_pool()
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    "SELECT id FROM indices WHERE project_id = $1 AND name = $2",
+                    project_id, index_name,
+                )
+                if not row:
+                    raise ValueError(f"Index '{index_name}' not found for this project")
+
+                index_id = row["id"]
+
+                chunk_count = await conn.fetchval(
+                    "SELECT count(*) FROM chunks WHERE index_id = $1",
+                    index_id,
+                )
+
+                await conn.execute(
+                    "DELETE FROM indices WHERE id = $1",
+                    index_id,
+                )
+
+        return {
+            "deleted": True,
+            "index_name": index_name,
+            "chunks_removed": chunk_count,
+        }
+
+    async def list_indices(
+        self,
+        user_id: str = "",
+        project_id: str = "",
+        session_id: str = "",
+        app_id: str = "",
+    ) -> dict[str, Any]:
+        """List all indices for a project."""
+        pool = await get_pool()
+
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT i.id, i.name, i.description, i.embedding_model,
+                       i.dimensions, i.chunk_size, i.chunk_overlap,
+                       i.created_at, i.updated_at,
+                       (SELECT count(*) FROM documents d WHERE d.index_id = i.id) AS document_count,
+                       (SELECT count(*) FROM chunks c WHERE c.index_id = i.id) AS chunk_count
+                FROM indices i
+                WHERE i.project_id = $1
+                ORDER BY i.created_at DESC
+                """,
+                project_id,
+            )
+
+        return {
+            "indices": [
+                {
+                    "id": str(row["id"]),
+                    "name": row["name"],
+                    "description": row["description"],
+                    "embedding_model": row["embedding_model"],
+                    "dimensions": row["dimensions"],
+                    "chunk_size": row["chunk_size"],
+                    "chunk_overlap": row["chunk_overlap"],
+                    "document_count": row["document_count"],
+                    "chunk_count": row["chunk_count"],
+                    "created_at": row["created_at"].isoformat(),
+                    "updated_at": row["updated_at"].isoformat(),
+                }
+                for row in rows
+            ],
+            "count": len(rows),
+        }
+
+    def _chunk_text(
+        self, text: str, chunk_size: int, chunk_overlap: int,
+    ) -> list[str]:
+        """Split text into overlapping chunks at sentence boundaries."""
+        if len(text) <= chunk_size:
+            return [text]
+
+        separators = ["\n\n", "\n", ". ", "! ", "? ", "; ", ", ", " "]
+        return self._recursive_split(text, chunk_size, chunk_overlap, separators)
+
+    def _recursive_split(
+        self,
+        text: str,
+        chunk_size: int,
+        chunk_overlap: int,
+        separators: list[str],
+    ) -> list[str]:
+        """Recursively split text using progressively finer separators."""
+        if len(text) <= chunk_size:
+            return [text.strip()] if text.strip() else []
+
+        separator = separators[0] if separators else ""
+        remaining_separators = separators[1:] if len(separators) > 1 else []
+
+        if separator:
+            parts = text.split(separator)
+        else:
+            step = max(1, chunk_size - chunk_overlap)
+            parts = [text[i:i + chunk_size] for i in range(0, len(text), step)]
+            return [p.strip() for p in parts if p.strip()]
+
+        chunks: list[str] = []
+        current = ""
+
+        for part in parts:
+            candidate = current + separator + part if current else part
+            if len(candidate) <= chunk_size:
+                current = candidate
+            else:
+                if current.strip():
+                    chunks.append(current.strip())
+                if len(part) > chunk_size and remaining_separators:
+                    sub_chunks = self._recursive_split(
+                        part, chunk_size, chunk_overlap, remaining_separators,
+                    )
+                    chunks.extend(sub_chunks)
+                    current = ""
+                else:
+                    current = part
+
+        if current.strip():
+            chunks.append(current.strip())
+
+        if chunk_overlap > 0 and len(chunks) > 1:
+            chunks = self._add_overlap(chunks, chunk_overlap)
+
+        return chunks
+
+    def _add_overlap(self, chunks: list[str], overlap: int) -> list[str]:
+        """Add overlap between consecutive chunks by prepending context from the previous chunk."""
+        result = [chunks[0]]
+        for i in range(1, len(chunks)):
+            prev_tail = chunks[i - 1][-overlap:] if len(chunks[i - 1]) > overlap else chunks[i - 1]
+            overlapped = prev_tail + " " + chunks[i]
+            result.append(overlapped)
+        return result
+
+    async def _get_embeddings(
+        self, texts: list[str], model: str,
+    ) -> list[list[float]]:
+        """Get embeddings from module-llm via MCP tool call."""
+        all_embeddings: list[list[float]] = []
+
+        for i in range(0, len(texts), EMBEDDING_BATCH_SIZE):
+            batch = texts[i:i + EMBEDDING_BATCH_SIZE]
+            embeddings = await self._call_llm_embed(batch, model)
+            all_embeddings.extend(embeddings)
+
+        return all_embeddings
+
+    async def _call_llm_embed(
+        self, texts: list[str], model: str,
+    ) -> list[list[float]]:
+        """Call module-llm embed tool via FastMCP client."""
+        arguments: dict[str, Any] = {"texts": texts}
+        if model and model != "default":
+            arguments["model"] = model
+
+        transport = StreamableHttpTransport(url=f"{self._llm_url}/mcp")
+        async with Client(transport) as client:
+            result = await client.call_tool("embed", arguments)
+
+        if isinstance(result, list) and len(result) > 0:
+            first_item = result[0]
+            if hasattr(first_item, "text"):
+                data = json.loads(first_item.text)
+                return data.get("embeddings", [])
+
+        raise RuntimeError("Unexpected response format from module-llm embed")
+
+    async def _ensure_vector_index(
+        self, conn, index_id: uuid.UUID, dimensions: int,
+    ):
+        """Create HNSW index for vector similarity search if not exists."""
+        if dimensions <= 0:
+            return
+
+        safe_id = str(index_id).replace("-", "_")
+        if not re.match(r"^[a-f0-9_]+$", safe_id):
+            raise ValueError(f"Invalid index_id format: {index_id}")
+        if not isinstance(dimensions, int) or dimensions <= 0 or dimensions > 10000:
+            raise ValueError(f"Invalid dimensions: {dimensions}")
+
+        index_name = f"idx_chunks_embedding_{safe_id}"
+
+        exists = await conn.fetchval(
+            "SELECT 1 FROM pg_indexes WHERE indexname = $1",
+            index_name,
+        )
+        if not exists:
+            await conn.execute(f"""
+                CREATE INDEX {index_name}
+                ON chunks USING hnsw ((embedding::vector({dimensions})) vector_cosine_ops)
+                WHERE index_id = '{index_id}'
+            """)
+            logger.info("Created HNSW index %s (dim=%d)", index_name, dimensions)
+
+
+def _to_json(data: dict | None) -> str:
+    return json.dumps(data or {})
+
+
+def _from_json(data) -> dict:
+    if isinstance(data, dict):
+        return data
+    if isinstance(data, str):
+        return json.loads(data)
+    return {}

--- a/druppie/mcp-servers/module-vectorstore/v1/schema/001_initial.sql
+++ b/druppie/mcp-servers/module-vectorstore/v1/schema/001_initial.sql
@@ -1,0 +1,44 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS indices (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id      TEXT NOT NULL,
+    name            TEXT NOT NULL,
+    description     TEXT NOT NULL DEFAULT '',
+    embedding_model TEXT NOT NULL DEFAULT 'default',
+    dimensions      INTEGER NOT NULL DEFAULT 0,
+    chunk_size      INTEGER NOT NULL DEFAULT 1000,
+    chunk_overlap   INTEGER NOT NULL DEFAULT 200,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (project_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS documents (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    index_id        UUID NOT NULL REFERENCES indices(id) ON DELETE CASCADE,
+    source_name     TEXT NOT NULL,
+    source_type     TEXT NOT NULL DEFAULT 'text',
+    chunk_count     INTEGER NOT NULL DEFAULT 0,
+    metadata        JSONB NOT NULL DEFAULT '{}',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_documents_index_id ON documents(index_id);
+
+CREATE TABLE IF NOT EXISTS chunks (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    index_id        UUID NOT NULL REFERENCES indices(id) ON DELETE CASCADE,
+    document_id     UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    chunk_index     INTEGER NOT NULL,
+    content         TEXT NOT NULL,
+    embedding       vector,
+    source_name     TEXT NOT NULL DEFAULT '',
+    source_page     INTEGER,
+    source_section  TEXT,
+    metadata        JSONB NOT NULL DEFAULT '{}',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_chunks_index_id ON chunks(index_id);
+CREATE INDEX IF NOT EXISTS idx_chunks_document_id ON chunks(document_id);

--- a/druppie/mcp-servers/module-vectorstore/v1/schema/current.sql
+++ b/druppie/mcp-servers/module-vectorstore/v1/schema/current.sql
@@ -1,0 +1,44 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS indices (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id      TEXT NOT NULL,
+    name            TEXT NOT NULL,
+    description     TEXT NOT NULL DEFAULT '',
+    embedding_model TEXT NOT NULL DEFAULT 'default',
+    dimensions      INTEGER NOT NULL DEFAULT 0,
+    chunk_size      INTEGER NOT NULL DEFAULT 1000,
+    chunk_overlap   INTEGER NOT NULL DEFAULT 200,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (project_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS documents (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    index_id        UUID NOT NULL REFERENCES indices(id) ON DELETE CASCADE,
+    source_name     TEXT NOT NULL,
+    source_type     TEXT NOT NULL DEFAULT 'text',
+    chunk_count     INTEGER NOT NULL DEFAULT 0,
+    metadata        JSONB NOT NULL DEFAULT '{}',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_documents_index_id ON documents(index_id);
+
+CREATE TABLE IF NOT EXISTS chunks (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    index_id        UUID NOT NULL REFERENCES indices(id) ON DELETE CASCADE,
+    document_id     UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    chunk_index     INTEGER NOT NULL,
+    content         TEXT NOT NULL,
+    embedding       vector,
+    source_name     TEXT NOT NULL DEFAULT '',
+    source_page     INTEGER,
+    source_section  TEXT,
+    metadata        JSONB NOT NULL DEFAULT '{}',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_chunks_index_id ON chunks(index_id);
+CREATE INDEX IF NOT EXISTS idx_chunks_document_id ON chunks(document_id);

--- a/druppie/mcp-servers/module-vectorstore/v1/tools.py
+++ b/druppie/mcp-servers/module-vectorstore/v1/tools.py
@@ -1,0 +1,228 @@
+"""Vector Store v1 — MCP Tool Definitions.
+
+Single source of truth for tool contract:
+- Tool name, description, input schema via @mcp.tool()
+- Version and module_id via @mcp.tool(meta={...})
+- Agent guidance via FastMCP(instructions=...)
+"""
+
+import os
+import time
+from typing import Any
+
+from fastmcp import FastMCP
+from .module import VectorStoreModule
+
+MODULE_ID = "vectorstore"
+MODULE_VERSION = "1.0.0"
+
+mcp = FastMCP(
+    "Vector Store v1",
+    version=MODULE_VERSION,
+    instructions="""Vector storage and retrieval for RAG (Retrieval-Augmented Generation).
+
+Use when:
+- Indexing documents for semantic search
+- Searching a knowledge base to find relevant context
+- Building document Q&A or citation-driven workflows
+- Finding similar content across a document collection
+
+Don't use when:
+- You need exact keyword/grep matching (use module-filesearch)
+- You only need to read a single known file (use coding read_file)
+- You need web search (use module-web)
+""",
+)
+
+module = VectorStoreModule(
+    llm_url=os.getenv("MODULE_LLM_URL", "http://module-llm:9008"),
+)
+
+
+@mcp.tool(
+    name="index_documents",
+    description="Index documents for semantic search. Chunks text, generates embeddings, and stores in vector database. Each document needs 'content' and 'source_name' fields.",
+    meta={
+        "module_id": MODULE_ID,
+        "version": MODULE_VERSION,
+        "resource_metrics": {
+            "processing_ms": {"type": "integer", "unit": "milliseconds"},
+        },
+    },
+)
+async def index_documents(
+    index_name: str,
+    documents: list[dict[str, Any]],
+    chunk_size: int = 1000,
+    chunk_overlap: int = 200,
+    embedding_model: str = "default",
+    description: str = "",
+    user_id: str = "",
+    project_id: str = "",
+    session_id: str = "",
+    app_id: str = "",
+) -> dict:
+    start = time.time()
+    result = await module.index_documents(
+        index_name=index_name,
+        documents=documents,
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        embedding_model=embedding_model,
+        description=description,
+        user_id=user_id,
+        project_id=project_id,
+        session_id=session_id,
+        app_id=app_id,
+    )
+    elapsed_ms = int((time.time() - start) * 1000)
+    return {
+        **result,
+        "_meta": {
+            "module_id": MODULE_ID,
+            "module_version": MODULE_VERSION,
+            "usage": {
+                "cost_cents": 0.0,
+                "resources": {"processing_ms": elapsed_ms},
+            },
+        },
+    }
+
+
+@mcp.tool(
+    name="search",
+    description="Search indexed documents using semantic similarity. Returns ranked chunks with source citations (source_name, source_page, source_section) for traceability.",
+    meta={
+        "module_id": MODULE_ID,
+        "version": MODULE_VERSION,
+        "resource_metrics": {
+            "processing_ms": {"type": "integer", "unit": "milliseconds"},
+        },
+    },
+)
+async def search(
+    index_name: str,
+    query: str,
+    top_k: int = 5,
+    similarity_threshold: float = 0.0,
+    filter_metadata: dict[str, Any] | None = None,
+    user_id: str = "",
+    project_id: str = "",
+    session_id: str = "",
+    app_id: str = "",
+) -> dict:
+    start = time.time()
+    result = await module.search(
+        index_name=index_name,
+        query=query,
+        top_k=top_k,
+        similarity_threshold=similarity_threshold,
+        filter_metadata=filter_metadata,
+        user_id=user_id,
+        project_id=project_id,
+        session_id=session_id,
+        app_id=app_id,
+    )
+    elapsed_ms = int((time.time() - start) * 1000)
+    return {
+        **result,
+        "_meta": {
+            "module_id": MODULE_ID,
+            "module_version": MODULE_VERSION,
+            "usage": {
+                "cost_cents": 0.0,
+                "resources": {"processing_ms": elapsed_ms},
+            },
+        },
+    }
+
+
+@mcp.tool(
+    name="get_chunk",
+    description="Retrieve a specific chunk by ID. Use after search to get the full context of a result including all source metadata for citation.",
+    meta={
+        "module_id": MODULE_ID,
+        "version": MODULE_VERSION,
+    },
+)
+async def get_chunk(
+    chunk_id: str,
+    user_id: str = "",
+    project_id: str = "",
+    session_id: str = "",
+    app_id: str = "",
+) -> dict:
+    result = await module.get_chunk(
+        chunk_id=chunk_id,
+        user_id=user_id,
+        project_id=project_id,
+        session_id=session_id,
+        app_id=app_id,
+    )
+    return {
+        **result,
+        "_meta": {
+            "module_id": MODULE_ID,
+            "module_version": MODULE_VERSION,
+        },
+    }
+
+
+@mcp.tool(
+    name="delete_index",
+    description="Delete an entire index and all its documents and chunks. This is irreversible.",
+    meta={
+        "module_id": MODULE_ID,
+        "version": MODULE_VERSION,
+    },
+)
+async def delete_index(
+    index_name: str,
+    user_id: str = "",
+    project_id: str = "",
+    session_id: str = "",
+    app_id: str = "",
+) -> dict:
+    result = await module.delete_index(
+        index_name=index_name,
+        user_id=user_id,
+        project_id=project_id,
+        session_id=session_id,
+        app_id=app_id,
+    )
+    return {
+        **result,
+        "_meta": {
+            "module_id": MODULE_ID,
+            "module_version": MODULE_VERSION,
+        },
+    }
+
+
+@mcp.tool(
+    name="list_indices",
+    description="List all vector indices for the current project with document and chunk counts.",
+    meta={
+        "module_id": MODULE_ID,
+        "version": MODULE_VERSION,
+    },
+)
+async def list_indices(
+    user_id: str = "",
+    project_id: str = "",
+    session_id: str = "",
+    app_id: str = "",
+) -> dict:
+    result = await module.list_indices(
+        user_id=user_id,
+        project_id=project_id,
+        session_id=session_id,
+        app_id=app_id,
+    )
+    return {
+        **result,
+        "_meta": {
+            "module_id": MODULE_ID,
+            "module_version": MODULE_VERSION,
+        },
+    }

--- a/druppie/skills/rag-patterns/SKILL.md
+++ b/druppie/skills/rag-patterns/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: rag-patterns
+description: >
+  Decision guide for RAG (Retrieval-Augmented Generation) patterns.
+  Covers chunking strategy, retrieval patterns, citation tracking,
+  embedding choices, and module-vectorstore configuration. Use when
+  a functional design involves document search, knowledge bases,
+  source references, or large-document processing.
+---
+
+# RAG Pattern Decision Guide
+
+## 1. When to Use RAG
+
+Use this decision tree to determine if a project needs RAG:
+
+```
+Does the project need to answer questions from a document corpus?
+  NO  -> RAG is not needed. Stop here.
+  YES -> Is the corpus small enough to fit in a single LLM context window (<50 pages)?
+           YES -> Consider prompt-stuffing (include full text in prompt). RAG optional.
+           NO  -> RAG is needed. Continue below.
+                  Does the corpus change over time?
+                    YES -> Use incremental indexing (re-index on change).
+                    NO  -> Index once at setup.
+                  Are source citations required in the output?
+                    YES -> Citation tracking is mandatory (see Section 5).
+                    NO  -> Citation tracking is recommended but optional.
+```
+
+**RAG indicators in a functional design:**
+- "Doorzoeken van beleidsdocumenten" / searching policy documents
+- "Bronverwijzingen" / source references or citations
+- "Kennisbank" / knowledge base
+- "Documenten als input voor antwoorden" / documents as input for answers
+- "Grote documenten verwerken" / processing large documents
+- References to specific document collections (notas, rapporten, beleidsstukken)
+
+## 2. RAG Pattern Catalog
+
+### Pattern A — Simple RAG (Index-then-Search)
+
+**How it works:** Documents are chunked and indexed once (or on change).
+At query time, the query is embedded, similar chunks are retrieved, and
+passed as context to the LLM for answer generation.
+
+**Best for:** Static document collections, FAQ-style retrieval, reference
+lookup where the user asks a single question.
+
+**Trade-offs:**
+| Aspect | Assessment |
+|--------|------------|
+| Complexity | Low — straightforward pipeline |
+| Latency | Low — single search + single LLM call |
+| Accuracy | Good for factual lookup, weaker for multi-hop reasoning |
+| Citation | Directly available from search results |
+
+**module-vectorstore usage:**
+1. `index_documents` at setup or document upload
+2. `search` per user query
+3. Pass results as context to `module-llm` chat
+
+### Pattern B — Conversational RAG
+
+**How it works:** Extends Simple RAG with conversation history. The user's
+question is rewritten using chat history before searching, so follow-up
+questions resolve pronouns and context.
+
+**Best for:** Interactive Q&A sessions where users ask follow-up questions
+about documents. Chat-based interfaces.
+
+**Trade-offs:**
+| Aspect | Assessment |
+|--------|------------|
+| Complexity | Medium — needs query rewriting step |
+| Latency | Medium — extra LLM call for query rewriting |
+| Accuracy | Better for multi-turn conversations |
+| Citation | Same as Simple RAG |
+
+**Implementation:** Use `module-llm` to rewrite the query incorporating
+chat history, then proceed as Simple RAG.
+
+### Pattern C — Agentic RAG
+
+**How it works:** An agent decides when and what to search. It may perform
+multiple searches with different queries, combine results across indices,
+and reason about whether it has enough information before answering.
+
+**Best for:** Complex multi-step reasoning, cross-document analysis,
+tasks where the agent must synthesise information from multiple sources.
+
+**Trade-offs:**
+| Aspect | Assessment |
+|--------|------------|
+| Complexity | High — agent loop with search tool |
+| Latency | Higher — multiple search iterations possible |
+| Accuracy | Highest for complex questions |
+| Citation | Requires aggregation across multiple searches |
+
+**Implementation:** Give the agent `vectorstore_search` as an MCP tool.
+The agent's system prompt instructs it to search before answering and to
+cite sources from results.
+
+## 3. Chunking Strategy Decision Tree
+
+```
+What type of document?
+  Unstructured text (prose, policy docs, reports)
+    -> chunk_size: 1000, chunk_overlap: 200 (default)
+
+  Structured with clear sections (markdown, HTML with headings)
+    -> chunk_size: 1500, chunk_overlap: 200
+       Set source_section per chunk for better citation
+
+  Tables / structured data
+    -> chunk_size: 500, chunk_overlap: 50
+       Keep rows together, don't split mid-row
+
+  Legal / regulatory text
+    -> chunk_size: 800, chunk_overlap: 300
+       Higher overlap preserves cross-reference context
+
+  Mixed content (text + tables + diagrams)
+    -> Pre-process: split by content type first, then chunk each type
+       with its own settings
+```
+
+**Rules of thumb:**
+- Smaller chunks (500-800) → higher precision, less context per result
+- Larger chunks (1000-2000) → more context, but may dilute relevance
+- Overlap (10-30% of chunk_size) → prevents losing information at boundaries
+- Always split at sentence boundaries, never mid-word
+
+## 4. Retrieval & Search Patterns
+
+### Vector-only search (default)
+Use `module-vectorstore` `search` tool with just a query. Best for
+semantic/meaning-based questions.
+
+### Metadata-filtered search
+Use `filter_metadata` parameter to narrow results. Best when documents
+have known categories, dates, or types.
+
+Example: search within a specific document type:
+```
+search(index_name="beleidsdocumenten", query="waterkwaliteitsnorm",
+       filter_metadata={"document_type": "nota"})
+```
+
+### Multi-index search
+Search multiple indices and merge results. Best for cross-domain
+questions that span different document collections.
+
+### Hybrid search (vector + metadata)
+Combine semantic search with metadata filters for the best balance of
+relevance and precision. This is the **recommended default** for most
+water authority use cases.
+
+## 5. Citation Tracking Pipeline
+
+Every search result from `module-vectorstore` includes:
+- `source_name` — original document filename or URI
+- `source_page` — page number (when available)
+- `source_section` — section heading (when available)
+- `chunk_index` — position within the document
+
+**Citation format for generated answers:**
+
+```
+[source_name, p. source_page, §source_section]
+```
+
+Example: [Nota Waterkwaliteit 2025.pdf, p. 12, §3.2 Normen]
+
+**Pipeline:**
+1. Search returns ranked chunks with source metadata
+2. LLM generates answer using chunks as context
+3. LLM instruction: "Cite every claim using [source, page, section] format"
+4. Verify citations map back to actual search results
+
+**TR requirements for citation-driven projects:**
+- TR-xx: Every generated claim MUST include a source citation traceable
+  to an indexed document (Principle 13: Traceability, Principle 15:
+  Reliability)
+- TR-xx: Citation accuracy: ≥95% of citations must correctly reference
+  the source chunk content
+- TR-xx: Source provenance: the system must store and expose the full
+  chain from generated answer → cited chunk → source document
+
+## 6. Embedding & Vector Store Choices
+
+### Platform defaults (use unless there's a reason to deviate)
+
+| Setting | Default | Rationale |
+|---------|---------|-----------|
+| Vector store | `module-vectorstore` (pgvector) | Platform standard, managed |
+| Embedding model | Platform default via `module-llm` | Centrally configured, multilingual |
+| Dimensions | Determined by model (auto-detected) | No manual config needed |
+| Distance metric | Cosine similarity | Best for text embeddings |
+| Index type | HNSW | Best recall/speed trade-off |
+
+### When to deviate
+
+- **Self-hosted embedding model:** Only if data sovereignty requires it
+  (data cannot leave the network). Requires extending `module-llm` with
+  a local model backend.
+- **Different vector store:** Only if pgvector performance is insufficient
+  for the scale (>10M chunks). For most water authority use cases,
+  pgvector handles the volume.
+
+## 7. RAG-Specific NFR Defaults
+
+Use these as starting points for TR-xx requirements in the TD:
+
+| Requirement | Default target | Verification |
+|-------------|---------------|--------------|
+| Retrieval latency | < 2 seconds for top-5 results | Performance test |
+| Relevance score | > 0.7 similarity threshold for included results | Relevance evaluation |
+| Citation accuracy | ≥ 95% of citations traceable to source | Manual + automated audit |
+| Index freshness | Re-indexed within 1 hour of document change | Integration test |
+| Chunk completeness | No information loss at chunk boundaries | Manual review of chunk samples |
+
+## 8. module-vectorstore Integration Pattern
+
+### Indexing documents (at setup or document upload)
+
+```python
+result = druppie.call("vectorstore", "index_documents", {
+    "index_name": "beleidsdocumenten",
+    "documents": [
+        {
+            "content": "Full text of document...",
+            "source_name": "Nota Waterkwaliteit 2025.pdf",
+            "source_type": "pdf",
+            "source_page": 1,
+            "source_section": "Inleiding",
+            "metadata": {"year": "2025", "type": "nota"}
+        }
+    ],
+    "chunk_size": 1000,
+    "chunk_overlap": 200,
+    "description": "Beleidsdocumenten waterschap"
+})
+```
+
+### Searching (at query time)
+
+```python
+results = druppie.call("vectorstore", "search", {
+    "index_name": "beleidsdocumenten",
+    "query": "Wat zijn de waterkwaliteitsnormen voor 2025?",
+    "top_k": 5
+})
+```
+
+### Generating answer with citations
+
+Pass search results as context to module-llm with citation instructions:
+
+```python
+context = "\n\n".join([
+    f"[{r['source_name']}, p.{r['source_page']}, §{r['source_section']}]:\n{r['content']}"
+    for r in results["results"]
+])
+
+answer = druppie.call("llm", "chat", {
+    "prompt": f"Beantwoord de vraag op basis van de bronnen. Citeer elke claim.\n\nBronnen:\n{context}\n\nVraag: {query}",
+    "system": "Je bent een beleidsmedewerker. Gebruik alleen de gegeven bronnen. Citeer met [bron, pagina, sectie] formaat."
+})
+```
+
+## 9. Anti-Patterns
+
+| Anti-pattern | Problem | Correct approach |
+|-------------|---------|------------------|
+| Indexing all documents in one batch | Memory pressure, timeout risk | Batch in groups of 10-50 documents |
+| No project_id scoping | Data leaks between projects | Always use project-scoped indices |
+| Ignoring chunk boundaries | Sentences split mid-word | Use module-vectorstore defaults (sentence-aware splitting) |
+| Skipping metadata | No way to filter or cite | Always set source_name, source_page, source_section |
+| Very large chunks (>3000 chars) | Diluted relevance scores | Keep chunks 500-1500 chars |
+| Very small chunks (<200 chars) | Lost context | Minimum 500 chars recommended |
+| Building custom vector store | Duplicates platform capability | Use module-vectorstore |
+| Direct embedding API calls | Bypasses centralized model config | Use module-llm embed tool |

--- a/druppie/skills/vectorstore-usage/SKILL.md
+++ b/druppie/skills/vectorstore-usage/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: vectorstore-usage
+description: >
+  How to use module-vectorstore tools for semantic search over indexed
+  document collections. Covers search, citation, and result interpretation.
+  Invoke when you have vectorstore tools available and need to search
+  or explore indexed documents.
+allowed-tools:
+  vectorstore:
+    - search
+    - get_chunk
+    - list_indices
+    - index_documents
+    - delete_index
+---
+
+# Vectorstore Usage Guide
+
+## Available Tools
+
+### vectorstore_list_indices()
+List all indexed document collections for the current project. Use this
+first to discover what's available before searching.
+
+Returns: index name, description, document count, chunk count, embedding
+model, and chunk size settings per index.
+
+### vectorstore_search(index_name, query, top_k=5, similarity_threshold=0.0, filter_metadata=None)
+Semantic search over an indexed document collection. Returns the most
+relevant text chunks ranked by similarity score.
+
+**Parameters:**
+- `index_name` — which index to search (from list_indices)
+- `query` — natural language question or search phrase
+- `top_k` — number of results to return (default 5, increase for broader context)
+- `similarity_threshold` — minimum similarity score (0.0-1.0, default 0.0 = no filter)
+- `filter_metadata` — optional dict to narrow results by metadata fields
+  (e.g., `{"document_type": "nota", "year": "2025"}`)
+
+**Result fields per chunk:**
+- `content` — the chunk text
+- `score` — similarity score (0.0-1.0, higher = more relevant)
+- `source_name` — original document name or URI
+- `source_page` — page number (if available)
+- `source_section` — section heading (if available)
+- `chunk_id` — unique ID for use with get_chunk
+- `metadata` — caller-defined metadata attached at indexing time
+
+### vectorstore_get_chunk(chunk_id)
+Retrieve a specific chunk by ID. Use after search when you need the full
+context of a result, including all source metadata for citation.
+
+### vectorstore_index_documents(index_name, documents, chunk_size=1000, chunk_overlap=200)
+Index documents for semantic search. Each document in the list needs:
+- `content` (required) — full text to index
+- `source_name` (required) — original filename or URI
+- `source_type` — text, pdf, markdown, html (default: text)
+- `source_page` — page number
+- `source_section` — section heading
+- `metadata` — arbitrary dict for filtering (e.g., `{"year": "2025"}`)
+
+### vectorstore_delete_index(index_name)
+Delete an entire index and all its documents and chunks. Irreversible.
+
+## When to Search
+
+- **Context gathering:** Search indexed documents to understand the domain
+  before making decisions.
+- **Research phase:** Find relevant precedents, policies, or reference
+  material to ground your analysis.
+- **Answering questions:** Retrieve specific passages from documents to
+  answer user questions with citations.
+- **Similarity check:** Search for related existing content before
+  creating new documents.
+
+## How to Cite
+
+Every search result includes source metadata for traceability. Use this
+format when referencing content from search results:
+
+```
+[source_name, p. source_page, §source_section]
+```
+
+Example: [Nota Waterkwaliteit 2025.pdf, p. 12, §3.2 Normen]
+
+When source_page or source_section is null, omit that part:
+- `[Beleidsdocument.pdf, §Inleiding]`
+- `[Rapport 2024.pdf, p. 5]`
+- `[Handleiding.md]`
+
+## Search Tips
+
+1. **Be specific in queries** — "waterkwaliteitsnormen voor stikstof"
+   returns better results than "normen"
+2. **Use metadata filters** to narrow scope — filter by document type,
+   year, or category when the index contains diverse documents
+3. **Increase top_k** (e.g., 10-15) when you need broader context or
+   aren't sure which documents are relevant
+4. **Use similarity_threshold** (e.g., 0.5) to filter out low-quality
+   matches when you need only high-confidence results
+5. **Multiple queries** — rephrase and search again if the first query
+   doesn't return relevant results; different phrasings surface
+   different chunks

--- a/druppie/templates/project/docs/platform-technical-standards.md
+++ b/druppie/templates/project/docs/platform-technical-standards.md
@@ -1,6 +1,6 @@
 # Platform Technical Standards
 
-**Revision:** 2026-04-20
+**Revision:** 2026-05-27
 
 Every Druppie-created application follows these technical defaults. The
 Architect treats them as givens when writing `docs/technical-design.md` and only
@@ -49,11 +49,30 @@ registry:
 - File search inside a codebase → `module-filesearch`
 - ArchiMate / architecture reasoning → `module-archimate`
 - Shell / coding execution → `module-coding`
+- Semantic search / document Q&A / RAG → `module-vectorstore`
 
 If an existing module covers the capability, the TD references the module
 and the SDK call pattern — it does not design an alternative. Building a
 new capability is only valid if no matching module exists; the Architect
 notes this in the TD with a short justification.
+
+### RAG defaults
+
+When a project needs retrieval-augmented generation (document search,
+knowledge bases, source-referenced answers):
+
+- **Use `module-vectorstore`** — do not build a custom vector store.
+- **Embedding model:** platform default (configured centrally on `module-llm`).
+- **Chunk size:** 1000 characters with 200 overlap (module default).
+- **Index scoping:** one index per logical document collection, scoped to
+  `project_id`. Do not share indices across projects.
+- **Search pattern:** hybrid (vector similarity + metadata filters) by default.
+- **Citation format:** always use the `source_name`, `source_page`, and
+  `source_section` fields from search results to provide citations.
+- **Index updates:** re-index on document change, not on a periodic schedule.
+
+The Architect loads the `rag-patterns` skill for the full decision guide
+when a functional design involves RAG.
 
 ## 4. Database & persistence
 

--- a/scripts/index_platform_knowledge.py
+++ b/scripts/index_platform_knowledge.py
@@ -1,0 +1,253 @@
+"""Index platform documentation into module-vectorstore.
+
+Indexes skills, platform standards, and module specifications into a
+'platform-knowledge' index so agents can semantically search platform docs.
+
+Requires module-vectorstore and module-llm to be running.
+"""
+
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("index-platform-knowledge")
+
+VECTORSTORE_URL = "http://module-vectorstore:9012"
+DRUPPIE_DIR = Path("/app/druppie") if Path("/app/druppie").exists() else Path(__file__).parent.parent / "druppie"
+
+INDEX_NAME = "platform-knowledge"
+PROJECT_ID = "__platform__"
+
+
+def collect_skills() -> list[dict]:
+    """Collect all SKILL.md files."""
+    docs = []
+    skills_dir = DRUPPIE_DIR / "skills"
+    if not skills_dir.exists():
+        logger.warning("Skills directory not found: %s", skills_dir)
+        return docs
+
+    for skill_dir in sorted(skills_dir.iterdir()):
+        skill_file = skill_dir / "SKILL.md"
+        if not skill_file.exists():
+            continue
+        content = skill_file.read_text(encoding="utf-8")
+        docs.append({
+            "content": content,
+            "source_name": f"skills/{skill_dir.name}/SKILL.md",
+            "source_type": "markdown",
+            "source_section": f"Skill: {skill_dir.name}",
+            "metadata": {"type": "skill", "skill_name": skill_dir.name},
+        })
+        logger.info("Collected skill: %s", skill_dir.name)
+
+    return docs
+
+
+def collect_standards() -> list[dict]:
+    """Collect platform standards templates."""
+    docs = []
+    templates_dir = DRUPPIE_DIR / "templates" / "project" / "docs"
+    if not templates_dir.exists():
+        logger.warning("Templates directory not found: %s", templates_dir)
+        return docs
+
+    for md_file in sorted(templates_dir.glob("*.md")):
+        content = md_file.read_text(encoding="utf-8")
+        docs.append({
+            "content": content,
+            "source_name": f"templates/project/docs/{md_file.name}",
+            "source_type": "markdown",
+            "source_section": f"Standard: {md_file.stem}",
+            "metadata": {"type": "standard", "standard_name": md_file.stem},
+        })
+        logger.info("Collected standard: %s", md_file.name)
+
+    return docs
+
+
+def collect_module_specs() -> list[dict]:
+    """Collect MODULE.yaml + tool descriptions from mcp_config."""
+    docs = []
+    mcp_servers_dir = DRUPPIE_DIR / "mcp-servers"
+    mcp_config_path = DRUPPIE_DIR / "core" / "mcp_config.yaml"
+
+    mcp_config_content = ""
+    if mcp_config_path.exists():
+        mcp_config_content = mcp_config_path.read_text(encoding="utf-8")
+        docs.append({
+            "content": mcp_config_content,
+            "source_name": "core/mcp_config.yaml",
+            "source_type": "yaml",
+            "source_section": "MCP Configuration",
+            "metadata": {"type": "config", "config_name": "mcp_config"},
+        })
+        logger.info("Collected mcp_config.yaml")
+
+    if not mcp_servers_dir.exists():
+        return docs
+
+    for module_dir in sorted(mcp_servers_dir.iterdir()):
+        if not module_dir.is_dir() or not module_dir.name.startswith("module-"):
+            continue
+
+        module_yaml = module_dir / "MODULE.yaml"
+        if not module_yaml.exists():
+            continue
+
+        parts = [module_yaml.read_text(encoding="utf-8")]
+
+        tools_py = module_dir / "v1" / "tools.py"
+        if tools_py.exists():
+            parts.append(tools_py.read_text(encoding="utf-8"))
+
+        content = "\n\n---\n\n".join(parts)
+        module_name = module_dir.name.replace("module-", "")
+
+        docs.append({
+            "content": content,
+            "source_name": f"mcp-servers/{module_dir.name}/MODULE.yaml",
+            "source_type": "yaml",
+            "source_section": f"Module: {module_name}",
+            "metadata": {"type": "module", "module_name": module_name},
+        })
+        logger.info("Collected module: %s", module_name)
+
+    return docs
+
+
+def collect_agent_definitions() -> list[dict]:
+    """Collect agent YAML definitions."""
+    docs = []
+    agents_dir = DRUPPIE_DIR / "agents" / "definitions"
+    if not agents_dir.exists():
+        logger.warning("Agent definitions directory not found: %s", agents_dir)
+        return docs
+
+    for yaml_file in sorted(agents_dir.glob("*.yaml")):
+        if yaml_file.name in ("llm_profiles.yaml",):
+            continue
+        content = yaml_file.read_text(encoding="utf-8")
+        agent_name = yaml_file.stem
+        docs.append({
+            "content": content,
+            "source_name": f"agents/definitions/{yaml_file.name}",
+            "source_type": "yaml",
+            "source_section": f"Agent: {agent_name}",
+            "metadata": {"type": "agent", "agent_name": agent_name},
+        })
+        logger.info("Collected agent definition: %s", agent_name)
+
+    return docs
+
+
+def collect_documentation() -> list[dict]:
+    """Collect docs/ folder markdown files."""
+    docs = []
+    docs_dir = DRUPPIE_DIR.parent / "docs"
+    if not docs_dir.exists():
+        logger.warning("Docs directory not found: %s", docs_dir)
+        return docs
+
+    for md_file in sorted(docs_dir.glob("**/*.md")):
+        content = md_file.read_text(encoding="utf-8")
+        rel_path = md_file.relative_to(docs_dir.parent)
+        docs.append({
+            "content": content,
+            "source_name": str(rel_path).replace("\\", "/"),
+            "source_type": "markdown",
+            "source_section": f"Doc: {md_file.stem}",
+            "metadata": {"type": "documentation", "doc_name": md_file.stem},
+        })
+        logger.info("Collected doc: %s", rel_path)
+
+    return docs
+
+
+def wait_for_service(url: str, name: str, max_retries: int = 30, delay: float = 2.0):
+    """Wait for a service to become healthy."""
+    for attempt in range(max_retries):
+        try:
+            resp = httpx.get(f"{url}/health", timeout=5.0)
+            if resp.status_code == 200:
+                logger.info("%s is healthy", name)
+                return
+        except httpx.ConnectError:
+            pass
+        if attempt < max_retries - 1:
+            logger.info("Waiting for %s... (attempt %d/%d)", name, attempt + 1, max_retries)
+            time.sleep(delay)
+
+    logger.error("%s not available after %d attempts", name, max_retries)
+    sys.exit(1)
+
+
+def index_documents(documents: list[dict]):
+    """Call vectorstore index_documents via direct HTTP API."""
+    from fastmcp import Client
+    from fastmcp.client.transports import StreamableHttpTransport
+    import asyncio
+
+    async def _do_index():
+        transport = StreamableHttpTransport(url=f"{VECTORSTORE_URL}/mcp")
+        async with Client(transport) as client:
+            result = await client.call_tool("index_documents", {
+                "index_name": INDEX_NAME,
+                "documents": documents,
+                "description": "Druppie platform documentation — skills, standards, modules, agents",
+                "project_id": PROJECT_ID,
+                "chunk_size": 1000,
+                "chunk_overlap": 200,
+            })
+            return result
+
+    return asyncio.run(_do_index())
+
+
+def main():
+    logger.info("=== Platform Knowledge Indexer ===")
+
+    wait_for_service(VECTORSTORE_URL, "module-vectorstore")
+
+    all_docs = []
+    all_docs.extend(collect_skills())
+    all_docs.extend(collect_standards())
+    all_docs.extend(collect_module_specs())
+    all_docs.extend(collect_agent_definitions())
+    all_docs.extend(collect_documentation())
+
+    if not all_docs:
+        logger.warning("No documents found to index")
+        return
+
+    logger.info("Collected %d documents total", len(all_docs))
+
+    batch_size = 20
+    total_chunks = 0
+
+    for i in range(0, len(all_docs), batch_size):
+        batch = all_docs[i:i + batch_size]
+        logger.info("Indexing batch %d-%d of %d...", i + 1, min(i + batch_size, len(all_docs)), len(all_docs))
+        try:
+            result = index_documents(batch)
+            if isinstance(result, list) and len(result) > 0:
+                first = result[0]
+                if hasattr(first, "text"):
+                    import json
+                    data = json.loads(first.text)
+                    total_chunks += data.get("chunks_created", 0)
+                    logger.info("  Indexed: %d docs, %d chunks", data.get("documents_indexed", 0), data.get("chunks_created", 0))
+        except Exception as e:
+            logger.error("Failed to index batch: %s", e)
+            raise
+
+    logger.info("=== Platform knowledge indexed: %d documents, %d chunks ===", len(all_docs), total_chunks)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

  Title: feat: add module-vectorstore for RAG semantic search

  Body:

  Summary

  - New MCP module module-vectorstore (port 9012) — semantic search over document collections using pgvector embeddings, with 5 tools: search, get_chunk, list_indices, index_documents, delete_index
  - Embed tool on module-llm — new embed MCP tool wrapping the OpenAI-compatible embeddings endpoint (Z.AI embedding-3 / DeepInfra BAAI/bge-m3)
  - Two new skills — rag-patterns (design decision guide) and vectorstore-usage (operational guide)
  - Architect agent wired up — RAG detection trigger, Level 2b context gathering, vectorstore tools (search + index)
  - Platform knowledge auto-indexing — indexes skills, standards, module specs, agent definitions, and docs on every startup
  - Docker infrastructure — module-vectorstore-db (pgvector/pg16), module-vectorstore, platform-knowledge-init
  - Documentation — FEATURES.md, TECHNICAL.md, platform-technical-standards.md all updated

  Test plan

  - [ ] docker compose --profile infra --profile init up -d — all containers healthy
  - [ ] curl http://localhost:9012/health — returns healthy
  - [ ] Test embed tool on module-llm with sample texts
  - [ ] Test index_documents + search flow via MCP calls to port 9012
  - [ ] Verify platform-knowledge-init logs show successful indexing
  - [ ] Verify architect agent loads correctly with new skills and vectorstore MCPs