### PR TITLE
Inline chart visualizations from the data MCP

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -343,3 +343,42 @@ Last updated: 2026-03-24
   - Optional policy: auto-purge packages with critical vulnerabilities
   - Dashboard or log aggregation for scan results over time
 - **Priority:** Medium — important for continuous security posture in production environments.
+
+### Visualization — Multiple Sources & Joins
+
+- **Current state:** `create_chart_from_source` charts a single table/file. Joining tables for a visualization is not supported.
+- **Desired improvement:**
+  - `create_chart_from_query` for SQL: the agent writes a `JOIN ... GROUP BY`, the DB aggregates, only the spec returns (same context-hygiene as the current pushdown). Reuses `execute_query` validation.
+  - Data Lake file joins via server-side `pandas.merge` (needs join-key/how params).
+  - Cross-source joins (SQL table ⋈ Data Lake file) — read both into the server and merge.
+- **Priority:** Medium — SQL joins are the common case and low-risk.
+
+### Visualization — Performance & Scale
+
+- **Current state:** For Data Lake, `create_chart_from_source` reads the whole file into MCP-server memory (`readall()` → `io.BytesIO`) before aggregating. Fine for ~hundreds of thousands of rows; a multi-GB file would pressure the server. Follow-up charts re-read the same file.
+- **Desired improvement:**
+  - Use DuckDB/Polars to run SQL-style aggregation directly over CSV/Parquet with column projection (no full in-memory materialization).
+  - Cache the read/aggregation within a session so follow-up charts don't re-scan.
+  - Chunked/streaming aggregation for files too large to hold in memory.
+- **Priority:** Medium — removes the in-memory ceiling flagged in `docs/MCP/data-access.md`.
+
+### Visualization — Smarter Graphing
+
+- **Current state:** The agent picks chart type and columns from a prompt decision matrix. No date bucketing, no histogram/binning, no "Other" bucket, fixed colors.
+- **Desired improvement:**
+  - Auto chart-type selection from `get_schema` (column cardinality + dtype).
+  - Date/time intelligence: detect date columns and bucket by day/week/month/quarter/year (fixes charting raw `YYYYMMDD` date keys as an x-axis).
+  - Numeric binning (true histograms); roll long tails into an "Other" bucket instead of dropping; sort controls; combo/dual-axis (`ComposedChart`); number/unit formatting on axes and tooltips.
+- **Priority:** Medium — biggest "charts make sense" quality lever.
+
+### Visualization — Frontend & Artifacts
+
+- **Current state:** `ChartBlock` renders statically inside a HITL/assistant message; the spec lives in the `messages` row. No interactivity, export, or persistence beyond the transcript.
+- **Desired improvement:** zoom/pan/fullscreen (like `MermaidBlock`), export PNG/SVG, "show data" table toggle, dark mode, a visible "sample" badge when `full_dataset` is false, and promoting charts to first-class session artifacts / a saved dashboard project.
+- **Priority:** Low–Medium — UX polish; artifacts overlap with the `create_project` dashboard path.
+
+### Visualization — Data Analyst Prompt Size
+
+- **Current state:** After merging the dataset-selection strategy and the charting guidance, the `data_analyst` system prompt is long, and the agent runs on `llm_profile: cheap` (small context). Long charting sessions can still approach context limits.
+- **Desired improvement:** trim/split the prompt or raise the agent's `llm_profile`; add conversation-history trimming for long sessions (overlaps with the existing "No Context Window Management" item).
+- **Priority:** Medium — reliability for extended sessions.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -234,6 +234,22 @@ The primary interface is a chat page where users submit natural language request
 
 ---
 
+## Data Visualizations
+
+The Data Analyst agent can render charts **inline in the chat** from data in the configured sources (Azure SQL, Azure Data Lake), via the Data Access MCP.
+
+- **Ask in natural language**: "Show me a chart of assets per category", "visualize subscriptions by type as a donut", "break it down by year". The agent picks an appropriate chart type, aggregates the data, and shows the result inline.
+- **13 chart types**: bar, line, area, horizontal bar, scatter, pie, donut, treemap, funnel, and multi-series stacked bar / grouped bar / stacked area / multi-line.
+- **Deliberate type selection**: the agent follows a decision matrix — counts per category → bar, long category names → horizontal bar, long-tail distributions → treemap, proportions → pie/donut, breakdowns by a second dimension → stacked/grouped, trends → line/area, correlation → scatter.
+- **Whole-dataset accuracy**: aggregation runs over the **entire** dataset (the database does it for SQL; the whole file is read server-side for Data Lake), so counts and sums are exact rather than sampled. The agent flags when a result is ever a sample.
+- **Data stays private**: raw rows never enter the LLM context and nothing is written to the workspace — only a compact chart spec is produced, stored in the chat transcript so charts survive a reload.
+- **Inline values too**: if the user types the numbers directly ("chart A=10, B=25, C=7"), the agent charts them immediately without touching a data source.
+- **Graceful failure**: a malformed chart renders as a small inline error card rather than breaking the message.
+
+The Data Analyst is read-only: it visualizes and explains data but does not build dashboards or write files (creating a persistent dashboard project is a separate `create_project` path).
+
+---
+
 ## Session Control
 
 ### Stop & Resume

--- a/docs/MCP/data-access.md
+++ b/docs/MCP/data-access.md
@@ -102,15 +102,21 @@ tests can assert on it.
 | `read_data` | `source_id`, `data_id`, `filter_expr?`, `limit?`, `offset?` | `{success, data: [...], row_count, columns, metadata}` |
 | `execute_query` | `source_id`, `query`, `limit?` | `{success, data: [...], row_count, columns, warnings, metadata}` |
 | `download_data` | `source_id`, `data_id`, `destination`, `session_id*`, `project_id*` | `{success, destination, size_bytes}` |
+| `create_chart` | `data`, `chart_type`, `x_column`, `y_column`, `title?`, `x_label?`, `y_label?` | `{success, spec, markdown}` |
+| `create_chart_from_source` | `source_id`, `data_id`, `chart_type`, `x_column`, `y_column?`, `series_column?`, `aggregation?`, `filter_expr?`, `top_n?`, `max_series?`, `read_limit?`, `title?`, `x_label?`, `y_label?` | `{success, spec, markdown, category_count, full_dataset, aggregated_in, rows_scanned?, series_count?}` |
 
 `*` `session_id` and `project_id` on `download_data` are auto-injected by
 the backend from the active session — agents do not supply them.
+
+The last two tools (`create_chart`, `create_chart_from_source`) render
+charts inline in the chat — see [Visualization](#visualization) below.
 
 ### Agent access
 
 | Agent | Tools | Rationale |
 |---|---|---|
 | `business_analyst` | `list_sources`, `test_connection`, `list_available_data`, `get_schema`, `read_data` | Answers general_chat data-discovery questions ("which data is available?") and gathers data context during `create_project` / `update_project` requirements work. Read-only — no `download_data`, BA does not write files into the workspace. |
+| `data_analyst` | `list_sources`, `test_connection`, `list_available_data`, `get_schema`, `read_data`, `execute_query`, `create_chart`, `create_chart_from_source` | Answers data questions and **renders charts inline in chat**. Uses discovery tools to locate a dataset, then `create_chart_from_source` to visualize it. Read-only — no `download_data`. |
 
 Other agents have no access yet. `download_data` is intentionally
 unassigned until a workflow needs the bytes on disk (Developer / Test
@@ -140,6 +146,101 @@ Builder when consuming sample data, most likely).
   itself.
 - For file-based sources (Azure Data Lake) the tool returns a clear
   "unsupported" error — use `read_data` instead.
+
+## Visualization
+
+`create_chart` and `create_chart_from_source` turn data into a chart that
+renders **inline in the chat**. The design principle: the LLM decides *what*
+to plot (chart type, columns, aggregation); the data is aggregated
+server-side and **never enters the model context**. Only a small JSON spec
+travels back.
+
+### Data flow
+
+```
+agent picks type + columns
+        │
+        ▼
+create_chart_from_source ──► SQL source:  GROUP BY pushed into the database
+        │                    Data Lake:   whole file read into MCP memory, aggregated
+        ▼
+{spec, markdown}  ◄── only the aggregated result (~hundreds of bytes)
+        │
+        ▼
+agent embeds the `markdown` (a ```chart fenced block) in hitl_ask_question
+        │
+        ▼
+frontend ChartBlock.jsx parses the spec → renders with recharts
+```
+
+No file is written for a chart — Data Lake blobs are read into memory
+(`io.BytesIO`) and discarded; SQL aggregation happens in the database. The
+only persisted artifact is the spec itself, stored in the chat `messages`
+row, which is what lets the chart re-render on session reload.
+
+### The chart spec
+
+A small JSON object wrapped in a ` ```chart ` fenced code block:
+
+```json
+{
+  "type": "bar",
+  "title": "Assets per category",
+  "x_label": "Category",
+  "y_label": "count",
+  "data": [{"x": "Afsluiter", "y": 9230}, {"x": "Elektromotor", "y": 3624}]
+}
+```
+
+Multi-series specs additionally carry a `series` array, and `data` rows are
+flat (`{x, <series_key>: value, ...}`).
+
+### Chart types
+
+13 types in three families (which columns each needs):
+
+| Family | Types | Columns |
+|---|---|---|
+| XY | `bar`, `line`, `area`, `horizontal_bar`, `scatter` | `x_column` + `y_column` |
+| Proportion | `pie`, `donut`, `treemap`, `funnel` | `x_column` (name) + `y_column` (value) |
+| Multi-series | `stacked_bar`, `grouped_bar`, `stacked_area`, `multi_line` | `x_column` + `y_column` + `series_column` |
+
+### `create_chart` vs `create_chart_from_source`
+
+- **`create_chart`** charts **inline values** the agent already holds (e.g.
+  the user typed "chart A=10, B=25"). Single-series + proportion types only.
+- **`create_chart_from_source`** reads + aggregates a configured source. Use
+  this for any real dataset. Key behaviors:
+  - **Full-dataset aggregation.** SQL sources push `GROUP BY` into the
+    database (`build_sql_aggregation_query`, `aggregated_in: "database"`);
+    Data Lake files are read in full and aggregated server-side
+    (`aggregated_in: "server"`). `read_limit` defaults to `None` (no cap) —
+    set it only to deliberately sample a very large Data Lake file. The
+    response carries `full_dataset` (false if a cap truncated the read) and,
+    for the server path, `rows_scanned`.
+  - **`aggregation`**: `count` (default, ignores `y_column`) or
+    `sum`/`avg`/`min`/`max` over `y_column`.
+  - **`series_column`** is required for multi-series types; it is the second
+    grouping dimension (each distinct value becomes a series). Capped by
+    `max_series` (default 10); categories capped by `top_n` (default 20).
+  - On invalid input returns `{success: false, error}` (unsupported
+    chart_type, missing column, non-numeric `y` values, empty result).
+
+> **Aggregation correctness.** Early versions aggregated over a row-capped
+> read, which silently skewed charts of large tables (a 279k-row source was
+> charted from its first 5000 rows). The current full-dataset behavior — DB
+> pushdown for SQL, full-file read for Data Lake — fixes this; `full_dataset`
+> signals when a result is nonetheless a sample.
+
+### Frontend rendering
+
+The chat already renders assistant / HITL message text through
+`react-markdown` with custom code-block handlers (the same mechanism that
+renders ` ```mermaid ` via `MermaidBlock`). `frontend/src/components/ChartBlock.jsx`
+is registered for the `chart` language in
+`frontend/src/components/chat/ChatHelpers.jsx`: it parses the spec, validates
+it, and renders the matching `recharts` component inside a `ResponsiveContainer`,
+falling back to an inline error card if the spec is malformed.
 
 ### Azure SQL row caps
 

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -502,7 +502,25 @@ ArchiMate model operations. Reads `.archimate` files from a mounted models direc
 | `search_model` | None | Search for elements by query |
 | `export_view` | None | Export an ArchiMate view |
 
-### 6.8 Declarative Parameter Injection
+### 6.8 Data Access Server (port 9010)
+
+Adapter-based access to heterogeneous data sources (Azure SQL, Azure Data Lake) plus inline chart generation. Full reference: [`docs/MCP/data-access.md`](MCP/data-access.md).
+
+| Tool | Approval | Description |
+|------|----------|-------------|
+| `list_sources` | None | List configured data sources |
+| `test_connection` | None | Verify a source is reachable |
+| `list_available_data` | None | List tables (SQL) or files (Data Lake) |
+| `get_schema` | None | Column metadata for a table/file |
+| `read_data` | None | Read rows (capped; goes into context) |
+| `execute_query` | None | Free-form read-only SELECT/WITH (SQL only) |
+| `download_data` | None | Stream a table/file to the workspace as CSV/Parquet |
+| `create_chart` | None | Chart inline values (returns a `chart` spec) |
+| `create_chart_from_source` | None | Read + aggregate a source server-side, return a `chart` spec |
+
+**Charting data flow.** `create_chart_from_source` keeps raw data out of the LLM context: for SQL sources the `GROUP BY` is pushed into the database (`build_sql_aggregation_query`); for Data Lake files the whole file is read into MCP-server memory and aggregated in Python. Either way only a small JSON spec (the chart) is returned — no file is written, and the aggregation covers the full dataset (`full_dataset`/`rows_scanned` report any sampling). The spec is emitted as a ` ```chart ` fenced code block; the chat frontend renders it via `frontend/src/components/ChartBlock.jsx` (registered for the `chart` language in `ChatHelpers.jsx`, mirroring how `MermaidBlock` handles `mermaid`) using `recharts`. 13 chart types span XY, proportion, and multi-series families.
+
+### 6.9 Declarative Parameter Injection
 
 MCP tools can have parameters auto-injected from the session/project context. Injected parameters are marked `hidden: true` and are removed from the LLM-visible tool schema. This prevents the LLM from needing to know internal IDs.
 
@@ -519,7 +537,7 @@ inject:
     tools: [read_file, write_file, list_dir, ...]
 ```
 
-### 6.9 Layered Approval System
+### 6.10 Layered Approval System
 
 Approvals have two layers:
 

--- a/druppie/agents/definitions/data_analyst.yaml
+++ b/druppie/agents/definitions/data_analyst.yaml
@@ -428,6 +428,16 @@ system_prompt: |
   shows the most information without distortion: bar for ≤15 categories,
   horizontal_bar for longer names, treemap for >15 categories.
 
+  **Choosing good columns (check get_schema first):**
+  - Pick a CATEGORICAL column for x_column (names, types, statuses, years).
+    Avoid raw date-key integers like 20190101 (YYYYMMDD) — they render as
+    meaningless numbers. If only a date-key exists and the user wants a
+    trend, say so rather than charting the raw key.
+  - The tool aggregates over the ENTIRE dataset (SQL via GROUP BY pushdown,
+    Data Lake by reading the whole file), so counts/sums are exact — you do
+    NOT need to read rows first or worry about row limits. Check the result's
+    `full_dataset` flag; if false, mention to the user that it is a sample.
+
   ###### Calling the tool
 
   Call `dataaccess_create_chart_from_source` with:

--- a/druppie/agents/definitions/data_analyst.yaml
+++ b/druppie/agents/definitions/data_analyst.yaml
@@ -136,6 +136,23 @@ system_prompt: |
   - web_search_web(query) — search for external data sources
   - web_get_page_info(url) — get information about an external data page
 
+  ### Level 5: Structured data sources — dataaccess tools
+  Call these tools to discover and read from Azure Data Lake / Azure SQL
+  sources configured on the platform:
+  - dataaccess_list_sources() — what structured sources are configured?
+  - dataaccess_list_available_data(source_id) — tables (SQL) or files (Data Lake)
+  - dataaccess_get_schema(source_id, data_id) — column names and types
+  - dataaccess_read_data(source_id, data_id, ...) — read a table or file
+    (NOTE: pulls raw rows into your conversation — use sparingly, only when
+    you need to inspect a small sample; cap with `limit=50` or so)
+  - dataaccess_execute_query(source_id, query) — run a read-only SELECT/WITH
+  - dataaccess_create_chart(data, chart_type, x_column, y_column, ...) —
+    turn USER-PROVIDED inline values into a chart
+  - dataaccess_create_chart_from_source(source_id, data_id, chart_type,
+    x_column, y_column, aggregation, ...) — SERVER-SIDE read + aggregate +
+    chart. The raw rows never enter your context. **Use this for any chart
+    of source data.**
+
   ### When to gather context
 
   Context gathering is OPTIONAL in general_chat. Use it when:
@@ -189,12 +206,30 @@ system_prompt: |
 
   | Type | Signal | Example |
   |------|--------|---------|
+  | **Inline chart request** | User already provided values in their message and asks for a chart | "Show me a bar chart of A=10, B=25, C=7, D=18" |
   | **Clarification needed** | Question is vague or ambiguous | "Show me the data" |
   | **Dataset discovery** | User wants to find data | "What data do we have about customers?" |
   | **Data question** | User wants an answer from data | "What were Q4 sales?" |
   | **Analysis planning** | User wants a structured analysis approach | "I need to analyze customer churn" |
 
   ### Step 2: Execute the Appropriate Flow
+
+  #### For INLINE CHART REQUEST (FAST PATH):
+  The user has already provided concrete values in their message and asked
+  for a chart. Do NOT do dataset discovery, do NOT search for data, do NOT
+  ask clarifying questions about styling. Just:
+
+  1. Parse the values directly from the user's message into a list of
+     `{column1: value, column2: value}` row dicts.
+  2. Call `dataaccess_create_chart` with that list, the requested
+     `chart_type` (bar / line / pie / scatter — default to "bar" if the
+     user didn't specify), and the appropriate column names.
+  3. Call `hitl_ask_question` with the chart embedded in the message:
+     include the tool's returned `markdown` field verbatim, optionally
+     with a 1-line lead-in like "Here's your chart:".
+  4. Call done() with status `CHAT_COMPLETE`.
+
+  This whole flow should take ~3 tool calls. Do not iterate further.
 
   #### For CLARIFICATION NEEDED:
   The user's question is too vague to act on. Ask clarifying questions to
@@ -234,13 +269,85 @@ system_prompt: |
   1. Identify which dataset(s) are likely to contain the answer
      - Use filesearch_search_files with keywords from the question
      - If the user mentioned a specific dataset, go directly to it
+     - For Azure SQL / Data Lake data, use dataaccess_list_sources and
+       dataaccess_list_available_data
   2. Read the relevant data using filesearch_read_file or coding_read_project_file
+     - For SQL data, use dataaccess_read_data (whole table) or
+       dataaccess_execute_query (free-form read-only SELECT/WITH)
   3. Analyze the data to find the answer
   4. Present the answer to the user via hitl_ask_question, including:
      - The direct answer to their question
      - The source dataset and file location
      - Any caveats or limitations in the data
   5. Ask if they need anything else related to this data
+
+  ##### Optional: visualize the answer
+
+  **CRITICAL — keep raw data OUT of your context.** When a chart of source
+  data is needed (Azure SQL table or Data Lake file), call
+  `dataaccess_create_chart_from_source` directly. Do NOT call
+  `dataaccess_read_data` first and then `dataaccess_create_chart` — that
+  pulls megabytes of rows into the conversation and will overflow the LLM.
+
+  `dataaccess_create_chart_from_source` does the read + aggregation
+  server-side and returns only the small per-category summary + chart spec.
+
+  ###### Picking a chart type — decision matrix
+
+  Use this table to pick `chart_type` deliberately. The goal is the chart
+  that fits the data shape and question — do NOT default to "bar" for
+  everything.
+
+  | Goal / shape                                          | Preferred type    |
+  |-------------------------------------------------------|-------------------|
+  | Count or value per category (≤15 categories)          | `bar`             |
+  | Count or value per category, LONG category names      | `horizontal_bar`  |
+  | Count or value per category, ≥15 categories (long tail) | `treemap`       |
+  | Proportions of a whole, ≤6 slices                     | `pie`             |
+  | Proportions of a whole, 6–10 slices                   | `donut`           |
+  | Stages of a process / drop-off                        | `funnel`          |
+  | Trend over time / ordered x (single line)             | `line`            |
+  | Trend with emphasis on volume                         | `area`            |
+  | Correlation between two numeric columns               | `scatter`         |
+  | Per-category breakdown by a SECOND dimension          | `stacked_bar` or `grouped_bar` |
+  | Cumulative trend by a second dimension                | `stacked_area`    |
+  | Multiple series over the same ordered x               | `multi_line`      |
+
+  Heuristics:
+  - "Per X" or "count of X" → bar (or horizontal_bar if X names are long)
+  - "Share of …" or "% of …" → pie / donut
+  - "Top N …" with a heavy tail → treemap or horizontal_bar
+  - "… per X by Y" or "… split by Y" → multi-series (stacked_bar / grouped_bar /
+    stacked_area / multi_line). Set `series_column=Y` in the tool call.
+  - "Over time" or "trend" with a date/year column → line / area
+  - Long Dutch or path-like category names (e.g. asset categories, file paths) →
+    horizontal_bar is almost always more readable than vertical bar.
+
+  When in doubt and the user just says "visualize", prefer the type that
+  shows the most information without distortion: bar for ≤15 categories,
+  horizontal_bar for longer names, treemap for >15 categories.
+
+  ###### Calling the tool
+
+  Call `dataaccess_create_chart_from_source` with:
+  - `source_id` and `data_id` from the discovery tools
+  - `chart_type` from the table above
+  - `x_column` (the primary grouping column)
+  - `y_column` (the numeric column to aggregate — omit for `aggregation="count"`)
+  - `series_column` (REQUIRED for multi-series types — the second grouping column)
+  - `aggregation` (count / sum / avg / min / max — default "count")
+  - `top_n` (default 20, keeps the chart readable; raise for treemap if needed)
+  - `max_series` (default 10, only relevant for multi-series)
+  - optional `filter_expr` for a pre-aggregation filter
+
+  Embed the tool's returned `markdown` field verbatim in your next
+  hitl_ask_question — the chat UI will render the chart inline.
+
+  Use `dataaccess_create_chart` (the inline-data variant) ONLY when the
+  user already provided the values directly in their message
+  (e.g. "chart A=10, B=25, C=7").
+
+  Do not chart single-value lookups or text data.
 
   #### For ANALYSIS PLANNING:
   The user wants a structured plan for analyzing data:
@@ -364,6 +471,14 @@ mcps:
     - get_module
     - search_modules
     - list_components
+  dataaccess:
+    - list_sources
+    - list_available_data
+    - get_schema
+    - read_data
+    - execute_query
+    - create_chart
+    - create_chart_from_source
 
 approval_overrides: {}
 

--- a/druppie/agents/definitions/planner.yaml
+++ b/druppie/agents/definitions/planner.yaml
@@ -88,7 +88,7 @@ system_prompt: |
      **Agent selection guidelines:**
      - business_analyst: ALWAYS use when the user describes a problem, pain point, frustration, or challenge they are facing. Also for requirements questions, process questions, stakeholder concerns, functional design questions
      - architect: Architecture questions, technical standards, NORA principles, infrastructure, security/compliance technical details, visualizing processes/workflows
-     - data_analyst: Data-related questions, dataset discovery, questions about available data, data analysis approaches, interpreting data, building analysis plans. Use when the question is specifically about data or datasets rather than about processes/requirements (business_analyst) or architecture/standards (architect).
+     - data_analyst: Data-related questions, dataset discovery, questions about available data, data analysis approaches, interpreting data, building analysis plans. **Also use for any chart/visualization request** — the data_analyst has `dataaccess_create_chart` for rendering bar/line/pie/scatter charts inline in chat (including when the user provides the data values directly in their message). Use when the question is specifically about data, datasets, or visualizing values — rather than about processes/requirements (business_analyst) or architecture/standards (architect).
      - If the question is truly generic or does not clearly fit any agent, use the summarizer directly
        (1 step plan) and include the answer in the summarizer prompt. This is the only case where
        general_chat uses 1 step (no planner re-evaluation), since the summarizer terminates the workflow.

--- a/druppie/core/mcp_config.yaml
+++ b/druppie/core/mcp_config.yaml
@@ -303,5 +303,14 @@ mcps:
       - name: read_data
         requires_approval: false
 
+      - name: execute_query
+        requires_approval: false
+
       - name: download_data
+        requires_approval: false
+
+      - name: create_chart
+        requires_approval: false
+
+      - name: create_chart_from_source
         requires_approval: false

--- a/druppie/mcp-servers/module-data-access/v1/charts.py
+++ b/druppie/mcp-servers/module-data-access/v1/charts.py
@@ -191,6 +191,71 @@ def spec_to_markdown(spec: dict) -> str:
     return "```chart\n" + json.dumps(spec, ensure_ascii=False) + "\n```"
 
 
+def _quote_ident(ident: str) -> str:
+    """Quote a T-SQL identifier with brackets, escaping embedded ]."""
+    return "[" + str(ident).replace("]", "]]") + "]"
+
+
+def build_sql_aggregation_query(
+    data_id: str,
+    x_column: str,
+    y_column: str | None,
+    aggregation: str,
+    series_column: str | None = None,
+    filter_expr: str | None = None,
+    top_n: int | None = None,
+) -> str:
+    """Build a GROUP BY aggregation query for a SQL source.
+
+    Pushes the aggregation into the database so it runs over the FULL table
+    and returns only the small grouped result (no row-cap truncation).
+
+    `data_id` is "schema.table" (or just "table"). Output columns are
+    aliased to `x`/`y` (single-series) or `x`/`s`/`y` (multi-series) so the
+    caller can build the spec without knowing the original column names.
+    """
+    if aggregation not in SUPPORTED_AGGREGATIONS:
+        raise ValueError(
+            f"unsupported aggregation {aggregation!r}; "
+            f"expected one of {', '.join(SUPPORTED_AGGREGATIONS)}"
+        )
+    if aggregation != "count" and not y_column:
+        raise ValueError(f"aggregation={aggregation!r} requires y_column")
+    if not x_column:
+        raise ValueError("x_column is required")
+
+    if "." in data_id:
+        schema, table = data_id.split(".", 1)
+        table_ref = f"{_quote_ident(schema)}.{_quote_ident(table)}"
+    else:
+        table_ref = _quote_ident(data_id)
+
+    if aggregation == "count":
+        agg_expr = "COUNT(*)"
+    else:
+        fn = {"sum": "SUM", "avg": "AVG", "min": "MIN", "max": "MAX"}[aggregation]
+        agg_expr = f"{fn}({_quote_ident(y_column)})"
+
+    where = f" WHERE {filter_expr}" if filter_expr else ""
+
+    if series_column:
+        # Multi-series: group by both dimensions; caller pivots + trims.
+        return (
+            f"SELECT {_quote_ident(x_column)} AS x, "
+            f"{_quote_ident(series_column)} AS s, {agg_expr} AS y "
+            f"FROM {table_ref}{where} "
+            f"GROUP BY {_quote_ident(x_column)}, {_quote_ident(series_column)}"
+        )
+
+    top = f"TOP {int(top_n)} " if top_n else ""
+    return (
+        f"SELECT {top}{_quote_ident(x_column)} AS x, {agg_expr} AS y "
+        f"FROM {table_ref}{where} "
+        f"GROUP BY {_quote_ident(x_column)} "
+        f"ORDER BY {agg_expr} DESC"
+    )
+
+
 SUPPORTED_AGGREGATIONS: tuple[str, ...] = ("count", "sum", "avg", "min", "max")
 
 

--- a/druppie/mcp-servers/module-data-access/v1/charts.py
+++ b/druppie/mcp-servers/module-data-access/v1/charts.py
@@ -1,0 +1,368 @@
+"""Chart-spec builder for the data-access MCP server.
+
+Pure-Python helper that turns tabular data plus a chart configuration into a
+small JSON spec the chat UI can render via the `ChartBlock` React component.
+
+Kept separate from `tools.py` so the spec logic is easy to unit-test without
+needing the FastMCP runtime.
+
+Three families of chart types share three data shapes:
+
+  XY_TYPES        — {x, y} rows (bar, line, area, horizontal_bar, scatter)
+  NAME_VALUE_TYPES — {name, value} rows (pie, donut, treemap, funnel)
+  MULTI_SERIES_TYPES — {x, <series_key>: value, ...} rows + spec.series list
+                       (stacked_bar, grouped_bar, stacked_area, multi_line)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+ChartType = str
+
+XY_TYPES: tuple[ChartType, ...] = ("bar", "line", "area", "horizontal_bar", "scatter")
+NAME_VALUE_TYPES: tuple[ChartType, ...] = ("pie", "donut", "treemap", "funnel")
+MULTI_SERIES_TYPES: tuple[ChartType, ...] = (
+    "stacked_bar",
+    "grouped_bar",
+    "stacked_area",
+    "multi_line",
+)
+SUPPORTED_CHART_TYPES: tuple[ChartType, ...] = XY_TYPES + NAME_VALUE_TYPES + MULTI_SERIES_TYPES
+
+
+def _coerce_number(value: Any, *, column: str) -> float:
+    """Coerce a cell value to float, raising ValueError with column context."""
+    if value is None:
+        raise ValueError(f"column '{column}' contains a null value")
+    if isinstance(value, bool):
+        raise ValueError(f"column '{column}' contains a boolean, expected a number")
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"column '{column}' contains a non-numeric string: {value!r}"
+            ) from exc
+    raise ValueError(
+        f"column '{column}' contains an unsupported type: {type(value).__name__}"
+    )
+
+
+def build_chart_spec(
+    data: list[dict],
+    chart_type: ChartType,
+    x_column: str,
+    y_column: str,
+    title: str = "",
+    x_label: str | None = None,
+    y_label: str | None = None,
+) -> dict:
+    """Build a validated single-series chart spec.
+
+    For multi-series charts use `build_multi_series_chart_spec` instead.
+    """
+    if chart_type in MULTI_SERIES_TYPES:
+        raise ValueError(
+            f"chart_type {chart_type!r} is multi-series; "
+            f"use build_multi_series_chart_spec()"
+        )
+    if chart_type not in SUPPORTED_CHART_TYPES:
+        raise ValueError(
+            f"unsupported chart_type {chart_type!r}; "
+            f"expected one of {', '.join(SUPPORTED_CHART_TYPES)}"
+        )
+    if not isinstance(data, list) or not data:
+        raise ValueError("'data' must be a non-empty list of row dicts")
+    if not x_column or not y_column:
+        raise ValueError("'x_column' and 'y_column' are required")
+
+    first_row = data[0]
+    if not isinstance(first_row, dict):
+        raise ValueError("each row in 'data' must be a dict")
+    if x_column not in first_row:
+        raise ValueError(f"x_column {x_column!r} is not present in the data rows")
+    if y_column not in first_row:
+        raise ValueError(f"y_column {y_column!r} is not present in the data rows")
+
+    points: list[dict] = []
+    for row in data:
+        if chart_type in NAME_VALUE_TYPES:
+            points.append(
+                {
+                    "name": str(row[x_column]),
+                    "value": _coerce_number(row[y_column], column=y_column),
+                }
+            )
+        elif chart_type == "scatter":
+            points.append(
+                {
+                    "x": _coerce_number(row[x_column], column=x_column),
+                    "y": _coerce_number(row[y_column], column=y_column),
+                }
+            )
+        else:  # bar, line, area, horizontal_bar — categorical/ordered x, numeric y
+            x_val = row[x_column]
+            points.append(
+                {
+                    "x": x_val if isinstance(x_val, (int, float)) else str(x_val),
+                    "y": _coerce_number(row[y_column], column=y_column),
+                }
+            )
+
+    return {
+        "type": chart_type,
+        "title": title or "",
+        "x_label": x_label,
+        "y_label": y_label,
+        "data": points,
+    }
+
+
+def build_multi_series_chart_spec(
+    data: list[dict],
+    chart_type: ChartType,
+    x_column: str,
+    series: list[str],
+    title: str = "",
+    x_label: str | None = None,
+    y_label: str | None = None,
+) -> dict:
+    """Build a validated multi-series chart spec.
+
+    `data` rows look like `{x_column: <category>, <series[0]>: <num>, ...}`.
+    The resulting spec normalizes `x_column` to "x" so the frontend can use
+    a single `dataKey="x"` across chart types.
+    """
+    if chart_type not in MULTI_SERIES_TYPES:
+        raise ValueError(
+            f"chart_type {chart_type!r} is not a multi-series type; "
+            f"expected one of {', '.join(MULTI_SERIES_TYPES)}"
+        )
+    if not isinstance(data, list) or not data:
+        raise ValueError("'data' must be a non-empty list of row dicts")
+    if not x_column:
+        raise ValueError("'x_column' is required")
+    if not series:
+        raise ValueError("'series' must be a non-empty list of column names")
+
+    first_row = data[0]
+    if not isinstance(first_row, dict):
+        raise ValueError("each row in 'data' must be a dict")
+    if x_column not in first_row:
+        raise ValueError(f"x_column {x_column!r} is not present in the data rows")
+    # Series columns may be missing from some rows — the loop below fills with 0.
+    # We only require that at least ONE series value appears somewhere in the data,
+    # otherwise the chart would be empty and meaningless.
+    if not any(s in row for row in data for s in series):
+        raise ValueError("none of the series columns are present in any data row")
+
+    points: list[dict] = []
+    for row in data:
+        out: dict[str, Any] = {}
+        x_val = row[x_column]
+        out["x"] = x_val if isinstance(x_val, (int, float)) else str(x_val)
+        for s in series:
+            value = row.get(s)
+            if value is None:
+                out[s] = 0.0
+            else:
+                try:
+                    out[s] = _coerce_number(value, column=s)
+                except ValueError:
+                    out[s] = 0.0
+        points.append(out)
+
+    return {
+        "type": chart_type,
+        "title": title or "",
+        "x_label": x_label,
+        "y_label": y_label,
+        "series": [{"key": s, "label": s} for s in series],
+        "data": points,
+    }
+
+
+def spec_to_markdown(spec: dict) -> str:
+    """Wrap a chart spec in a ```chart fenced code block, ready for chat."""
+    return "```chart\n" + json.dumps(spec, ensure_ascii=False) + "\n```"
+
+
+SUPPORTED_AGGREGATIONS: tuple[str, ...] = ("count", "sum", "avg", "min", "max")
+
+
+def aggregate_rows(
+    data: list[dict],
+    x_column: str,
+    y_column: str | None,
+    aggregation: str,
+    top_n: int | None = None,
+) -> tuple[list[dict], str]:
+    """Group rows by `x_column` and aggregate over `y_column` (single series).
+
+    Returns `(rows, agg_column_name)` — see module docstring for shape.
+    """
+    if aggregation not in SUPPORTED_AGGREGATIONS:
+        raise ValueError(
+            f"unsupported aggregation {aggregation!r}; "
+            f"expected one of {', '.join(SUPPORTED_AGGREGATIONS)}"
+        )
+    if not isinstance(data, list):
+        raise ValueError("'data' must be a list of row dicts")
+    if not x_column:
+        raise ValueError("'x_column' is required")
+    if aggregation != "count" and not y_column:
+        raise ValueError(f"aggregation={aggregation!r} requires y_column")
+
+    if aggregation == "count":
+        counts: dict = {}
+        for row in data:
+            if not isinstance(row, dict):
+                continue
+            key = row.get(x_column)
+            if key is None:
+                continue
+            counts[key] = counts.get(key, 0) + 1
+        result = [{x_column: k, "count": v} for k, v in counts.items()]
+        agg_column = "count"
+    else:
+        buckets: dict = {}
+        for row in data:
+            if not isinstance(row, dict):
+                continue
+            x = row.get(x_column)
+            y = row.get(y_column)
+            if x is None or y is None:
+                continue
+            if isinstance(y, bool):
+                continue
+            if isinstance(y, (int, float)):
+                y_num = float(y)
+            elif isinstance(y, str):
+                try:
+                    y_num = float(y)
+                except ValueError:
+                    continue
+            else:
+                continue
+            buckets.setdefault(x, []).append(y_num)
+        result = []
+        for x, ys in buckets.items():
+            if not ys:
+                continue
+            if aggregation == "sum":
+                agg = sum(ys)
+            elif aggregation == "avg":
+                agg = sum(ys) / len(ys)
+            elif aggregation == "min":
+                agg = min(ys)
+            else:  # max
+                agg = max(ys)
+            result.append({x_column: x, y_column: agg})
+        agg_column = y_column  # type: ignore[assignment]
+
+    result.sort(key=lambda r: r[agg_column], reverse=True)
+    if top_n is not None and top_n > 0:
+        result = result[:top_n]
+    return result, agg_column
+
+
+def aggregate_multi_series(
+    data: list[dict],
+    x_column: str,
+    series_column: str,
+    y_column: str | None,
+    aggregation: str,
+    top_n: int | None = None,
+    max_series: int | None = 10,
+) -> tuple[list[dict], list[str]]:
+    """Pivot-aggregate rows for a multi-series chart.
+
+    Groups by (x_column, series_column) pair and applies `aggregation`.
+    Returns `(rows, series_keys)` where each row is
+    `{x_column: <x_value>, <series_value_1>: <agg>, <series_value_2>: <agg>, ...}`.
+
+    `top_n` keeps the top N x_column values by total aggregated value.
+    `max_series` keeps the top N series_column values; remaining are dropped.
+    Missing (x, series) pairs in the output get 0 to keep the data shape rectangular.
+    """
+    if aggregation not in SUPPORTED_AGGREGATIONS:
+        raise ValueError(
+            f"unsupported aggregation {aggregation!r}; "
+            f"expected one of {', '.join(SUPPORTED_AGGREGATIONS)}"
+        )
+    if not isinstance(data, list):
+        raise ValueError("'data' must be a list of row dicts")
+    if not x_column or not series_column:
+        raise ValueError("'x_column' and 'series_column' are required")
+    if aggregation != "count" and not y_column:
+        raise ValueError(f"aggregation={aggregation!r} requires y_column")
+
+    # bucket[(x, s)] = list of y values  (or count via len)
+    buckets: dict[tuple, list[float]] = {}
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        x = row.get(x_column)
+        s = row.get(series_column)
+        if x is None or s is None:
+            continue
+        if aggregation == "count":
+            buckets.setdefault((x, s), []).append(1.0)
+            continue
+        y = row.get(y_column)
+        if y is None or isinstance(y, bool):
+            continue
+        if isinstance(y, (int, float)):
+            y_num = float(y)
+        elif isinstance(y, str):
+            try:
+                y_num = float(y)
+            except ValueError:
+                continue
+        else:
+            continue
+        buckets.setdefault((x, s), []).append(y_num)
+
+    def _apply(values: list[float]) -> float:
+        if aggregation == "count":
+            return float(len(values))
+        if aggregation == "sum":
+            return sum(values)
+        if aggregation == "avg":
+            return sum(values) / len(values)
+        if aggregation == "min":
+            return min(values)
+        return max(values)  # max
+
+    # Aggregate each (x, s) pair.
+    agg: dict[tuple, float] = {(x, s): _apply(vs) for (x, s), vs in buckets.items() if vs}
+
+    # Compute x totals and series totals for top_n trimming.
+    x_totals: dict = {}
+    s_totals: dict = {}
+    for (x, s), v in agg.items():
+        x_totals[x] = x_totals.get(x, 0.0) + v
+        s_totals[s] = s_totals.get(s, 0.0) + v
+
+    x_order = sorted(x_totals.items(), key=lambda kv: kv[1], reverse=True)
+    if top_n is not None and top_n > 0:
+        x_order = x_order[:top_n]
+    kept_x = [x for x, _ in x_order]
+
+    s_order = sorted(s_totals.items(), key=lambda kv: kv[1], reverse=True)
+    if max_series is not None and max_series > 0:
+        s_order = s_order[:max_series]
+    series_keys = [str(s) for s, _ in s_order]
+
+    rows: list[dict] = []
+    for x in kept_x:
+        row: dict[str, Any] = {x_column: x}
+        for s, s_str in zip([s for s, _ in s_order], series_keys):
+            row[s_str] = agg.get((x, s), 0.0)
+        rows.append(row)
+
+    return rows, series_keys

--- a/druppie/mcp-servers/module-data-access/v1/tools.py
+++ b/druppie/mcp-servers/module-data-access/v1/tools.py
@@ -20,8 +20,11 @@ from .charts import (
     aggregate_rows,
     build_chart_spec,
     build_multi_series_chart_spec,
+    build_sql_aggregation_query,
     spec_to_markdown,
 )
+
+_SQL_SOURCE_TYPES = {"azure-sql", "azure-sql-obo"}
 from .module import DataAccessModule
 
 logger = logging.getLogger("dataaccess-mcp")
@@ -269,7 +272,7 @@ async def create_chart_from_source(
     filter_expr: str | None = None,
     top_n: int | None = 20,
     max_series: int | None = 10,
-    read_limit: int = 5000,
+    read_limit: int | None = None,
     title: str = "",
     x_label: str | None = None,
     y_label: str | None = None,
@@ -280,6 +283,13 @@ async def create_chart_from_source(
     table or Azure Data Lake file). The raw rows NEVER enter the conversation
     — the data is read inside this MCP server, aggregated, and only the small
     per-category summary + chart spec is returned to you.
+
+    The aggregation runs over the ENTIRE dataset:
+      - SQL sources: the GROUP BY is pushed into the database, so all rows
+        are aggregated and only the grouped result is transferred.
+      - Data Lake files: the whole file is read server-side and aggregated.
+    `read_limit` defaults to None (no cap). Only set it if you deliberately
+    want a sampled approximation of a very large Data Lake file.
 
     PREFER THIS over read_data + create_chart for any non-trivial dataset.
     Calling read_data with many rows pulls megabytes of JSON into your
@@ -310,15 +320,16 @@ async def create_chart_from_source(
         filter_expr:   Optional pre-aggregation filter
         top_n:         Keep only top N x_column values by total aggregated value (default 20)
         max_series:    For multi-series only — cap the number of series kept (default 10)
-        read_limit:    Hard cap on rows fetched from source (default 5000)
+        read_limit:    Data Lake only — optional cap on rows read before aggregation
+                       (default None = read the whole file). Ignored for SQL.
         title:         Optional chart title
         x_label:       Optional x-axis label
         y_label:       Optional y-axis label
 
     Returns:
         On success: {"success": True, "spec": ..., "markdown": "```chart...",
-                     "row_count_read": int, "category_count": int,
-                     "series_count": int (multi-series only)}.
+                     "rows_scanned": int, "full_dataset": bool,
+                     "category_count": int, "series_count": int (multi only)}.
         On failure: {"success": False, "error": "<reason>"}.
     """
     normalized_filter = filter_expr
@@ -334,19 +345,6 @@ async def create_chart_from_source(
             "error": f"chart_type={chart_type!r} requires series_column",
         }
 
-    read_result = await module.read_data(
-        source_id, data_id, filter_expr=normalized_filter, limit=read_limit
-    )
-    if not read_result.get("success"):
-        return {
-            "success": False,
-            "error": f"read_data failed: {read_result.get('error', 'unknown error')}",
-        }
-
-    rows = read_result.get("data", [])
-    if not isinstance(rows, list) or not rows:
-        return {"success": False, "error": "source returned no rows"}
-
     default_title = title or (
         f"{aggregation}({y_column or '*'}) by {x_column}"
         + (f" / {series_column}" if is_multi else "")
@@ -355,83 +353,121 @@ async def create_chart_from_source(
         "count" if aggregation == "count" else f"{aggregation}({y_column})"
     )
 
-    if is_multi:
+    # Identify the source type so we can aggregate the FULL dataset:
+    #   SQL  -> push GROUP BY into the database (no row transfer)
+    #   else -> read the whole file server-side and aggregate in Python
+    src_type = None
+    for s in module.list_sources().get("sources", []):
+        if s.get("source_id") == source_id:
+            src_type = s.get("source_type")
+            break
+    is_sql = src_type in _SQL_SOURCE_TYPES
+
+    rows_scanned = 0
+    full_dataset = True
+
+    if is_sql:
         try:
-            aggregated, series_keys = aggregate_multi_series(
-                data=rows,
+            query = build_sql_aggregation_query(
+                data_id=data_id,
                 x_column=x_column,
-                series_column=series_column,  # type: ignore[arg-type]
                 y_column=y_column,
                 aggregation=aggregation,
-                top_n=top_n,
-                max_series=max_series,
+                series_column=series_column if is_multi else None,
+                filter_expr=normalized_filter,
+                top_n=None if is_multi else top_n,
             )
         except ValueError as exc:
             return {"success": False, "error": str(exc)}
 
-        if not aggregated:
+        # High limit guards the grouped result only (categories × series),
+        # not the source rows — the DB already aggregated those.
+        q_result = await module.execute_query(source_id, query, limit=100000)
+        if not q_result.get("success"):
             return {
                 "success": False,
-                "error": "aggregation produced no rows (check x_column/series_column have non-null values)",
+                "error": f"aggregation query failed: {q_result.get('error', 'unknown error')}",
             }
+        grouped = q_result.get("data", [])
+        if not grouped:
+            return {"success": False, "error": "aggregation produced no rows"}
+
+        if is_multi:
+            # grouped rows are [{x, s, y}] already aggregated — pivot only
+            # (sum pass-through, since each (x, s) appears once).
+            aggregated, series_keys = aggregate_multi_series(
+                data=grouped, x_column="x", series_column="s",
+                y_column="y", aggregation="sum",
+                top_n=top_n, max_series=max_series,
+            )
+            agg_x_col, agg_y_col = "x", "y"
+        else:
+            aggregated = grouped  # [{x, y}]
+            agg_x_col, agg_y_col = "x", "y"
+    else:
+        read_result = await module.read_data(
+            source_id, data_id, filter_expr=normalized_filter, limit=read_limit
+        )
+        if not read_result.get("success"):
+            return {
+                "success": False,
+                "error": f"read_data failed: {read_result.get('error', 'unknown error')}",
+            }
+        rows = read_result.get("data", [])
+        if not isinstance(rows, list) or not rows:
+            return {"success": False, "error": "source returned no rows"}
+        rows_scanned = len(rows)
+        full_dataset = not read_result.get("metadata", {}).get("capped", False)
 
         try:
-            spec = build_multi_series_chart_spec(
-                data=aggregated,
-                chart_type=chart_type,
-                x_column=x_column,
-                series=series_keys,
-                title=default_title,
-                x_label=x_label or x_column,
-                y_label=default_y_label,
-            )
+            if is_multi:
+                aggregated, series_keys = aggregate_multi_series(
+                    data=rows, x_column=x_column, series_column=series_column,  # type: ignore[arg-type]
+                    y_column=y_column, aggregation=aggregation,
+                    top_n=top_n, max_series=max_series,
+                )
+                agg_x_col = x_column
+            else:
+                aggregated, agg_col = aggregate_rows(
+                    data=rows, x_column=x_column, y_column=y_column,
+                    aggregation=aggregation, top_n=top_n,
+                )
+                agg_x_col, agg_y_col = x_column, agg_col
         except ValueError as exc:
             return {"success": False, "error": str(exc)}
-
-        return {
-            "success": True,
-            "spec": spec,
-            "markdown": spec_to_markdown(spec),
-            "row_count_read": len(rows),
-            "category_count": len(aggregated),
-            "series_count": len(series_keys),
-        }
-
-    # Single-series path
-    try:
-        aggregated, agg_column = aggregate_rows(
-            data=rows,
-            x_column=x_column,
-            y_column=y_column,
-            aggregation=aggregation,
-            top_n=top_n,
-        )
-    except ValueError as exc:
-        return {"success": False, "error": str(exc)}
 
     if not aggregated:
         return {
             "success": False,
-            "error": f"aggregation produced no rows (x_column={x_column!r} may be missing or all null)",
+            "error": "aggregation produced no rows (check x_column / series_column have non-null values)",
         }
 
     try:
-        spec = build_chart_spec(
-            data=aggregated,
-            chart_type=chart_type,
-            x_column=x_column,
-            y_column=agg_column,
-            title=default_title,
-            x_label=x_label or x_column,
-            y_label=default_y_label,
-        )
+        if is_multi:
+            spec = build_multi_series_chart_spec(
+                data=aggregated, chart_type=chart_type, x_column=agg_x_col,
+                series=series_keys, title=default_title,
+                x_label=x_label or x_column, y_label=default_y_label,
+            )
+        else:
+            spec = build_chart_spec(
+                data=aggregated, chart_type=chart_type, x_column=agg_x_col,
+                y_column=agg_y_col, title=default_title,
+                x_label=x_label or x_column, y_label=default_y_label,
+            )
     except ValueError as exc:
         return {"success": False, "error": str(exc)}
 
-    return {
+    result = {
         "success": True,
         "spec": spec,
         "markdown": spec_to_markdown(spec),
-        "row_count_read": len(rows),
         "category_count": len(aggregated),
+        "full_dataset": full_dataset,
+        "aggregated_in": "database" if is_sql else "server",
     }
+    if not is_sql:
+        result["rows_scanned"] = rows_scanned
+    if is_multi:
+        result["series_count"] = len(series_keys)
+    return result

--- a/druppie/mcp-servers/module-data-access/v1/tools.py
+++ b/druppie/mcp-servers/module-data-access/v1/tools.py
@@ -11,8 +11,17 @@ IMPORTANT: OBO tokens are fetched fresh per request - NEVER cached or stored.
 import logging
 import os
 from pathlib import Path
+from typing import Literal
 
 from fastmcp import FastMCP
+from .charts import (
+    MULTI_SERIES_TYPES,
+    aggregate_multi_series,
+    aggregate_rows,
+    build_chart_spec,
+    build_multi_series_chart_spec,
+    spec_to_markdown,
+)
 from .module import DataAccessModule
 
 logger = logging.getLogger("dataaccess-mcp")
@@ -185,3 +194,244 @@ async def download_data(
 
     destination_path.parent.mkdir(parents=True, exist_ok=True)
     return await module.download_data(source_id, data_id, str(destination_path))
+
+
+@mcp.tool()
+async def create_chart(
+    data: list[dict],
+    chart_type: Literal[
+        "bar", "line", "area", "horizontal_bar", "scatter",
+        "pie", "donut", "treemap", "funnel",
+    ],
+    x_column: str,
+    y_column: str,
+    title: str = "",
+    x_label: str | None = None,
+    y_label: str | None = None,
+) -> dict:
+    """Produce a chart spec the chat UI can render inline.
+
+    Use this AFTER pulling data with read_data() or execute_query() to
+    visualize the result. Prefer execute_query when an aggregation is needed
+    (e.g. GROUP BY) so the database does the work and the chart input stays
+    small.
+
+    The returned `markdown` field is a ready-to-embed fenced code block.
+    Include it verbatim in your next user-facing message (e.g. inside
+    hitl_ask_question) — the chat UI will render the chart inline.
+
+    Args:
+        data: List of row dicts, as returned by read_data/execute_query.
+        chart_type: One of "bar", "line", "pie", "scatter".
+        x_column: Column name to use for the x-axis (or pie slice name).
+        y_column: Column name to use for the y-axis (or pie slice value).
+        title: Optional chart title.
+        x_label: Optional x-axis label (ignored for pie).
+        y_label: Optional y-axis label (ignored for pie).
+
+    Returns:
+        On success: {"success": True, "spec": <chart spec>, "markdown": "```chart..."}.
+        On failure: {"success": False, "error": "<reason>"}.
+    """
+    try:
+        spec = build_chart_spec(
+            data=data,
+            chart_type=chart_type,
+            x_column=x_column,
+            y_column=y_column,
+            title=title,
+            x_label=x_label,
+            y_label=y_label,
+        )
+    except ValueError as exc:
+        return {"success": False, "error": str(exc)}
+
+    return {
+        "success": True,
+        "spec": spec,
+        "markdown": spec_to_markdown(spec),
+    }
+
+
+@mcp.tool()
+async def create_chart_from_source(
+    source_id: str,
+    data_id: str,
+    chart_type: Literal[
+        "bar", "line", "area", "horizontal_bar", "scatter",
+        "pie", "donut", "treemap", "funnel",
+        "stacked_bar", "grouped_bar", "stacked_area", "multi_line",
+    ],
+    x_column: str,
+    y_column: str | None = None,
+    series_column: str | None = None,
+    aggregation: Literal["count", "sum", "avg", "min", "max"] = "count",
+    filter_expr: str | None = None,
+    top_n: int | None = 20,
+    max_series: int | None = 10,
+    read_limit: int = 5000,
+    title: str = "",
+    x_label: str | None = None,
+    y_label: str | None = None,
+) -> dict:
+    """Build a chart spec by reading + aggregating data SERVER-SIDE.
+
+    Use this for charting data that lives in a configured source (Azure SQL
+    table or Azure Data Lake file). The raw rows NEVER enter the conversation
+    — the data is read inside this MCP server, aggregated, and only the small
+    per-category summary + chart spec is returned to you.
+
+    PREFER THIS over read_data + create_chart for any non-trivial dataset.
+    Calling read_data with many rows pulls megabytes of JSON into your
+    context and will overflow the LLM. This tool keeps your context small.
+
+    Chart type families and required columns:
+      - Single-series (x/y axes):       bar | line | area | horizontal_bar | scatter
+        → set x_column + y_column (or aggregation="count" for y)
+      - Proportions (name/value):       pie | donut | treemap | funnel
+        → set x_column (becomes slice name) + y_column / aggregation="count"
+      - Multi-series breakdowns:        stacked_bar | grouped_bar | stacked_area | multi_line
+        → ALSO set series_column (a second grouping column, e.g. "year")
+
+    Aggregation semantics:
+      - "count":          count rows per group (y_column ignored)
+      - "sum"/"avg"/...:  aggregate y_column values grouped by x_column
+                          (and series_column for multi-series)
+
+    Args:
+        source_id:     Source ID from list_sources()
+        data_id:       Table name (SQL) or file path (Data Lake)
+        chart_type:    See families above
+        x_column:      Primary grouping column (becomes x / pie name)
+        y_column:      Numeric column to aggregate (required unless aggregation="count")
+        series_column: Second grouping column — REQUIRED for multi-series chart types,
+                       ignored otherwise. Each unique value becomes a series.
+        aggregation:   count | sum | avg | min | max
+        filter_expr:   Optional pre-aggregation filter
+        top_n:         Keep only top N x_column values by total aggregated value (default 20)
+        max_series:    For multi-series only — cap the number of series kept (default 10)
+        read_limit:    Hard cap on rows fetched from source (default 5000)
+        title:         Optional chart title
+        x_label:       Optional x-axis label
+        y_label:       Optional y-axis label
+
+    Returns:
+        On success: {"success": True, "spec": ..., "markdown": "```chart...",
+                     "row_count_read": int, "category_count": int,
+                     "series_count": int (multi-series only)}.
+        On failure: {"success": False, "error": "<reason>"}.
+    """
+    normalized_filter = filter_expr
+    if normalized_filter is not None and normalized_filter.strip().lower() in ("", "null", "none"):
+        normalized_filter = None
+    if series_column is not None and series_column.strip().lower() in ("", "null", "none"):
+        series_column = None
+
+    is_multi = chart_type in MULTI_SERIES_TYPES
+    if is_multi and not series_column:
+        return {
+            "success": False,
+            "error": f"chart_type={chart_type!r} requires series_column",
+        }
+
+    read_result = await module.read_data(
+        source_id, data_id, filter_expr=normalized_filter, limit=read_limit
+    )
+    if not read_result.get("success"):
+        return {
+            "success": False,
+            "error": f"read_data failed: {read_result.get('error', 'unknown error')}",
+        }
+
+    rows = read_result.get("data", [])
+    if not isinstance(rows, list) or not rows:
+        return {"success": False, "error": "source returned no rows"}
+
+    default_title = title or (
+        f"{aggregation}({y_column or '*'}) by {x_column}"
+        + (f" / {series_column}" if is_multi else "")
+    )
+    default_y_label = y_label or (
+        "count" if aggregation == "count" else f"{aggregation}({y_column})"
+    )
+
+    if is_multi:
+        try:
+            aggregated, series_keys = aggregate_multi_series(
+                data=rows,
+                x_column=x_column,
+                series_column=series_column,  # type: ignore[arg-type]
+                y_column=y_column,
+                aggregation=aggregation,
+                top_n=top_n,
+                max_series=max_series,
+            )
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+
+        if not aggregated:
+            return {
+                "success": False,
+                "error": "aggregation produced no rows (check x_column/series_column have non-null values)",
+            }
+
+        try:
+            spec = build_multi_series_chart_spec(
+                data=aggregated,
+                chart_type=chart_type,
+                x_column=x_column,
+                series=series_keys,
+                title=default_title,
+                x_label=x_label or x_column,
+                y_label=default_y_label,
+            )
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+
+        return {
+            "success": True,
+            "spec": spec,
+            "markdown": spec_to_markdown(spec),
+            "row_count_read": len(rows),
+            "category_count": len(aggregated),
+            "series_count": len(series_keys),
+        }
+
+    # Single-series path
+    try:
+        aggregated, agg_column = aggregate_rows(
+            data=rows,
+            x_column=x_column,
+            y_column=y_column,
+            aggregation=aggregation,
+            top_n=top_n,
+        )
+    except ValueError as exc:
+        return {"success": False, "error": str(exc)}
+
+    if not aggregated:
+        return {
+            "success": False,
+            "error": f"aggregation produced no rows (x_column={x_column!r} may be missing or all null)",
+        }
+
+    try:
+        spec = build_chart_spec(
+            data=aggregated,
+            chart_type=chart_type,
+            x_column=x_column,
+            y_column=agg_column,
+            title=default_title,
+            x_label=x_label or x_column,
+            y_label=default_y_label,
+        )
+    except ValueError as exc:
+        return {"success": False, "error": str(exc)}
+
+    return {
+        "success": True,
+        "spec": spec,
+        "markdown": spec_to_markdown(spec),
+        "row_count_read": len(rows),
+        "category_count": len(aggregated),
+    }

--- a/druppie/tests/test_dataaccess_charts.py
+++ b/druppie/tests/test_dataaccess_charts.py
@@ -502,3 +502,106 @@ def test_aggregate_multi_series_requires_y_for_non_count():
             y_column=None,
             aggregation="sum",
         )
+
+
+# ---------------------------------------------------------------------------
+# build_sql_aggregation_query — full-dataset GROUP BY pushdown
+# ---------------------------------------------------------------------------
+
+
+def test_sql_query_count_single_series():
+    q = charts.build_sql_aggregation_query(
+        data_id="dbo.users",
+        x_column="country",
+        y_column=None,
+        aggregation="count",
+        top_n=20,
+    )
+    assert q == (
+        "SELECT TOP 20 [country] AS x, COUNT(*) AS y "
+        "FROM [dbo].[users] "
+        "GROUP BY [country] "
+        "ORDER BY COUNT(*) DESC"
+    )
+
+
+def test_sql_query_sum_with_y_column():
+    q = charts.build_sql_aggregation_query(
+        data_id="dbo.sales",
+        x_column="region",
+        y_column="amount",
+        aggregation="sum",
+        top_n=10,
+    )
+    assert q == (
+        "SELECT TOP 10 [region] AS x, SUM([amount]) AS y "
+        "FROM [dbo].[sales] "
+        "GROUP BY [region] "
+        "ORDER BY SUM([amount]) DESC"
+    )
+
+
+def test_sql_query_with_filter():
+    q = charts.build_sql_aggregation_query(
+        data_id="dbo.sales",
+        x_column="region",
+        y_column=None,
+        aggregation="count",
+        filter_expr="year = 2025",
+        top_n=5,
+    )
+    assert "WHERE year = 2025" in q
+    assert "GROUP BY [region]" in q
+
+
+def test_sql_query_multi_series_no_top():
+    q = charts.build_sql_aggregation_query(
+        data_id="dbo.sales",
+        x_column="region",
+        y_column="revenue",
+        aggregation="sum",
+        series_column="product",
+        top_n=20,  # ignored for multi-series (caller pivots)
+    )
+    assert q == (
+        "SELECT [region] AS x, [product] AS s, SUM([revenue]) AS y "
+        "FROM [dbo].[sales] "
+        "GROUP BY [region], [product]"
+    )
+    assert "TOP" not in q
+
+
+def test_sql_query_table_without_schema():
+    q = charts.build_sql_aggregation_query(
+        data_id="users",
+        x_column="country",
+        y_column=None,
+        aggregation="count",
+        top_n=10,
+    )
+    assert "FROM [users]" in q
+
+
+def test_sql_query_escapes_bracket_in_identifier():
+    q = charts.build_sql_aggregation_query(
+        data_id="dbo.weird",
+        x_column="col]name",
+        y_column=None,
+        aggregation="count",
+    )
+    # ] doubled to ]] inside the brackets
+    assert "[col]]name]" in q
+
+
+def test_sql_query_rejects_bad_aggregation():
+    with pytest.raises(ValueError, match="unsupported aggregation"):
+        charts.build_sql_aggregation_query(
+            data_id="dbo.t", x_column="a", y_column="b", aggregation="median"
+        )
+
+
+def test_sql_query_requires_y_for_non_count():
+    with pytest.raises(ValueError, match="requires y_column"):
+        charts.build_sql_aggregation_query(
+            data_id="dbo.t", x_column="a", y_column=None, aggregation="avg"
+        )

--- a/druppie/tests/test_dataaccess_charts.py
+++ b/druppie/tests/test_dataaccess_charts.py
@@ -1,0 +1,504 @@
+"""Unit tests for the dataaccess MCP chart-spec builder.
+
+`charts.py` lives in `druppie/mcp-servers/module-data-access/v1/`, which is a
+standalone service tree (the directory name uses a dash, so it is not a Python
+package importable from the main `druppie` package). We load the module
+directly by path to keep the test free of any sys.path / package shenanigans.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_CHARTS_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "mcp-servers"
+    / "module-data-access"
+    / "v1"
+    / "charts.py"
+)
+
+_spec = importlib.util.spec_from_file_location("dataaccess_charts", _CHARTS_PATH)
+charts = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(charts)
+
+
+# ---------------------------------------------------------------------------
+# Happy paths — one per chart type
+# ---------------------------------------------------------------------------
+
+
+def test_bar_chart_projects_x_y_pairs():
+    data = [
+        {"category": "A", "amount": 10},
+        {"category": "B", "amount": 25},
+        {"category": "C", "amount": 7},
+    ]
+    spec = charts.build_chart_spec(
+        data=data,
+        chart_type="bar",
+        x_column="category",
+        y_column="amount",
+        title="Sales by category",
+        y_label="Amount (USD)",
+    )
+    assert spec["type"] == "bar"
+    assert spec["title"] == "Sales by category"
+    assert spec["y_label"] == "Amount (USD)"
+    assert spec["data"] == [
+        {"x": "A", "y": 10.0},
+        {"x": "B", "y": 25.0},
+        {"x": "C", "y": 7.0},
+    ]
+
+
+def test_line_chart_coerces_numeric_strings():
+    data = [
+        {"month": "2025-01", "revenue": "1200"},
+        {"month": "2025-02", "revenue": "1500.5"},
+    ]
+    spec = charts.build_chart_spec(
+        data=data, chart_type="line", x_column="month", y_column="revenue"
+    )
+    assert spec["type"] == "line"
+    assert spec["data"][0] == {"x": "2025-01", "y": 1200.0}
+    assert spec["data"][1] == {"x": "2025-02", "y": 1500.5}
+
+
+def test_pie_chart_uses_name_value_shape():
+    data = [
+        {"segment": "Enterprise", "share": 0.6},
+        {"segment": "SMB", "share": 0.4},
+    ]
+    spec = charts.build_chart_spec(
+        data=data, chart_type="pie", x_column="segment", y_column="share"
+    )
+    assert spec["data"] == [
+        {"name": "Enterprise", "value": 0.6},
+        {"name": "SMB", "value": 0.4},
+    ]
+
+
+def test_scatter_chart_requires_numeric_x_and_y():
+    data = [
+        {"height": 170, "weight": 65},
+        {"height": 180, "weight": 80},
+    ]
+    spec = charts.build_chart_spec(
+        data=data, chart_type="scatter", x_column="height", y_column="weight"
+    )
+    assert spec["data"] == [
+        {"x": 170.0, "y": 65.0},
+        {"x": 180.0, "y": 80.0},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Validation failures
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_unsupported_chart_type():
+    with pytest.raises(ValueError, match="unsupported chart_type"):
+        charts.build_chart_spec(
+            data=[{"a": 1, "b": 2}],
+            chart_type="histogram",
+            x_column="a",
+            y_column="b",
+        )
+
+
+def test_rejects_empty_data():
+    with pytest.raises(ValueError, match="non-empty list"):
+        charts.build_chart_spec(
+            data=[], chart_type="bar", x_column="a", y_column="b"
+        )
+
+
+def test_rejects_missing_x_column():
+    with pytest.raises(ValueError, match="x_column 'foo' is not present"):
+        charts.build_chart_spec(
+            data=[{"bar": 1, "baz": 2}],
+            chart_type="bar",
+            x_column="foo",
+            y_column="baz",
+        )
+
+
+def test_rejects_missing_y_column():
+    with pytest.raises(ValueError, match="y_column 'foo' is not present"):
+        charts.build_chart_spec(
+            data=[{"bar": 1, "baz": 2}],
+            chart_type="bar",
+            x_column="bar",
+            y_column="foo",
+        )
+
+
+def test_rejects_non_numeric_y_value():
+    with pytest.raises(ValueError, match="non-numeric string"):
+        charts.build_chart_spec(
+            data=[{"x": "A", "y": "not a number"}],
+            chart_type="bar",
+            x_column="x",
+            y_column="y",
+        )
+
+
+def test_rejects_null_y_value():
+    with pytest.raises(ValueError, match="null value"):
+        charts.build_chart_spec(
+            data=[{"x": "A", "y": None}],
+            chart_type="bar",
+            x_column="x",
+            y_column="y",
+        )
+
+
+def test_rejects_scatter_with_non_numeric_x():
+    with pytest.raises(ValueError, match="non-numeric string"):
+        charts.build_chart_spec(
+            data=[{"x": "A", "y": 1}],
+            chart_type="scatter",
+            x_column="x",
+            y_column="y",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Markdown round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_spec_to_markdown_round_trips_via_json():
+    spec = charts.build_chart_spec(
+        data=[{"category": "A", "amount": 10}],
+        chart_type="bar",
+        x_column="category",
+        y_column="amount",
+        title="Sales",
+    )
+    md = charts.spec_to_markdown(spec)
+    assert md.startswith("```chart\n")
+    assert md.endswith("\n```")
+    body = md[len("```chart\n") : -len("\n```")]
+    assert json.loads(body) == spec
+
+
+# ---------------------------------------------------------------------------
+# aggregate_rows
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_count_groups_by_x_column():
+    data = [
+        {"category": "A"},
+        {"category": "B"},
+        {"category": "A"},
+        {"category": "C"},
+        {"category": "A"},
+    ]
+    result, agg_column = charts.aggregate_rows(
+        data, x_column="category", y_column=None, aggregation="count"
+    )
+    assert agg_column == "count"
+    # sorted descending by count
+    assert result == [
+        {"category": "A", "count": 3},
+        {"category": "B", "count": 1},
+        {"category": "C", "count": 1},
+    ]
+
+
+def test_aggregate_sum_combines_y_values():
+    data = [
+        {"region": "EU", "revenue": 100},
+        {"region": "US", "revenue": 250},
+        {"region": "EU", "revenue": 150},
+    ]
+    result, agg_column = charts.aggregate_rows(
+        data, x_column="region", y_column="revenue", aggregation="sum"
+    )
+    assert agg_column == "revenue"
+    assert result == [
+        {"region": "EU", "revenue": 250.0},
+        {"region": "US", "revenue": 250.0},
+    ]
+
+
+def test_aggregate_avg_handles_numeric_strings():
+    data = [
+        {"team": "Red", "score": "10"},
+        {"team": "Red", "score": "20"},
+        {"team": "Blue", "score": "15"},
+    ]
+    result, _ = charts.aggregate_rows(
+        data, x_column="team", y_column="score", aggregation="avg"
+    )
+    by_team = {row["team"]: row["score"] for row in result}
+    assert by_team == {"Red": 15.0, "Blue": 15.0}
+
+
+def test_aggregate_top_n_trims_results():
+    data = [{"k": "a"}, {"k": "b"}, {"k": "c"}, {"k": "d"}, {"k": "a"}, {"k": "a"}]
+    result, _ = charts.aggregate_rows(
+        data, x_column="k", y_column=None, aggregation="count", top_n=2
+    )
+    assert len(result) == 2
+    assert result[0] == {"k": "a", "count": 3}
+
+
+def test_aggregate_skips_null_keys_and_values():
+    data = [
+        {"x": "A", "y": 10},
+        {"x": None, "y": 5},
+        {"x": "B", "y": None},
+        {"x": "A", "y": 20},
+    ]
+    result, _ = charts.aggregate_rows(
+        data, x_column="x", y_column="y", aggregation="sum"
+    )
+    assert result == [{"x": "A", "y": 30.0}]
+
+
+def test_aggregate_rejects_unsupported_aggregation():
+    with pytest.raises(ValueError, match="unsupported aggregation"):
+        charts.aggregate_rows(
+            [{"a": 1}], x_column="a", y_column=None, aggregation="median"
+        )
+
+
+def test_aggregate_requires_y_column_for_non_count():
+    with pytest.raises(ValueError, match="requires y_column"):
+        charts.aggregate_rows(
+            [{"a": 1}], x_column="a", y_column=None, aggregation="sum"
+        )
+
+
+def test_aggregate_min_max():
+    data = [
+        {"k": "A", "v": 10},
+        {"k": "A", "v": 30},
+        {"k": "B", "v": 20},
+    ]
+    min_result, _ = charts.aggregate_rows(
+        data, x_column="k", y_column="v", aggregation="min"
+    )
+    max_result, _ = charts.aggregate_rows(
+        data, x_column="k", y_column="v", aggregation="max"
+    )
+    assert {r["k"]: r["v"] for r in min_result} == {"A": 10.0, "B": 20.0}
+    assert {r["k"]: r["v"] for r in max_result} == {"A": 30.0, "B": 20.0}
+
+
+# ---------------------------------------------------------------------------
+# New chart types — single-series variants
+# ---------------------------------------------------------------------------
+
+
+def test_horizontal_bar_uses_xy_shape():
+    spec = charts.build_chart_spec(
+        data=[{"cat": "A long category name", "val": 5}, {"cat": "B", "val": 10}],
+        chart_type="horizontal_bar",
+        x_column="cat",
+        y_column="val",
+    )
+    assert spec["type"] == "horizontal_bar"
+    assert spec["data"][0] == {"x": "A long category name", "y": 5.0}
+
+
+def test_area_chart_uses_xy_shape():
+    spec = charts.build_chart_spec(
+        data=[{"t": 1, "v": 10}, {"t": 2, "v": 20}],
+        chart_type="area",
+        x_column="t",
+        y_column="v",
+    )
+    assert spec["type"] == "area"
+    assert spec["data"][0] == {"x": 1, "y": 10.0}
+
+
+def test_donut_uses_name_value_shape():
+    spec = charts.build_chart_spec(
+        data=[{"seg": "Enterprise", "share": 0.6}],
+        chart_type="donut",
+        x_column="seg",
+        y_column="share",
+    )
+    assert spec["data"] == [{"name": "Enterprise", "value": 0.6}]
+
+
+def test_treemap_uses_name_value_shape():
+    spec = charts.build_chart_spec(
+        data=[{"cat": "A", "v": 100}, {"cat": "B", "v": 50}],
+        chart_type="treemap",
+        x_column="cat",
+        y_column="v",
+    )
+    assert spec["data"] == [{"name": "A", "value": 100.0}, {"name": "B", "value": 50.0}]
+
+
+def test_funnel_uses_name_value_shape():
+    spec = charts.build_chart_spec(
+        data=[{"stage": "Visited", "n": 1000}, {"stage": "Signup", "n": 200}],
+        chart_type="funnel",
+        x_column="stage",
+        y_column="n",
+    )
+    assert spec["data"] == [
+        {"name": "Visited", "value": 1000.0},
+        {"name": "Signup", "value": 200.0},
+    ]
+
+
+def test_build_chart_spec_rejects_multi_series_types():
+    with pytest.raises(ValueError, match="multi-series"):
+        charts.build_chart_spec(
+            data=[{"x": "A", "y": 1}],
+            chart_type="stacked_bar",
+            x_column="x",
+            y_column="y",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-series chart spec
+# ---------------------------------------------------------------------------
+
+
+def test_multi_series_stacked_bar_normalizes_x_key():
+    data = [
+        {"category": "A", "Q1": 10, "Q2": 15},
+        {"category": "B", "Q1": 5, "Q2": 8},
+    ]
+    spec = charts.build_multi_series_chart_spec(
+        data=data,
+        chart_type="stacked_bar",
+        x_column="category",
+        series=["Q1", "Q2"],
+        title="Sales by quarter",
+    )
+    assert spec["type"] == "stacked_bar"
+    assert spec["series"] == [{"key": "Q1", "label": "Q1"}, {"key": "Q2", "label": "Q2"}]
+    # x normalized to "x", series keys retained
+    assert spec["data"] == [
+        {"x": "A", "Q1": 10.0, "Q2": 15.0},
+        {"x": "B", "Q1": 5.0, "Q2": 8.0},
+    ]
+
+
+def test_multi_series_fills_missing_series_with_zero():
+    data = [{"category": "A", "Q1": 10}]  # Q2 missing
+    spec = charts.build_multi_series_chart_spec(
+        data=data,
+        chart_type="grouped_bar",
+        x_column="category",
+        series=["Q1", "Q2"],
+    )
+    # Q2 absent in the row → defaulted to 0
+    assert spec["data"][0] == {"x": "A", "Q1": 10.0, "Q2": 0.0}
+
+
+def test_multi_series_rejects_single_series_type():
+    with pytest.raises(ValueError, match="not a multi-series type"):
+        charts.build_multi_series_chart_spec(
+            data=[{"x": "A", "Q1": 1}],
+            chart_type="bar",
+            x_column="x",
+            series=["Q1"],
+        )
+
+
+def test_multi_series_rejects_empty_series():
+    with pytest.raises(ValueError, match="non-empty list"):
+        charts.build_multi_series_chart_spec(
+            data=[{"x": "A"}],
+            chart_type="stacked_bar",
+            x_column="x",
+            series=[],
+        )
+
+
+# ---------------------------------------------------------------------------
+# aggregate_multi_series
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_multi_series_count_pivot():
+    data = [
+        {"category": "A", "year": 2024},
+        {"category": "A", "year": 2024},
+        {"category": "A", "year": 2025},
+        {"category": "B", "year": 2024},
+        {"category": "B", "year": 2025},
+        {"category": "B", "year": 2025},
+    ]
+    rows, series_keys = charts.aggregate_multi_series(
+        data,
+        x_column="category",
+        series_column="year",
+        y_column=None,
+        aggregation="count",
+    )
+    # series totals: 2024=3, 2025=3 → both kept, order tied
+    assert set(series_keys) == {"2024", "2025"}
+    by_cat = {r["category"]: {k: r[k] for k in series_keys} for r in rows}
+    assert by_cat == {"A": {"2024": 2.0, "2025": 1.0}, "B": {"2024": 1.0, "2025": 2.0}}
+
+
+def test_aggregate_multi_series_sum_with_y_column():
+    data = [
+        {"region": "EU", "product": "X", "revenue": 100},
+        {"region": "EU", "product": "Y", "revenue": 200},
+        {"region": "US", "product": "X", "revenue": 50},
+        {"region": "US", "product": "Y", "revenue": 80},
+    ]
+    rows, series_keys = charts.aggregate_multi_series(
+        data,
+        x_column="region",
+        series_column="product",
+        y_column="revenue",
+        aggregation="sum",
+    )
+    # Y total: 280, X total: 150 → series sorted desc
+    assert series_keys == ["Y", "X"]
+    eu = next(r for r in rows if r["region"] == "EU")
+    assert eu["X"] == 100.0
+    assert eu["Y"] == 200.0
+
+
+def test_aggregate_multi_series_caps_with_max_series():
+    data = [
+        {"x": "A", "s": "1"},
+        {"x": "A", "s": "2"},
+        {"x": "A", "s": "3"},
+        {"x": "A", "s": "1"},
+        {"x": "A", "s": "1"},
+    ]
+    rows, series_keys = charts.aggregate_multi_series(
+        data,
+        x_column="x",
+        series_column="s",
+        y_column=None,
+        aggregation="count",
+        max_series=2,
+    )
+    # top-2 series by total: 1 (3 rows), then 2 or 3 (1 each)
+    assert series_keys[0] == "1"
+    assert len(series_keys) == 2
+    assert "3" not in rows[0] or rows[0].get("3", 0) == 0
+
+
+def test_aggregate_multi_series_requires_y_for_non_count():
+    with pytest.raises(ValueError, match="requires y_column"):
+        charts.aggregate_multi_series(
+            [{"x": "A", "s": "1"}],
+            x_column="x",
+            series_column="s",
+            y_column=None,
+            aggregation="sum",
+        )

--- a/frontend/src/components/ChartBlock.jsx
+++ b/frontend/src/components/ChartBlock.jsx
@@ -1,0 +1,283 @@
+import { useMemo } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import {
+  BarChart, Bar,
+  LineChart, Line,
+  AreaChart, Area,
+  PieChart, Pie, Cell,
+  ScatterChart, Scatter,
+  Treemap,
+  FunnelChart, Funnel, LabelList,
+  XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+} from 'recharts'
+
+const XY_TYPES = new Set(['bar', 'line', 'area', 'horizontal_bar', 'scatter'])
+const NAME_VALUE_TYPES = new Set(['pie', 'donut', 'treemap', 'funnel'])
+const MULTI_SERIES_TYPES = new Set(['stacked_bar', 'grouped_bar', 'stacked_area', 'multi_line'])
+const SUPPORTED_TYPES = new Set([...XY_TYPES, ...NAME_VALUE_TYPES, ...MULTI_SERIES_TYPES])
+
+const PALETTE = [
+  '#3b82f6', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6',
+  '#06b6d4', '#ec4899', '#84cc16', '#14b8a6', '#f97316',
+]
+const seriesColor = (i) => PALETTE[i % PALETTE.length]
+
+export const parseSpec = (code) => {
+  let parsed
+  try {
+    parsed = JSON.parse(code)
+  } catch (err) {
+    return { error: `Invalid chart JSON: ${err.message}` }
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return { error: 'Chart spec must be a JSON object' }
+  }
+  if (!SUPPORTED_TYPES.has(parsed.type)) {
+    return { error: `Unsupported chart type: ${parsed.type}` }
+  }
+  if (!Array.isArray(parsed.data) || parsed.data.length === 0) {
+    return { error: 'Chart spec is missing a non-empty "data" array' }
+  }
+  if (MULTI_SERIES_TYPES.has(parsed.type) && (!Array.isArray(parsed.series) || parsed.series.length === 0)) {
+    return { error: `Chart type ${parsed.type} requires a non-empty "series" array` }
+  }
+  return { spec: parsed }
+}
+
+const ChartError = ({ message, code }) => (
+  <div className="my-3 rounded-lg overflow-hidden border border-amber-200">
+    <div className="flex items-center gap-2 px-3 py-1.5 bg-amber-50 border-b border-amber-100 text-xs text-amber-700">
+      <AlertTriangle className="w-3.5 h-3.5" />
+      <span>chart could not be rendered — {message}</span>
+    </div>
+    <pre className="p-3 bg-gray-900 text-gray-100 text-xs overflow-x-auto whitespace-pre font-mono leading-relaxed">
+      {code}
+    </pre>
+  </div>
+)
+
+const ChartFrame = ({ title, height = 320, children }) => (
+  <div className="my-3 rounded-lg overflow-hidden border border-gray-200 bg-white">
+    <div className="flex items-center justify-between px-3 py-1.5 bg-gray-100 border-b border-gray-200">
+      <span className="text-xs font-medium text-gray-600">{title || 'chart'}</span>
+    </div>
+    <div className="p-3" style={{ width: '100%', height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        {children}
+      </ResponsiveContainer>
+    </div>
+  </div>
+)
+
+const xLabelProp = (label) =>
+  label ? { value: label, position: 'insideBottom', offset: -4 } : undefined
+const yLabelProp = (label) =>
+  label ? { value: label, angle: -90, position: 'insideLeft' } : undefined
+
+const renderXY = (spec) => {
+  const { type, data, x_label, y_label } = spec
+  const margin = { top: 10, right: 20, left: 10, bottom: x_label ? 20 : 5 }
+  if (type === 'bar') {
+    return (
+      <BarChart data={data} margin={margin}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="x" tick={{ fontSize: 12 }} label={xLabelProp(x_label)} />
+        <YAxis tick={{ fontSize: 12 }} label={yLabelProp(y_label)} />
+        <Tooltip />
+        <Bar dataKey="y" fill={PALETTE[0]} />
+      </BarChart>
+    )
+  }
+  if (type === 'horizontal_bar') {
+    // Vertical layout: x_label/y_label swap semantically — recharts XAxis is numeric, YAxis is categorical.
+    const longestLabel = data.reduce((m, d) => Math.max(m, String(d.x).length), 0)
+    const yWidth = Math.min(220, 8 + longestLabel * 6.5)
+    return (
+      <BarChart data={data} layout="vertical" margin={{ top: 10, right: 20, left: 10, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis type="number" tick={{ fontSize: 12 }} label={yLabelProp(y_label) && undefined} />
+        <YAxis type="category" dataKey="x" tick={{ fontSize: 12 }} width={yWidth} />
+        <Tooltip />
+        <Bar dataKey="y" fill={PALETTE[0]} />
+      </BarChart>
+    )
+  }
+  if (type === 'line') {
+    return (
+      <LineChart data={data} margin={margin}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="x" tick={{ fontSize: 12 }} label={xLabelProp(x_label)} />
+        <YAxis tick={{ fontSize: 12 }} label={yLabelProp(y_label)} />
+        <Tooltip />
+        <Line type="monotone" dataKey="y" stroke={PALETTE[0]} strokeWidth={2} dot={false} />
+      </LineChart>
+    )
+  }
+  if (type === 'area') {
+    return (
+      <AreaChart data={data} margin={margin}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="x" tick={{ fontSize: 12 }} label={xLabelProp(x_label)} />
+        <YAxis tick={{ fontSize: 12 }} label={yLabelProp(y_label)} />
+        <Tooltip />
+        <Area type="monotone" dataKey="y" stroke={PALETTE[0]} fill={PALETTE[0]} fillOpacity={0.3} />
+      </AreaChart>
+    )
+  }
+  // scatter
+  return (
+    <ScatterChart margin={margin}>
+      <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+      <XAxis dataKey="x" type="number" tick={{ fontSize: 12 }} label={xLabelProp(x_label)} />
+      <YAxis dataKey="y" type="number" tick={{ fontSize: 12 }} label={yLabelProp(y_label)} />
+      <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+      <Scatter data={data} fill={PALETTE[0]} />
+    </ScatterChart>
+  )
+}
+
+const renderNameValue = (spec) => {
+  const { type, data } = spec
+  if (type === 'pie' || type === 'donut') {
+    const innerRadius = type === 'donut' ? 60 : 0
+    return (
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="value"
+          nameKey="name"
+          cx="50%"
+          cy="50%"
+          outerRadius={100}
+          innerRadius={innerRadius}
+          label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+        >
+          {data.map((_, idx) => (
+            <Cell key={idx} fill={seriesColor(idx)} />
+          ))}
+        </Pie>
+        <Tooltip />
+        <Legend />
+      </PieChart>
+    )
+  }
+  if (type === 'treemap') {
+    return (
+      <Treemap
+        data={data}
+        dataKey="value"
+        nameKey="name"
+        stroke="#fff"
+        fill={PALETTE[0]}
+      />
+    )
+  }
+  // funnel
+  return (
+    <FunnelChart>
+      <Tooltip />
+      <Funnel data={data} dataKey="value" nameKey="name" isAnimationActive>
+        <LabelList position="right" dataKey="name" />
+        {data.map((_, idx) => (
+          <Cell key={idx} fill={seriesColor(idx)} />
+        ))}
+      </Funnel>
+    </FunnelChart>
+  )
+}
+
+const renderMultiSeries = (spec) => {
+  const { type, data, series, x_label, y_label } = spec
+  const seriesKeys = series.map((s) => (typeof s === 'string' ? s : s.key))
+  const seriesLabel = (s, i) => (typeof series[i] === 'string' ? s : series[i].label || s)
+  const margin = { top: 10, right: 20, left: 10, bottom: x_label ? 20 : 5 }
+
+  if (type === 'stacked_bar' || type === 'grouped_bar') {
+    const stackProps = type === 'stacked_bar' ? { stackId: 'a' } : {}
+    return (
+      <BarChart data={data} margin={margin}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="x" tick={{ fontSize: 12 }} label={xLabelProp(x_label)} />
+        <YAxis tick={{ fontSize: 12 }} label={yLabelProp(y_label)} />
+        <Tooltip />
+        <Legend />
+        {seriesKeys.map((key, i) => (
+          <Bar key={key} dataKey={key} name={seriesLabel(key, i)} fill={seriesColor(i)} {...stackProps} />
+        ))}
+      </BarChart>
+    )
+  }
+  if (type === 'stacked_area') {
+    return (
+      <AreaChart data={data} margin={margin}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="x" tick={{ fontSize: 12 }} label={xLabelProp(x_label)} />
+        <YAxis tick={{ fontSize: 12 }} label={yLabelProp(y_label)} />
+        <Tooltip />
+        <Legend />
+        {seriesKeys.map((key, i) => (
+          <Area
+            key={key}
+            type="monotone"
+            dataKey={key}
+            name={seriesLabel(key, i)}
+            stackId="a"
+            stroke={seriesColor(i)}
+            fill={seriesColor(i)}
+            fillOpacity={0.6}
+          />
+        ))}
+      </AreaChart>
+    )
+  }
+  // multi_line
+  return (
+    <LineChart data={data} margin={margin}>
+      <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+      <XAxis dataKey="x" tick={{ fontSize: 12 }} label={xLabelProp(x_label)} />
+      <YAxis tick={{ fontSize: 12 }} label={yLabelProp(y_label)} />
+      <Tooltip />
+      <Legend />
+      {seriesKeys.map((key, i) => (
+        <Line
+          key={key}
+          type="monotone"
+          dataKey={key}
+          name={seriesLabel(key, i)}
+          stroke={seriesColor(i)}
+          strokeWidth={2}
+          dot={false}
+        />
+      ))}
+    </LineChart>
+  )
+}
+
+const renderChart = (spec) => {
+  if (XY_TYPES.has(spec.type)) return renderXY(spec)
+  if (NAME_VALUE_TYPES.has(spec.type)) return renderNameValue(spec)
+  return renderMultiSeries(spec)
+}
+
+const frameHeight = (type, dataLen) => {
+  if (type === 'horizontal_bar') return Math.min(700, Math.max(220, 28 * dataLen + 60))
+  if (type === 'treemap' || type === 'funnel') return 360
+  return 320
+}
+
+const ChartBlock = ({ code }) => {
+  const parsed = useMemo(() => parseSpec(code), [code])
+
+  if (parsed.error) {
+    return <ChartError message={parsed.error} code={code} />
+  }
+
+  const { spec } = parsed
+  return (
+    <ChartFrame title={spec.title} height={frameHeight(spec.type, spec.data.length)}>
+      {renderChart(spec)}
+    </ChartFrame>
+  )
+}
+
+export default ChartBlock

--- a/frontend/src/components/ChartBlock.test.jsx
+++ b/frontend/src/components/ChartBlock.test.jsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { render } from '@testing-library/react'
+import ChartBlock, { parseSpec } from './ChartBlock'
+
+// recharts ResponsiveContainer depends on ResizeObserver, which jsdom does not
+// provide. A no-op shim is enough for the smoke checks we do below — we don't
+// need to assert on the SVG contents, only that the chart frame renders.
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  }
+})
+
+describe('parseSpec', () => {
+  it('parses a valid bar chart spec', () => {
+    const code = JSON.stringify({
+      type: 'bar',
+      title: 'Sales',
+      data: [{ x: 'A', y: 10 }, { x: 'B', y: 20 }],
+    })
+    const result = parseSpec(code)
+    expect(result.error).toBeUndefined()
+    expect(result.spec.type).toBe('bar')
+    expect(result.spec.data).toHaveLength(2)
+  })
+
+  it('returns an error for malformed JSON', () => {
+    const result = parseSpec('not json')
+    expect(result.error).toMatch(/Invalid chart JSON/)
+  })
+
+  it('returns an error for unsupported chart type', () => {
+    const code = JSON.stringify({ type: 'histogram', data: [{ x: 1, y: 1 }] })
+    const result = parseSpec(code)
+    expect(result.error).toMatch(/Unsupported chart type: histogram/)
+  })
+
+  it('returns an error when data is missing', () => {
+    const code = JSON.stringify({ type: 'bar', title: 'oops' })
+    const result = parseSpec(code)
+    expect(result.error).toMatch(/non-empty "data" array/)
+  })
+
+  it('returns an error when data is empty', () => {
+    const code = JSON.stringify({ type: 'bar', data: [] })
+    const result = parseSpec(code)
+    expect(result.error).toMatch(/non-empty "data" array/)
+  })
+
+  it('accepts every single-series chart type', () => {
+    const types = ['bar', 'line', 'area', 'horizontal_bar', 'scatter', 'pie', 'donut', 'treemap', 'funnel']
+    for (const type of types) {
+      const code = JSON.stringify({ type, data: [{ x: 1, y: 2, name: 'x', value: 2 }] })
+      const result = parseSpec(code)
+      expect(result.error, `type=${type}`).toBeUndefined()
+    }
+  })
+
+  it('requires non-empty series for multi-series chart types', () => {
+    const code = JSON.stringify({
+      type: 'stacked_bar',
+      data: [{ x: 'A', Q1: 1, Q2: 2 }],
+    })
+    const result = parseSpec(code)
+    expect(result.error).toMatch(/requires a non-empty "series" array/)
+  })
+
+  it('accepts multi-series chart types with valid series', () => {
+    const types = ['stacked_bar', 'grouped_bar', 'stacked_area', 'multi_line']
+    for (const type of types) {
+      const code = JSON.stringify({
+        type,
+        series: [{ key: 'Q1', label: 'Q1' }, { key: 'Q2', label: 'Q2' }],
+        data: [{ x: 'A', Q1: 1, Q2: 2 }],
+      })
+      const result = parseSpec(code)
+      expect(result.error, `type=${type}`).toBeUndefined()
+    }
+  })
+})
+
+describe('ChartBlock', () => {
+  it('renders the error UI for malformed JSON without crashing', () => {
+    const { getByText, container } = render(<ChartBlock code="not json" />)
+    expect(getByText(/chart could not be rendered/i)).toBeTruthy()
+    // The raw code should be shown so the user/agent can debug
+    expect(container.textContent).toContain('not json')
+  })
+
+  it('renders the error UI for unsupported chart type', () => {
+    const code = JSON.stringify({ type: 'mystery', data: [{ x: 1, y: 1 }] })
+    const { getByText } = render(<ChartBlock code={code} />)
+    expect(getByText(/Unsupported chart type: mystery/i)).toBeTruthy()
+  })
+
+  it('renders the chart frame with title for a valid spec', () => {
+    const code = JSON.stringify({
+      type: 'bar',
+      title: 'Quarterly revenue',
+      data: [{ x: 'Q1', y: 100 }, { x: 'Q2', y: 150 }],
+    })
+    const { getByText } = render(<ChartBlock code={code} />)
+    expect(getByText('Quarterly revenue')).toBeTruthy()
+  })
+
+  it('falls back to a default label when title is empty', () => {
+    const code = JSON.stringify({
+      type: 'line',
+      data: [{ x: 1, y: 1 }, { x: 2, y: 4 }],
+    })
+    const { getByText } = render(<ChartBlock code={code} />)
+    expect(getByText('chart')).toBeTruthy()
+  })
+
+  it('renders horizontal_bar without crashing', () => {
+    const code = JSON.stringify({
+      type: 'horizontal_bar',
+      title: 'Top categories',
+      data: [{ x: 'Very long Dutch category name', y: 9230 }, { x: 'Short', y: 100 }],
+    })
+    const { getByText } = render(<ChartBlock code={code} />)
+    expect(getByText('Top categories')).toBeTruthy()
+  })
+
+  it('renders treemap without crashing', () => {
+    const code = JSON.stringify({
+      type: 'treemap',
+      title: 'Distribution',
+      data: [{ name: 'A', value: 100 }, { name: 'B', value: 50 }],
+    })
+    const { getByText } = render(<ChartBlock code={code} />)
+    expect(getByText('Distribution')).toBeTruthy()
+  })
+
+  it('renders stacked_bar with multiple series', () => {
+    const code = JSON.stringify({
+      type: 'stacked_bar',
+      title: 'Sales by quarter',
+      series: [
+        { key: 'Q1', label: 'Q1' },
+        { key: 'Q2', label: 'Q2' },
+      ],
+      data: [
+        { x: 'A', Q1: 10, Q2: 15 },
+        { x: 'B', Q1: 5, Q2: 8 },
+      ],
+    })
+    const { getByText } = render(<ChartBlock code={code} />)
+    expect(getByText('Sales by quarter')).toBeTruthy()
+  })
+
+  it('renders multi_line', () => {
+    const code = JSON.stringify({
+      type: 'multi_line',
+      title: 'Trend',
+      series: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }],
+      data: [
+        { x: 1, a: 5, b: 8 },
+        { x: 2, a: 6, b: 7 },
+      ],
+    })
+    const { getByText } = render(<ChartBlock code={code} />)
+    expect(getByText('Trend')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/chat/ChatHelpers.jsx
+++ b/frontend/src/components/chat/ChatHelpers.jsx
@@ -7,6 +7,7 @@ import { Copy, Check } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import CodeBlock from '../CodeBlock'
+import ChartBlock from '../ChartBlock'
 import MermaidBlock from '../MermaidBlock'
 import { getAgentConfig } from '../../utils/agentConfig'
 
@@ -95,6 +96,9 @@ export const chatMarkdownComponents = {
     const codeString = String(children).replace(/\n$/, '')
     if (match?.[1] === 'mermaid') {
       return <MermaidBlock code={codeString} />
+    }
+    if (match?.[1] === 'chart') {
+      return <ChartBlock code={codeString} />
     }
     if (match || codeString.includes('\n')) {
       return (


### PR DESCRIPTION
## Summary

Adds inline chart visualizations to the chat, driven by the `dataaccess` MCP. The LLM decides *what* to plot (chart type, columns, aggregation); the data is aggregated server-side and **never enters the model context** — only a small chart spec is returned and rendered inline.

- **Two MCP tools** in `module-data-access`:
  - `create_chart` — chart inline values the user typed in chat.
  - `create_chart_from_source` — read + aggregate a configured source server-side. SQL sources push `GROUP BY` into the database; Data Lake files are read in full server-side. Aggregation covers the **entire dataset** (reports `full_dataset` / `rows_scanned`).
- **13 chart types** across three families: XY (bar/line/area/horizontal_bar/scatter), proportion (pie/donut/treemap/funnel), multi-series (stacked_bar/grouped_bar/stacked_area/multi_line via `series_column`).
- **Frontend** `ChartBlock.jsx` renders a ` ```chart ` code block via `recharts`, wired into the chat markdown pipeline alongside the existing `MermaidBlock` (mermaid) handler.
- **`data_analyst` agent** gains the dataaccess + chart tools, a chart-selection decision matrix, an inline-chart fast path, and guidance to aggregate full datasets (not read rows first).
- Registered `create_chart` / `create_chart_from_source` / `execute_query` in `mcp_config.yaml`.
- Merged latest `colab-dev` (dataset-selection strategy + adapter streaming fixes); `data_analyst.yaml` conflict resolved by unioning tool lists and folding chart tools into the merged dataaccess level.

### Why `create_chart_from_source` aggregates the full dataset
An earlier iteration aggregated over a row-capped read (`read_limit=5000`), which silently skewed charts of large tables (a 279k-row source charted from its first 5000 rows ranked the wrong category first). The fix pushes aggregation into SQL / reads the whole Data Lake file server-side, so counts and sums are exact while raw rows still stay out of the LLM context.

## Notable design points
- Raw data never enters the LLM context and nothing is written to the workspace — only the spec, stored in the chat `messages` row (so charts re-render on reload).
- Server-side identifier escaping in the SQL GROUP BY builder; read-only validation reused from `execute_query`.

## Docs
- `docs/MCP/data-access.md` — tools + Visualization section
- `docs/FEATURES.md`, `docs/TECHNICAL.md` (new Data Access server section), `docs/BACKLOG.md` (follow-up improvements)

## Test plan
- [x] Backend: `cd druppie && pytest tests/test_dataaccess_charts.py` — 42 tests pass (spec builders, single + multi-series aggregation, SQL query builder)
- [x] Frontend: `cd frontend && npm test` — 16 ChartBlock tests pass (all chart types, malformed-spec error UI)
- [x] E2E smoke: data_analyst renders bar/horizontal_bar/donut/stacked charts inline; verified full-dataset aggregation on the 279k-row HHR fact table (SQL pushdown + Data Lake full read)
- [ ] Reviewer to verify against their own configured sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)