### PR TITLE
feat: Kubernetes migration with Helm chart

### DIFF
--- a/docs/ADR-KUBERNETES.md
+++ b/docs/ADR-KUBERNETES.md
@@ -1,0 +1,774 @@
+# ADR-001: Kubernetes Migratie Architectuur
+
+| Veld | Waarde |
+|------|--------|
+| **Status** | Geaccepteerd |
+| **Datum** | 2026-06-09 |
+| **Auteur** | Druppie Team |
+| **Deciders** | Druppie architectuurteam |
+| **Referentie** | [KUBERNETES-STRATEGY.md](./KUBERNETES-STRATEGY.md) |
+
+---
+
+## Beslissingsoverzicht
+
+| # | Beslissing | Keuze | Reden |
+|---|-----------|-------|-------|
+| 4.1 | Hosting | **Hetzner VMs + Ubuntu** | Commodity cloud, geen vendor lock-in, ~€86/mo basis (3 servers + infra + app pool) |
+| 4.2 | Platform | **K3s (3 servers + 2 agent pools)** | CNCF certified, 3 servers voor etcd quorum, vaste infra pool + autoscaled app pool |
+| 4.3 | Database | **CloudNativePG** | CNCF Sandbox, auto-failover <30s, ingebouwde PgBouncer, 1 operator voor 3 instances |
+| 4.4 | Autoscaling | **HPA + KEDA** | HPA voor frontend (CPU), KEDA voor backend (LLM I/O-bound, CPU alleen is te traag) |
+| 4.5 | Networking | **Traefik + cert-manager** | K3s standaard, Middleware CRDs, Let's Encrypt via cert-manager |
+| 4.6 | Secrets | **Sealed Secrets** | Asymmetrisch versleuteld in git, lage complexiteit, geen extra infra |
+| 4.7 | Monitoring | **kube-prometheus-stack** | De-facto standaard, Prometheus + Grafana + Alertmanager in 1 Helm chart |
+| 4.8 | Registry | **Gitea Container Registry** | Al aanwezig in Druppie, OCI-compatible, nul extra infra |
+| 4.9 | Deployment | **PR-based CI/CD op colab-dev** | GitHub Actions: PR merge naar `colab-dev` triggert build → push → deploy |
+| 4.10 | MCP Modules | **Shared volume, vaste replicas** | Worden herbouwd als built-in backend tools, shared volume is tijdelijk en voldoende |
+| 4.11 | High Availability | **PDB + anti-affinity + graceful shutdown** | Backend en frontend beschikbaar houden bij node failures en rolling updates |
+| 4.12 | Cluster Provisioning | **hetzner-k3s CLI** | Ubuntu, 1 YAML config, 2-3 min cluster, alles ingebouwd (CCM, CSI, autoscaler) |
+| 4.13 | Node Autoscaling | **Kubernetes Cluster Autoscaler (Hetzner provider)** | Upstream K8s, auto-provisioneert VMs bij Pending pods, ~60s nieuwe node |
+
+---
+
+## Context
+
+Druppie draait op Docker Compose: een FastAPI backend, React frontend, 9 MCP microservices, Keycloak, Gitea, 3 PostgreSQL databases, en een sandbox-infrastructuur. De backend draait op 1 hardcoded replica. Er is geen autoscaling, geen database HA, en geen production-ready monitoring.
+
+De migratie naar Kubernetes lost drie problemen op:
+
+1. **Schaalbaarheid**: Backend en frontend moeten horizontaal schaalbaar zijn voor wisselende belasting
+2. **Betrouwbaarheid**: Single points of failure elimineren (database failover, PDB, anti-affinity)
+3. **Onderhoudbaarheid**: Gecentraliseerde monitoring, declaratieve configuratie, reproduceerbare deployments
+
+Uitgangspunten: 100% open source, geen vendor lock-in, portable Helm chart.
+
+Het spike-onderzoek ([KUBERNETES-STRATEGY.md](./KUBERNETES-STRATEGY.md)) bevat de volledige vergelijkingsmatrixen en technische onderbouwing voor alle keuzes hieronder.
+
+---
+
+## Beslissingen
+
+### 4.1 Hosting: Hetzner VMs + Ubuntu
+
+**Gekozen:** 3x Hetzner Cloud VM (CPX31: 4 vCPU, 8GB RAM, 160GB NVMe) met Ubuntu als OS.
+
+**Waarom:** Cloud VMs zijn commodity. K3s draait op elke Linux machine. Verhuizen naar een andere provider (OVH, Scaleway, on-prem) betekent nieuwe VMs provisionen + K3s installeren + `helm install`. Geen cloud-specifieke API's, geen proprietary services, geen lock-in.
+
+Ubuntu is de meest geteste OS voor K3s, heeft brede documentatie, en langdurige support releases (LTS).
+
+**Afgewezen:**
+- Bare metal: hoge CAPEX, fysiek begrensd, niet snel schaalbaar
+- Managed Kubernetes (EKS, AKS, GKE): vendor lock-in, proprietary API's
+- On-premises: geen data-residency eis die dit rechtvaardigt
+
+### 4.2 Platform: K3s (3-server HA + twee agent pools)
+
+**Gekozen:** K3s met een vast cluster van 3 server nodes (embedded etcd HA) plus twee agent pools: een vaste "infra" pool en een autoscaled "app" pool.
+
+**Waarom:** K3s is CNCF-gecertificeerd (volledige Kubernetes API, identieke conformance tests). Eén binary van 70MB met alles erin: API server, scheduler, controller manager, etcd, containerd, Flannel CNI, CoreDNS, Traefik ingress, local-path storage.
+
+**Node architectuur:**
+
+| Rol | Aantal | Type | Functie | Scaling |
+|-----|--------|------|---------|---------|
+| **K3s Server** | **3 (vast)** | CPX31 (4 vCPU, 8GB) | Control plane: API server, scheduler, etcd | Niet autoscalable. 3 = minimum voor etcd quorum (1 mag falen) |
+| **K3s Agent — infra pool** | **1-2 (vast)** | CPX31 (4 vCPU, 8GB) | Keycloak, Gitea, MCP modules, CNPG, monitoring | Niet autoscalable. Stabiele workloads die niet geëvinceerd mogen worden |
+| **K3s Agent — app pool** | **1-10 (autoscaling)** | CPX31 (4 vCPU, 8GB) | Backend, Frontend | Cluster Autoscaler voegt toe/verwijdert op basis van Pending pods |
+
+**Waarom 3 servers:** Etcd vereist een quorum (meerderheid) voor consistency. Met 3 nodes is het quorum 2 — 1 server mag falen zonder dat het cluster uitvalt. 1 server = geen HA (single point of failure). 5 servers = 2 mogen falen, maar overkill voor Druppie's schaal.
+
+**Waarom twee agent pools:** Backend en frontend hebben wisselende load en moeten schalen. Keycloak, Gitea, MCP modules en CNPG hebben constante, voorspelbare load en mogen niet verstoord worden door de Cluster Autoscaler. Het scheiden in twee pools voorkomt dat infra services geëvinceerd worden wanneer de autoscaler nodes verwijdert. Dit houdt de setup het dichtst bij de Docker Compose / Kind architectuur waar alles "gewoon draait".
+
+**Waarom masters geen workloads draaien:** `schedule_workloads_on_masters: false` in hetzner-k3s. De control plane moet geïsoleerd blijven — als workloads alle resources verbruiken, reageert de API server niet meer.
+
+```
+┌─ 3x K3s Server (vast) ───────────────────────────────┐
+│  etcd quorum + API server + scheduler                 │
+│  Geen workloads (NoSchedule taint)                    │
+└───────────────────────────────────────────────────────┘
+
+┌─ 1-2x Agent: infra pool (vast) ──────────────────────┐
+│  Keycloak (1 pod)    Gitea (1 pod + registry)         │
+│  MCP modules (9 pods, shared volume)                  │
+│  CloudNativePG (3 DB clusters, 9 pods)                │
+│  Monitoring (Prometheus, Grafana, Alertmanager)        │
+│  Sealed Secrets, cert-manager, KEDA, Cluster Autoscl. │
+│  → Vaste nodes, nooit geëvinceerd                     │
+└───────────────────────────────────────────────────────┘
+
+┌─ 1-10x Agent: app pool (autoscaling) ────────────────┐
+│  Backend (2-10 pods, HPA + KEDA)                      │
+│  Frontend (2-8 pods, HPA)                             │
+│  → Cluster Autoscaler beheert dit pool                │
+└───────────────────────────────────────────────────────┘
+```
+
+**Afgewezen:**
+- RKE2: meer resources, complexer, pas nuttig bij multi-cluster management
+- OpenShift/OKD: ~8GB+ RAM footprint, afwijkende standaarden (Routes, SCC), Dockerfile aanpassingen nodig
+- Vanilla kubeadm: veel handmatig werk, geen ingebouwde tooling
+- Kind: alleen voor development/CI, geen persistent storage, geen HA
+
+**Development/CI:** Kind blijft in gebruik voor lokale development en CI pipelines.
+
+### 4.3 Database: CloudNativePG
+
+**Gekozen:** CloudNativePG operator (v1.29.1+) met 3 database clusters: `druppie-db`, `keycloak-db`, `gitea-db`. Elke cluster draait 3 instances (1 primary + 2 read replicas).
+
+**Waarom:** CloudNativePG is de enige PostgreSQL operator met CNCF Sandbox status. Het beheert de volledige lifecycle: provisioning, streaming replicatie, automatische failover (<30s), continuous backup naar S3/MinIO, point-in-time recovery, zero-downtime rolling updates, en ingebouwde PgBouncer connection pooling.
+
+Eén operator beheert alle drie de databases als aparte `Cluster` CRDs. Geen extra infrastructuur.
+
+**Belangrijk:** Altijd v1.29.1+ gebruiken. Deze release fixt CVE-2026-44477 (CVSS 9.4, Critical) en drie HA failover bugs.
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: druppie-db
+spec:
+  instances: 3
+  postgresql:
+    parameters:
+      shared_buffers: "256MB"
+      max_connections: "200"
+  storage:
+    size: 20Gi
+    storageClass: local-path
+  backup:
+    barmanObjectStore:
+      destinationPath: "s3://druppie-backups/db"
+      endpointURL: "http://minio:9000"
+      s3Credentials:
+        accessKeyId:
+          name: minio-creds
+          key: access-key
+        secretAccessKey:
+          name: minio-creds
+          key: secret-key
+    retentionPolicy: "30d"
+  monitoring:
+    enablePodMonitor: true
+```
+
+**Afgewezen:**
+- CrunchyData PGO: 19 CRDs (vs 6 voor CNPG), complexere configuratie, geen CNCF status
+- Zalando PG Operator: minder actief onderhouden, geen ingebouwde backup
+- Managed database (cloud): vendor lock-in
+- Container PostgreSQL: geen HA, geen failover, geen backup (alleen dev)
+
+### 4.4 Autoscaling: HPA + KEDA
+
+**Gekozen:** HPA (CPU-based) voor frontend en backend, plus KEDA (Prometheus metric) voor de backend.
+
+**Waarom HPA voor beide services:** Frontend is pure static file serving, CPU is een betrouwbare metric. Backend krijgt HPA als basislaag.
+
+**Waarom KEDA extra voor de backend:** LLM calls zijn I/O-bound (wachten op externe API responses), niet CPU-bound. CPU-utilisatie blijft laag terwijl de wachtrij volloopt. KEDA schaalt op `druppie_pending_agent_runs` (een Prometheus metric gebaseerd op een database query), wat de daadwerkelijke workload reflecteert in plaats van CPU-gebruik.
+
+| Service | Min replicas | Max replicas | Scaling trigger |
+|---------|-------------|-------------|-----------------|
+| Frontend | 2 | 8 | HPA op CPU (70%) |
+| Backend | 2 | 10 | HPA op CPU (70%) + KEDA op queue depth (>5 pending) |
+
+**HPA configuratie (backend):**
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: druppie-backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: druppie-backend
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+```
+
+**KEDA configuratie (backend):**
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: druppie-backend-keda
+spec:
+  scaleTargetRef:
+    name: druppie-backend
+  minReplicaCount: 2
+  maxReplicaCount: 10
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus:9090
+        metricName: druppie_pending_agent_runs
+        query: sum(druppie_pending_agent_runs)
+        threshold: "5"
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Percent
+              value: 50
+              periodSeconds: 60
+```
+
+De `behavior` sectie voorkomt oscillatie: bij AI workloads ontstaan korte spikes, en zonder stabilization window schalen pods constant op en af.
+
+**Afgewezen:**
+- Alleen HPA op CPU: te traag voor I/O-bound LLM workloads
+- VPA in auto-mode: herstart pods, onacceptabel voor langlopende sessies (alleen recommendation mode)
+- Scale-to-zero: niet gewenst bij een governance platform dat altijd beschikbaar moet zijn
+
+### 4.5 Networking: Traefik + cert-manager
+
+**Gekozen:** Traefik (K3s standaard ingress controller) + cert-manager voor TLS.
+
+**Waarom:** K3s installeert Traefik automatisch. Geen extra configuratie nodig. Traefik biedt Middleware CRDs voor rate limiting en headers (schoner dan NGINX annotations), een dashboard voor real-time traffic monitoring, en IngressRoute CRDs voor complexe routing.
+
+cert-manager + Let's Encrypt verzorgt automatische TLS certificaten. Geen handmatig certificaatbeheer.
+
+**Afgewezen:**
+- NGINX Ingress: geen toegevoegde waarde boven Traefik, annotations worden rommelig bij complexe configuratie
+- Cilium Ingress: te zwaar voor huidige behoeften, hogere leercurve
+- HAProxy: overkill voor deze schaal
+
+### 4.6 Secrets: Sealed Secrets
+
+**Gekozen:** Sealed Secrets (Bitnami, v0.27+) voor alle gevoelige configuratie (API keys, DB wachtwoorden, HMAC secrets).
+
+**Waarom:** Sealed Secrets versleutelt Kubernetes Secrets asymmetrisch. De versleutelde `SealedSecret` resources gaan veilig in git. De controller in het cluster ontsleutelt ze naar gewone Kubernetes Secrets. Lage complexiteit, geen extra infrastructuur (alleen de controller in het cluster).
+
+**Kritiek:** Backup van de Sealed Secrets controller private key is verplicht. Zonder deze key zijn alle sealed secrets ontoegankelijk na een cluster rebuild.
+
+```bash
+# Secret versleutelen
+kubectl create secret generic druppie-secrets \
+  --from-literal=zai-api-key=sk-xxx \
+  --from-literal=db-password=xxx \
+  --dry-run=client -o yaml | kubeseal > sealed-secrets.yaml
+```
+
+**Afgewezen:**
+- External Secrets Operator: vereist externe secret store, meer complexiteit
+- HashiCorp Vault: BSL 1.1 licentie (niet open source), zware infrastructuur (3+ nodes)
+- SOPS + age: geen automatische sync, handmatige deploy cyclus
+- Plaintext Helm values: niet veilig voor productie
+
+### 4.7 Monitoring: kube-prometheus-stack
+
+**Gekozen:** kube-prometheus-stack (Prometheus + Grafana + Alertmanager).
+
+**Waarom:** De de-facto standaard voor Kubernetes monitoring. Eén `helm install` levert: Prometheus (metrics), Grafana (dashboards), Alertmanager (notificaties), Node-exporter (host metrics), en kube-state-metrics (K8s object metrics).
+
+CloudNativePG exporteert automatisch PostgreSQL metrics via PodMonitor. KEDA, Traefik, en Keycloak hebben native Prometheus endpoints. Alles centraliseert in Grafana.
+
+**Afgewezen:**
+- Victoria Metrics: efficiënter, maar een extra abstraction layer die we niet nodig hebben
+- Managed monitoring (cloud): vendor lock-in
+- Zelfbouw Prometheus stack: teveel configuratiewerk
+
+### 4.8 Container Registry: Gitea Built-in Registry
+
+**Gekozen:** Gitea Container Registry (al aanwezig in Druppie).
+
+**Waarom:** Gitea heeft een ingebouwde OCI-compatible container registry. Nul extra infrastructuur. Images pushen naar dezelfde Gitea instance die al git repos host. Harbor toevoegen als er behoefte komt aan vulnerability scanning of image signing.
+
+**Afgewezen:**
+- Harbor: nuttige features (Trivy scanning, Cosign signing) maar extra infra en operationeel overhead die we nu niet nodig hebben
+- Docker Distribution: te basic, geen UI
+- GitHub GHCR: niet self-hosted
+- Zot: onvoldoende community adoptie
+
+### 4.9 Deployment: PR-based CI/CD op `colab-dev`
+
+**Gekozen:** PR-based CI/CD met GitHub Actions. De default branch is `colab-dev` (niet `main`). Pipeline triggert op merge naar `colab-dev` (of een configureerbare branch via workflow variable).
+
+**Waarom:** Druppie's core code host op GitHub. PR-based deploy betekent: elke change gaat via PR review → CI build → automatic deploy na merge. Dit geeft code review als quality gate en een audit trail van elke productie-release.
+
+**Pipeline flow:**
+
+```
+PR open → CI: lint + test + build (preview)
+PR merge naar colab-dev → CI: build images → push naar Gitea registry → helm upgrade op K3s
+```
+
+```yaml
+# .github/workflows/deploy.yml
+on:
+  push:
+    branches: [colab-dev]   # Configureerbaar: ook andere branches mogelijk
+  pull_request:
+    branches: [colab-dev]   # Preview builds op PRs
+
+jobs:
+  deploy:
+    if: github.event_name == 'push'  # Alleen deployen op merge
+    steps:
+      - name: Build & push images
+        run: |
+          docker build -t $REGISTRY/druppie-backend:$SHA ./druppie
+          docker push $REGISTRY/druppie-backend:$SHA
+      - name: Deploy to K3s
+        run: |
+          helm upgrade druppie helm/druppie/ \
+            --namespace druppie \
+            --values helm/druppie/values-prod.yaml \
+            --set global.imageRegistry=$REGISTRY/ \
+            --set global.imageTag=$SHA \
+            --wait --timeout 600s
+```
+
+**Branch:** `colab-dev` is de default branch. Deploy target is configureerbaar via de workflow `branches` config. `main` is deprecated en wordt verwijderd.
+
+**Afgewezen:**
+- ArgoCD: GitOps met drift detection, maar complexer en vereist een extra server in het cluster. Wordt toegevoegd in Phase 2 als er meerdere omgevingen zijn en drift detection nodig wordt.
+- FluxCD: vergelijkbaar met ArgoCD maar zonder web dashboard
+- Handmatige `helm upgrade`: geen audit trail, geen quality gate
+
+### 4.10 MCP Modules: Shared Volume, Geen Scaling
+
+**Gekozen:** MCP modules draaien met vaste replicas (1-2 per module) en delen een PVC via de K3s local-path provisioner. Geen onafhankelijke scaling, geen RWX storage driver.
+
+**Waarom deze keuze gerechtvaardigd is:** MCP modules worden in een latere fase herbouwd als built-in backend tools. Ze verdwijnen als losse services en worden onderdeel van de backend applicatie zelf. Dat elimineert de shared volume noodzaak volledig. De investering in onafhankelijke module scaling (Longhorn RWX, per-module HPA, service mesh) is weggegooid geld omdat de architectuur fundamenteel verandert.
+
+Tot die tijd voldoet een simpele shared PVC. De modules hebben lage en voorspelbare belasting. Ze schalen mee met het cluster (meer nodes = meer beschikbaarheid), niet onafhankelijk.
+
+**Afgewezen:**
+- Longhorn RWX volumes: alleen nuttig als modules onafhankelijk schalen, wat niet gaat gebeuren
+- Sidecar pattern: elke backend replica draait alle modules, te veel resource overhead
+- Per-session microservices: te complex voor een tijdelijke oplossing
+
+### 4.11 High Availability: PDB + Anti-affinity + Graceful Shutdown
+
+**Gekozen:** PodDisruptionBudgets, pod anti-affinity, en graceful shutdown voor backend en frontend (app pool). Keycloak, Gitea, MCP modules en CNPG draaien op de vaste infra pool en hoeven geen eigen PDB — de infra nodes worden niet geëvinceerd.
+
+**PDB** garandeert dat Kubernetes nooit alle pods tegelijk weghaalt tijdens onderhoud:
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: druppie-backend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: druppie-backend
+```
+
+**Anti-affinity** spreidt pods over verschillende nodes, zodat één node failure niet alle replicas raakt:
+
+```yaml
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: druppie-backend
+          topologyKey: kubernetes.io/hostname
+```
+
+**Graceful shutdown:** Backend pods moeten lopende LLM calls afronden voor ze stoppen. `terminationGracePeriodSeconds: 60` met SIGTERM handling in FastAPI die nieuwe requests weigert maar actieve afrondt.
+
+**Backend multi-replica:** De huidige `reconstruct_from_db()` functie rebuildt al agent state vanuit de database. Bij multi-replica werkt de webhook handler als volgt: update het ToolCall record in de DB, waarna elke backend replica de agent kan oppakken en doorgaan. Database-driven resume, geen nieuwe infrastructuur nodig.
+
+### 4.12 Cluster Provisioning: hetzner-k3s
+
+**Gekozen:** `hetzner-k3s` CLI tool (vitobotta/hetzner-k3s, MIT licentie, 3.5k+ GitHub stars).
+
+**Waarom:** Eén YAML configuratie file definieert het hele cluster: 3 master nodes (embedded etcd HA), worker pools met autoscaling, networking, firewall. De tool installeert automatisch: K3s, Hetzner CCM, CSI driver, System Upgrade Controller, en Cluster Autoscaler. Cluster klaar in 2-3 minuten. Ubuntu als OS (default).
+
+**K3s architectuur — Servers vs Agents:**
+
+K3s kent twee nodetypes. **Servers** draaien de control plane (API server, scheduler, controller manager) plus embedded etcd voor cluster state. **Agents** draaien alleen de kubelet en voeren pods uit — geen control plane, geen etcd. Voor HA draaien 3 servers met embedded etcd (1 mag falen, quorum blijft intact). Alle workloads draaien op agents; servers zijn puur control plane (`schedule_workloads_on_masters: false`). De Cluster Autoscaler beheert uitsluitend agent nodes — servers zijn vast.
+
+```yaml
+# cluster.yaml — complete cluster definitie
+hetzner_token: <token>
+cluster_name: druppie
+k3s_version: v1.32.3+k3s1
+
+schedule_workloads_on_masters: false   # Masters = puur control plane
+
+masters_pool:                          # K3s SERVERS — control plane + etcd
+  instance_type: cpx31                 # 3 servers = HA (etcd quorum)
+  instance_count: 3                    # Vast, niet autoscalable
+  location: fsn1
+
+worker_node_pools:
+- name: infra                          # INFRA POOL — vast
+  instance_type: cpx31
+  instance_count: 1                    # 1-2 vaste nodes
+  location: fsn1
+  autoscaling:
+    enabled: false                     # Niet autoscalable
+  labels:
+    pool: infra                        # Keycloak, Gitea, MCP, CNPG, monitoring
+  taints: []                           # Geen taint — schedulable voor infra workloads
+
+- name: app                            # APP POOL — autoscaling
+  instance_type: cpx31
+  instance_count: 1                    # Min 1, max 10
+  location: fsn1
+  autoscaling:
+    enabled: true
+    min_instances: 1
+    max_instances: 10                  # Cluster Autoscaler beheert
+  labels:
+    pool: app                          # Backend, Frontend
+  taints: []                           # Geen taint — schedulable voor app workloads
+```
+
+**Afgewezen:**
+- kube-hetzner (Terraform): MicroOS i.p.v. Ubuntu, Terraform leercurve, meer complexiteit
+- Custom Terraform: meer werk, zelf alles configureren
+- Handmatige setup: niet reproduceerbaar, geen IaC
+
+### 4.13 Node Autoscaling: Cluster Autoscaler (Hetzner)
+
+**Gekozen:** Officiële Kubernetes Cluster Autoscaler met ingebouwde Hetzner Cloud provider (`--cloud-provider=hetzner`).
+
+**Waarom:** HPA/KEDA schalen pods, maar als alle nodes vol zitten, blijven pods Pending. De Cluster Autoscaler detecteert Pending pods, provisioneert automatisch nieuwe Hetzner VMs via de Cloud API, en laat ze joinen via cloud-init. Bij onderbelasting worden nodes automatisch verwijderd.
+
+**Twee-tier autoscaling architectuur:**
+
+| Tier | Wat | Tool | Trigger | Snelheid |
+|------|-----|------|---------|----------|
+| **1. Pod scaling** | Pods toevoegen/verwijderen | HPA + KEDA | CPU usage, queue depth | Seconden |
+| **2. Node scaling** | VMs toevoegen/verwijderen | Cluster Autoscaler | Pending pods (geen capaciteit) | ~60 seconden |
+
+Flow:
+```
+Load spike
+  → HPA: meer pods nodig
+    → Nodes vol? Pods blijven Pending
+      → Cluster Autoscaler: nieuwe VM via Hetzner API
+        → Cloud-init: K3s agent install + join
+          → Node ready → Pending pods ingepland
+```
+
+**Afgewezen:**
+- Karpenter: geen Hetzner provider beschikbaar, niet op de roadmap
+- Handmatig VMs toevoegen: niet automatisch, trage reactietijd
+- Terraform-gestuurde scaling: state drift conflict met Cluster Autoscaler
+
+---
+
+## Out of Scope (Niet in Phase 1)
+
+| Onderwerp | Waarom niet nu | Wanneer |
+|-----------|----------------|---------|
+| **Sandbox migratie** (Docker → K8s) | Docker socket dependency vereist significante refactor. Sandbox blijft op Docker tot Agent Sandbox operator stabiel is (v1alpha1 risico). | Phase 2 |
+| **MCP module autoscaling** | Modules worden herbouwd als built-in backend tools. Onafhankelijke scaling is weggegooide investering. | Vervalt |
+| **ArgoCD** | Push-based CI/CD is voldoende voor één omgeving. ArgoCD wordt nuttig bij meerdere environments en drift detection. | Phase 2 |
+| **Agent Sandbox operator** | v1alpha1 API kan significant veranderen. Eerst de SDK evalueren op Kind. | Phase 2 |
+| **Longhorn** | Niet nodig zolang modules geen onafhankelijke RWX volumes nodig hebben. Local-path provisioner volstaat. | Phase 2 (indien nodig) |
+| **gVisor / Kata Containers** | Sandbox runtime isolatie. Pas relevant als sandboxes naar K8s migreren. | Phase 2 |
+| **Event-driven backend** (message queue) | Backend draait Phase 1 met 2-10 replicas en database-driven resume. Message queue (Redis Streams/NATS) wordt toegevoegd als de belasting het rechtvaardigt. | Phase 2 |
+| **Network Policies** | Per-namespace isolatie. Nuttig, maar niet blocking voor Phase 1. | Phase 2 |
+| **Harbor registry** | Vulnerability scanning en image signing. Gitea registry volstaat. | Phase 2 |
+| **Distributed tracing** (Jaeger/Tempo) | Nuttig bij 20+ services met complexe request flows. Nog niet nodig. | Phase 3 |
+| **Database partitioning** | Pas relevant bij >100k tool_calls/llm_calls records. | Phase 3 |
+
+---
+
+## Doelarchitectuur
+
+```mermaid
+flowchart TB
+    subgraph Internet["Internet"]
+        USER["Gebruiker"]
+    end
+
+    subgraph GitHub["GitHub (Core Code)"]
+        REPO["druppie-kubernetes<br/>branch: colab-dev"]
+        GHA["GitHub Actions<br/>CI/CD Pipeline"]
+    end
+
+    subgraph Hetzner["Hetzner Cloud"]
+        HAPI["Hetzner Cloud API"]
+
+        subgraph Provisioning["Cluster Provisioning"]
+            HK3S["hetzner-k3s CLI<br/>1 YAML config"]
+        end
+
+        LB["Load Balancer<br/>€6/mo"]
+
+        subgraph K3sCluster["K3s Cluster"]
+            direction TB
+
+            subgraph MasterNodes["🖥️ K3s Servers — Control Plane (3 vast, etcd HA)"]
+                direction LR
+                M1["server-1<br/>etcd + API"]
+                M2["server-2<br/>etcd + API"]
+                M3["server-3<br/>etcd + API"]
+            end
+
+            subgraph InfraPool["📦 Infra Pool — K3s Agents (1-2 vast)"]
+                direction TB
+
+                subgraph InfraServices["Services"]
+                    direction LR
+                    KC["Keycloak<br/>1 pod"]
+                    GT["Gitea<br/>1 pod<br/>+ Registry"]
+                end
+
+                subgraph MCPModules["MCP Modules"]
+                    direction LR
+                    MC["module-coding"]
+                    MD["module-docker"]
+                    MO["+ 6 modules"]
+                end
+
+                subgraph SharedVol["Shared PVC"]
+                    PVC["MCP workspace"]
+                end
+
+                subgraph DBLayer["CloudNativePG"]
+                    direction LR
+                    subgraph DB1["druppie-db"]
+                        DB1P["Primary"]
+                        DB1R1["Replica"]
+                        DB1R2["Replica"]
+                    end
+                    subgraph DB2["keycloak-db"]
+                        DB2P["Primary"]
+                        DB2R1["Replica"]
+                        DB2R2["Replica"]
+                    end
+                    subgraph DB3["gitea-db"]
+                        DB3P["Primary"]
+                        DB3R1["Replica"]
+                        DB3R2["Replica"]
+                    end
+                end
+
+                subgraph PlatformLayer["Platform"]
+                    direction LR
+                    PROM["Prometheus"]
+                    GRAF["Grafana"]
+                    SS["Sealed Secrets"]
+                    KEDAO["KEDA"]
+                    CA["Cluster<br/>Autoscaler"]
+                end
+
+                INFRA_LABEL["✅ Vast — nooit geëvinceerd door autoscaler"]
+            end
+
+            subgraph AppPool["🚀 App Pool — K3s Agents (1-10 autoscaling)"]
+                direction TB
+
+                subgraph AppNode1["app-node-1"]
+                    direction LR
+                    A1FE["frontend<br/>pod"]
+                    A1BE["backend<br/>pod"]
+                end
+
+                subgraph AppNode2["app-node-2"]
+                    direction LR
+                    A2FE["frontend<br/>pod"]
+                    A2BE["backend<br/>pod"]
+                end
+
+                subgraph AppNodeN["app-node-N<br/>(auto-provisioned)"]
+                    direction LR
+                    ANFE["frontend<br/>pod"]
+                    ANBE["backend<br/>pod"]
+                end
+
+                PODSCALE["⬆ POD SCALING (Tier 1)<br/>HPA: CPU 70% · KEDA: queue > 5<br/>Nieuwe pods op bestaande nodes"]
+            end
+
+            NODESCALE["⬆ NODE SCALING (Tier 2)<br/>Cluster Autoscaler → Hetzner API: nieuwe VM → cloud-init join<br/>~60 seconden"]
+
+            subgraph IngressLayer["Ingress"]
+                TRAEFIK["Traefik"]
+                CM["cert-manager"]
+            end
+        end
+    end
+
+    %% User flow
+    USER -->|"HTTPS"| LB
+    LB -->|"traffic"| TRAEFIK
+    TRAEFIK -->|"/"| A1FE
+    TRAEFIK -->|"/"| A2FE
+    TRAEFIK -->|"/api"| A1BE
+    TRAEFIK -->|"/api"| A2BE
+    CM -.->|"TLS"| TRAEFIK
+
+    %% CI/CD
+    REPO -->|"PR merge"| GHA
+    GHA -->|"docker push"| GT
+    GHA -->|"helm upgrade"| K3sCluster
+
+    %% App → Infra connections
+    A1BE -->|"MCP calls"| MC
+    A2BE -->|"MCP calls"| MC
+    MCPModules ---|"r/w"| PVC
+    A1BE -->|"auth"| KC
+    A2BE -->|"git push"| GT
+    A1BE -->|"queries"| DB1
+    KC -->|"queries"| DB2
+    GT -->|"queries"| DB3
+
+    %% Pod scaling (Tier 1)
+    KEDAO -.->|"KEDA trigger"| PODSCALE
+    PODSCALE -.->|"meer pods"| AppPool
+
+    %% Node scaling (Tier 2)
+    PODSCALE -.->|"nodes vol?"| CA
+    CA -.->|"create VM"| HAPI
+    HAPI -.->|"new agent"| NODESCALE
+    NODESCALE -.-> AppPool
+
+    %% Monitoring
+    PROM -.->|"scrape"| AppPool
+    PROM -.->|"scrape"| DBLayer
+
+    %% Provisioning
+    HK3S -.->|"create cluster"| HAPI
+
+    %% Styling
+    style K3sCluster fill:#1a1a2e,color:#e0e0e0
+    style Internet fill:#transparent
+    style GitHub fill:#24292e,color:#ffffff
+    style Hetzner fill:#f0f0f0
+    style MasterNodes fill:#2d3436,color:#e0e0e0
+    style InfraPool fill:#0984e3,color:#ffffff
+    style AppPool fill:#00b894,color:#1a1a2e
+    style AppNode1 fill:#16213e,color:#e0e0e0
+    style AppNode2 fill:#16213e,color:#e0e0e0
+    style AppNodeN fill:#16213e,color:#e0e0e0
+    style DBLayer fill:#0f3460,color:#e0e0e0
+    style PlatformLayer fill:#1a1a2e,color:#e0e0e0
+    style IngressLayer fill:#533483,color:#e0e0e0
+    style InfraServices fill:#1a1a2e,color:#e0e0e0
+    style SharedVol fill:#2d3436,color:#e0e0e0
+    style Provisioning fill:#dfe6e9
+    style MCPModules fill:#2d3436,color:#e0e0e0
+    style NODESCALE fill:#d63031,color:#ffffff
+    style PODSCALE fill:#fdcb6e,color:#1a1a2e
+```
+
+---
+
+## Fasering
+
+### Week 1-2: Cluster Setup
+
+- hetzner-k3s CLI installeren, cluster.yaml configureren, cluster aanmaken (2-3 min)
+- Cluster provisioning via hetzner-k3s (3 masters + 1-10 autoscaled workers, Ubuntu)
+- Traefik ingress verifiëren (K3s standaard)
+- kube-prometheus-stack deployen
+
+### Week 3-4: Database + Storage
+
+- CloudNativePG operator installeren (v1.29.1+)
+- 3 database clusters aanmaken: druppie-db, keycloak-db, gitea-db
+- Failover scenario testen op staging
+- Backup naar S3/MinIO configureren en verifiëren
+
+### Week 5-6: Applicatie Deploy
+
+- Helm chart aanpassen voor K3s: `values-prod.yaml`, Traefik config, resource limits
+- Gitea Container Registry configureren
+- CI/CD pipeline: GitHub Actions bouwt images, pusht naar Gitea registry, `helm upgrade`
+- Sealed Secrets installeren, alle secrets versleutelen
+- cert-manager + Let's Encrypt voor TLS
+
+### Week 7-8: Autoscaling + HA
+
+- HPA toevoegen voor frontend (2-8 replicas) en backend (2-10 replicas)
+- KEDA operator installeren, ScaledObject voor backend (Prometheus trigger)
+- PDB's configureren voor backend en frontend
+- Pod anti-affinity toevoegen
+- Graceful shutdown in FastAPI implementeren
+- Load testing en tuning
+
+---
+
+## Risico's en Mitigaties
+
+| Risico | Impact | Kans | Mitigatie |
+|--------|--------|------|-----------|
+| Backend multi-replica race conditions bij webhooks | Data inconsistentie | Medium | Database-driven resume patroon (bestaande `reconstruct_from_db()`). Testen met 3+ replicas op staging. |
+| CloudNativePG operationele kennis ontbreekt | DB issues in productie | Medium | Failover scenario's testen op staging vóór productie. Runbooks schrijven. CNPG documentatie bestuderen. |
+| KEDA scaling te agressief of te traag | Oscillatie of vertraging | Laag | Stabilization windows configureren (300s scale-down, 60s scale-up). Tunen op basis van load tests. |
+| Sealed Secrets key verloren | Alle secrets ontoegankelijk | Medium | Private key backup procedure documenteren én testen. Key opslaan in offline vault. |
+| 3 nodes onvoldoende voor piekbelasting | Performance degradatie | Laag | K3s agent join is triviaal. Nieuwe VM toevoegen bij noodzaak. CPX31 → CPX41 upgrade is 1 klik in Hetzner console. |
+| CloudNativePG CVE-2026-44477 | Superuser privilege escalation | Laag | Altijd v1.29.1+. Pin operator versie in Helm values. |
+| hetzner-k3s single maintainer dependency | Tool wordt niet meer onderhouden | Laag | Actieve community (3.5k+ stars, laatste update juni 2026). Fallback: eigen Terraform module. Het cluster zelf is standaard K3s — de tool is alleen voor provisioning, niet runtime afhankelijk. |
+
+---
+
+## Kostenschatting
+
+Gebaseerd op Hetzner publieke prijzen (juni 2026).
+
+| Component | Specificatie | Kosten/maand |
+|-----------|-------------|-------------|
+| K3s servers (3x) | CPX31 (4 vCPU, 8GB RAM, 160GB NVMe) | 3 × €13 = ~€39 |
+| Infra agents (1-2x, vast) | CPX31 — Keycloak, Gitea, MCP, CNPG, monitoring | 1-2 × €13 = ~€13-26 |
+| App agents (1-10x, autoscaling) | CPX31 — Backend, Frontend | 1 × €13 = ~€13 (idle), schaalt mee met load |
+| Extra storage | 200GB block storage (DB data, backups) | ~€10 |
+| Load balancer | Hetzner Load Balancer | ~€6 |
+| Backup storage | 100GB (DB backups, MinIO/S3) | ~€5 |
+| **Totaal Phase 1 (basis)** | 3 servers + 1 infra + 1 app | **~€86/maand** |
+| **Totaal bij belasting** | 3 servers + 2 infra + 3-5 app | **~€125-165/maand** |
+
+Bij schaalvergroting (meer nodes of grotere VMs): CPX41 (8 vCPU, 16GB RAM) is ~€24/mo per node. Dedicated servers (AX42: 8 vCPU, 64GB RAM) zijn ~€49/mo per node.
+
+---
+
+## Consequenties
+
+### Wat dit mogelijk maakt
+
+- Horizontaal schalen van backend en frontend op basis van werkelijke belasting (KEDA + HPA)
+- Automatisch node-level schalen: Cluster Autoscaler provisioneert nieuwe Hetzner VMs bij Pending pods (~60s), en verwijdert ze bij onderbelasting
+- Database hoge beschikbaarheid met automatische failover (<30s)
+- Gecentraliseerde monitoring en alerting via Prometheus + Grafana
+- TLS voor alle endpoints via cert-manager + Let's Encrypt
+- Versleutelde secrets in git via Sealed Secrets
+- Reproduceerbare deployments via Helm + CI/CD
+- Cluster provisioning in 2-3 minuten vanuit 1 YAML file (Infrastructure as Code)
+- Cluster uitbreiden door een VM toe te voegen (K3s agent join, 1 commando)
+
+### Wat dit beperkt
+
+- Sandbox blijft op Docker Compose. De Docker socket dependency is niet opgelost in Phase 1. Sandbox migratie volgt in Phase 2, afhankelijk van Agent Sandbox operator volwassenheid.
+- MCP modules schalen niet onafhankelijk. Dit is bewust: modules worden herbouwd als built-in backend tools, waarna de shared PVC vervalt.
+- Geen drift detection. Push-based CI/CD betekent dat handmatige cluster wijzigingen onopgemerkt blijven. ArgoCD (Phase 2) lost dit op.
+- Backend sessie tracking blijft in-memory in Phase 1. Multi-replica webhooks worden afgehandeld via database-driven resume. Een message queue (Redis Streams/NATS) volgt in Phase 2 als de belasting het rechtvaardigt.
+- Geen sandbox runtime isolatie (gVisor/Kata). Pas relevant als sandboxes naar K8s migreren.
+
+### Migratiepad
+
+Druppie blijft draaien op Docker Compose tijdens de migratie. De K3s cluster wordt parallel opgebouwd. Switchover gebeurt in één stap: DNS pointing van de Docker Compose host naar de Hetzner Load Balancer. Terugdraaien is een DNS revert.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -42,6 +42,9 @@ Last updated: 2026-03-24
 - Update Core Flow — End-to-End Improvements
 - ~~Update Core — Technical Basis~~ ✅ DONE
 - ~~Update Core — Architect Signal & Dual-Repo Sandbox~~ ✅ DONE
+- Kubernetes — Sandbox Image Builder Job is a Placeholder
+- Kubernetes — Helm Chart Test Suite
+- Kubernetes — Production Hardening (TLS, External Secrets, HPA)
 - Dependency Cache — Remote/Distributed Caching
 - Dependency Cache — Pre-Populated Common Packages
 - Dependency Cache — Automated Periodic Vulnerability Scanning
@@ -315,6 +318,34 @@ Last updated: 2026-03-24
 - **`repo_target` parameter:** `execute_coding_task` accepts `repo_target` enum (`"project"` default, `"druppie_core"`). Controls whether the sandbox gets single-repo or dual-repo credentials.
 - **Simplified branch targeting:** The sandbox agent determines PR base branch from its git remote (GitHub repos → `colab-dev`, Gitea repos → `main`). Configured in sandbox agent prompts — no branch parameter threaded through infrastructure.
 - **YAML auto-reload:** `AgentDefinitionLoader` checks file mtime on each load and automatically reloads YAML definitions when they change on disk. No backend restart needed for prompt edits during development.
+
+### Kubernetes — Sandbox Image Builder Job is a Placeholder
+
+- **Location:** `helm/druppie/templates/sandbox-image-builder-job.yaml`
+- **Current state:** The sandbox image builder Job in the Helm chart is a placeholder that just echoes a message. The actual `open-inspect-sandbox` image must be pre-built and pushed to a registry before deploying to Kubernetes.
+- **Desired improvement:** Either automate the sandbox image build as part of the Helm install (using a Kaniko-based Job or similar), or document the pre-build step more prominently and add a health check that verifies the image exists before sandbox-dependent components start.
+- **Priority:** Medium — blocks sandbox functionality in Kubernetes deployments.
+
+### Kubernetes — Helm Chart Test Suite
+
+- **Current state:** The Helm chart has no automated tests. Template rendering and resource correctness are only verified manually.
+- **Desired improvement:** Add `helm unittest` tests (or `helm template` + snapshot tests) to validate:
+  - All templates render without errors for default values
+  - Module enable/disable toggles correctly include/exclude resources
+  - NetworkPolicies, ingress rules, and service ports match expected values
+  - Secret and ConfigMap values are correctly templated
+- **Priority:** Medium — prevents regressions as the chart evolves.
+
+### Kubernetes — Production Hardening (TLS, External Secrets, HPA)
+
+- **Current state:** The Helm chart is designed for local Kind clusters. Production requires TLS, external secret management, autoscaling, and a real container registry. See `docs/kubernetes.md` section 9 and `docs/KUBERNETES-STRATEGY.md` for the full production roadmap.
+- **Desired improvement:**
+  - cert-manager integration for automatic TLS certificates
+  - External Secrets Operator or Sealed Secrets support
+  - HorizontalPodAutoscaler templates for backend and MCP modules
+  - PodDisruptionBudget templates for availability during updates
+  - Container registry configuration in `values.yaml` (currently all images use `IfNotPresent` with local tags)
+- **Priority:** Low — only needed when moving beyond local development.
 
 ### Dependency Cache — Remote/Distributed Caching
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -598,6 +598,35 @@ The dashboards goal is to provide an overview of platform activity. This page is
 
 ---
 
+## Kubernetes Deployment (Helm Chart)
+
+Druppie can be deployed to Kubernetes using the included Helm chart (`helm/druppie/`). The chart packages all platform components — backend, frontend, Keycloak, Gitea, 8 MCP modules, and 3 PostgreSQL databases — into ~43 Kubernetes resources managed as a single release.
+
+### What the Chart Deploys
+
+- **12 Deployments**: backend, frontend, Keycloak, Gitea, and 8 MCP modules (coding, docker, filesearch, web, archimate, registry, llm, vision)
+- **3 StatefulSets**: PostgreSQL instances for Druppie, Keycloak, and Gitea
+- **Path-based ingress**: nginx routes `/api` to backend, `/realms` to Keycloak, `/git` to Gitea, `/` to frontend — all on a single domain
+- **5 NetworkPolicies**: internal app communication, sandbox isolation, controlled egress for LLM API calls
+- **4 PVCs**: workspace (10Gi), dataset (5Gi), sandbox-bundles (5Gi), gitea-data (5Gi)
+- **Post-install init Job**: automatically sets up Keycloak realm, clients, roles, and test users
+
+### Local Development with Kind
+
+A Kind cluster configuration is included (`kind/cluster-dev.yaml`) for local testing. Helper scripts in `scripts/` automate cluster creation (`setup-kind.sh`), image building and loading (`build-and-load.sh`), and port forwarding (`port-forward.sh`).
+
+### Key Configuration
+
+All configuration is centralized in `values.yaml`:
+- `global.domain` — platform domain (default: `localhost`)
+- `global.ingress.port` — external port (default: `9080`)
+- `secrets.zaiApiKey` — LLM provider API key
+- Each MCP module can be individually enabled/disabled
+
+See `docs/kubernetes.md` for the full setup guide and troubleshooting.
+
+---
+
 ## Settings Page
 
 The Settings page displays system configuration and status (read-only). This page too is a prototype and might not work correctly.

--- a/docs/KUBERNETES-STRATEGY.md
+++ b/docs/KUBERNETES-STRATEGY.md
@@ -2,9 +2,59 @@
 
 > **Status:** Voorstel  
 > **Datum:** 2026-06-02  
+> **Laatst bijgewerkt:** 2026-06-09  
 > **Type:** Spike / Architecture Decision Record  
 > **Story:** Story 2 — Spike: schaalbare Kubernetes strategie (3 SP)  
 > **Principe:** Alles open source, geen vendor lock-in
+
+---
+
+## Strategieoverzicht
+
+Dit document onderzoekt **12 strategiegebieden** voor de migratie van Docker Compose naar productie-ready Kubernetes. Elke strategie adresseert een specifieke bottleneck of risico in de huidige architectuur.
+
+| # | Strategie | Waarom | Huidige staat | Beslissing |
+|---|-----------|--------|---------------|------------|
+| 2.1 | **Kubernetes Platform** | Welke distributie voor dev, staging, productie | Kind (alleen dev) | Kind (dev) → K3s (staging/prod) |
+| 2.2 | **Hosting Model** | Waar draait het cluster, zonder vendor lock-in | Lokaal (Docker Desktop) | Cloud VMs (commodity provider) |
+| 2.3 | **Schaalbaarheid** | Backend is single-replica, geen autoscaling | 1 replica, hardcoded, geen HPA | HPA + KEDA per service |
+| 2.4 | **Database** | 3× container PostgreSQL zonder HA, backup, of failover | StatefulSets, geen replicatie | CloudNativePG operator |
+| 2.5 | **High Availability** | Single point of failure op elke laag | Geen PDB, geen anti-affinity | PDB + anti-affinity + graceful shutdown |
+| 2.6 | **Sandbox** | Docker socket dependency werkt niet in K8s | `docker_manager.py` via Docker CLI | Agent Sandbox (SIG Apps) / K8s Jobs fallback |
+| 2.7 | **Shared Volumes (RWX)** | Workspace PVC is ReadWriteOnce — blokkeert multi-node | RWO, 4 services delen 1 volume | Longhorn RWX → per-session eliminatie |
+| 2.8 | **Deployment** | Geen GitOps, geen drift detection | Handmatig `helm upgrade` | Helm + CI/CD → ArgoCD |
+| 2.9 | **Container Registry** | Images moeten ergens naartoe (niet `kind load`) | Geen registry | Gitea registry → Harbor |
+| 2.10 | **Networking/Ingress** | TLS, routing, rate limiting voor productie | NGINX op Kind (port 9080) | Traefik (K3s standaard) + cert-manager |
+| 2.11 | **Secrets Management** | API keys en wachtwoorden staan in plaintext values | Helm values (onversleuteld) | Sealed Secrets |
+| 2.12 | **Monitoring** | Geen observability, blind vliegen in productie | Niets | kube-prometheus-stack |
+
+**Sectie 3** beschrijft **architectuursuggesties** die dieper ingrijpen dan tooling-keuzes — dit zijn de wijzigingen die nodig zijn om Druppie écht horizontaal schaalbaar te maken:
+
+| # | Suggestie | Kernprobleem |
+|---|-----------|-------------|
+| 3.1 | Event-driven backend | In-memory session tracking (`_active_session_tasks` dict) voorkomt multi-replica |
+| 3.2 | MCP module mesh | 9 MCP modules als losse services + shared volume = NFS bottleneck |
+| 3.3 | Database partitioning | `tool_calls`/`llm_calls` tabellen groeien onbegrensd |
+| 3.4 | Sandbox pool pre-warming | Cold start 3-10s is te traag voor interactieve sessies |
+| 3.5 | Multi-tenant schaalbaarheid | Geen tenant isolatie op K8s niveau |
+| 3.6 | Control plane schaalbaarheid | SQLite in sandbox-control-plane = single replica |
+
+### Toekomstige uitbreidingen (nog niet behandeld)
+
+De volgende onderwerpen vallen buiten scope van deze spike maar worden relevant bij groei:
+
+| Onderwerp | Waarom relevant | Wanneer |
+|-----------|----------------|---------|
+| **Service mesh** (Istio/Linkerd) | mTLS tussen services, traffic shaping, circuit breaking | Multi-tenant of compliance-eisen |
+| **Distributed caching** (Redis/Valkey) | Session state delen tussen replicas, MCP response caching | Backend multi-replica (fase 2) |
+| **Blue/green & canary deployments** | Zero-downtime releases met rollback op metrics | Productie met SLA |
+| **API rate limiting per tenant** | Fair use, abuse prevention | Multi-tenant |
+| **Distributed tracing** (Jaeger/Tempo) | Request flow door 20+ services debuggen | Productie debugging |
+| **Log aggregation** (Loki/ELK) | Gecentraliseerd loggen, correlatie tussen services | Productie operatie |
+| **Webhook retry & dead-letter queue** | Sandbox webhooks kunnen falen, geen retry mechanisme nu | Backend reliability |
+| **FinOps / cost management** | Resource right-sizing, idle detection, burst billing | Cloud productie |
+| **Disaster recovery automatisering** | Cluster rebuild, cross-region failover | Enterprise / SLA 99.9%+ |
+| **Feature flags** | Graduele rollout van nieuwe agent capabilities | Team groei |
 
 ---
 
@@ -800,9 +850,11 @@ CloudNativePG exporteert automatisch PostgreSQL metrics via PodMonitor. KEDA, Tr
 
 De huidige Druppie-architectuur is ontworpen voor single-instance Docker Compose. Om echt schaalbaar te worden op Kubernetes zijn er architectuurwijzigingen nodig. Deze sectie beschrijft suggesties — geen van deze vereist de huidige codebase als beperking.
 
+> **Huidige staat samengevat:** Backend draait op 1 hardcoded replica (`backend-deployment.yaml:9`). Session tracking is in-memory via `_active_session_tasks` dict in `core/background_tasks.py` — dit voorkomt multi-replica zonder race conditions. Workspace PVC is `ReadWriteOnce` — blokkeert scheduling naar andere nodes. Sandbox-manager spawnt containers via `docker run` subprocess calls. Geen HPA, geen PDB, geen autoscaling geconfigureerd in het Helm chart.
+
 ### 3.1 Event-Driven Backend (huidige bottleneck elimineren)
 
-**Probleem:** Het backend verwerkt agent sessies synchroon via `asyncio.create_task()`. Dit koppelt webhook ontvangst aan de specifieke replica die de agent draait — een fundamentele belemmering voor horizontale schaalbaarheid.
+**Probleem:** Het backend verwerkt agent sessies via `create_session_task()` (`core/background_tasks.py`), dat een in-memory `dict[UUID, asyncio.Task]` bijhoudt per session_id. Dit voorkomt dubbele runs binnen één replica, maar bij meerdere replicas is er **geen cross-replica coördinatie** — twee replicas kunnen tegelijk dezelfde sessie draaien. De sandbox webhook (`api/routes/sandbox.py`) landt op een willekeurige replica via de Service load balancer, niet noodzakelijk op de replica die de agent sessie host.
 
 **Suggestie: Message queue als backbone**
 
@@ -955,7 +1007,26 @@ Voor Druppie is **namespace per tenant + vCluster** de sweet spot: volledige Kub
 
 Alternatief: als de control plane voornamelijk caching en session state doet, overweeg Redis als backing store (sneller dan PostgreSQL voor key-value lookups, maar minder durable).
 
+### 3.7 Concrete codebase-wijzigingen voor schaalbaarheid
+
+Onderstaande wijzigingen zijn nodig om van single-replica naar horizontaal schaalbaar te gaan. Geordend op prioriteit:
+
+| Prioriteit | Wijziging | Bestand(en) | Wat |
+|------------|-----------|-------------|-----|
+| **P0** | Replica count configureerbaar | `helm/druppie/templates/backend-deployment.yaml` | Hardcoded `replicas: 1` → `{{ .Values.backend.replicas }}` |
+| **P0** | Workspace PVC naar RWX | `helm/druppie/templates/persistentvolumeclaims.yaml` | `ReadWriteOnce` → `ReadWriteMany` + storageClass |
+| **P0** | HPA toevoegen | `helm/druppie/templates/` (nieuw) | HPA resources voor backend, frontend, MCP modules |
+| **P1** | Session locking naar database | `druppie/core/background_tasks.py` | `_active_session_tasks` dict → PostgreSQL advisory lock of `FOR UPDATE SKIP LOCKED` |
+| **P1** | Sandbox manager naar K8s API | `background-agents/.../docker_manager.py` | `docker run` subprocess → `kubernetes` Python client |
+| **P2** | PDB's toevoegen | `helm/druppie/templates/` (nieuw) | PodDisruptionBudget per kritieke service |
+| **P2** | Anti-affinity configureren | `helm/druppie/templates/*-deployment.yaml` | Pod anti-affinity op hostname |
+| **P2** | Graceful shutdown | `druppie/api/main.py` | `terminationGracePeriodSeconds` + SIGTERM handler uitbreiden |
+| **P3** | Control plane SQLite → PG | `background-agents/` | SQLite vervangen door PostgreSQL client |
+| **P3** | Replica counts in values.yaml | `helm/druppie/values.yaml` | Expose `replicas` per service in values |
+
 ---
+
+## 4. Fasering
 
 ### Fase 1 — Minimaal Productie-Ready (4-6 weken)
 

--- a/docs/KUBERNETES-STRATEGY.md
+++ b/docs/KUBERNETES-STRATEGY.md
@@ -11,7 +11,7 @@
 
 ## Strategieoverzicht
 
-Dit document onderzoekt **12 strategiegebieden** voor de migratie van Docker Compose naar productie-ready Kubernetes. Elke strategie adresseert een specifieke bottleneck of risico in de huidige architectuur.
+Dit document onderzoekt **13 strategiegebieden** voor de migratie van Docker Compose naar productie-ready Kubernetes. Elke strategie adresseert een specifieke bottleneck of risico in de huidige architectuur.
 
 | # | Strategie | Waarom | Huidige staat | Beslissing |
 |---|-----------|--------|---------------|------------|
@@ -27,6 +27,7 @@ Dit document onderzoekt **12 strategiegebieden** voor de migratie van Docker Com
 | 2.10 | **Networking/Ingress** | TLS, routing, rate limiting voor productie | NGINX op Kind (port 9080) | Traefik (K3s standaard) + cert-manager |
 | 2.11 | **Secrets Management** | API keys en wachtwoorden staan in plaintext values | Helm values (onversleuteld) | Sealed Secrets |
 | 2.12 | **Monitoring** | Geen observability, blind vliegen in productie | Niets | kube-prometheus-stack |
+| 2.13 | **Infrastructure Provisioning & Node Autoscaling** | HPA/KEDA schalen pods, maar nodes zijn vol = geen scheduling | Geen node-level autoscaling | hetzner-k3s CLI + Cluster Autoscaler (upstream) |
 
 **Sectie 3** beschrijft **architectuursuggesties** die dieper ingrijpen dan tooling-keuzes — dit zijn de wijzigingen die nodig zijn om Druppie écht horizontaal schaalbaar te maken:
 
@@ -843,6 +844,156 @@ Dit is de de-facto standaard voor Kubernetes monitoring. Eén `helm install` gee
 - kube-state-metrics voor Kubernetes object metrics
 
 CloudNativePG exporteert automatisch PostgreSQL metrics via PodMonitor. KEDA, Traefik, en Keycloak hebben ook Prometheus endpoints.
+
+---
+
+### 2.13 Infrastructure Provisioning & Node Autoscaling
+
+#### Probleemstelling
+
+HPA en KEDA schalen pods, maar wanneer alle 3 nodes vol zijn, heeft Kubernetes geen plek om nieuwe pods te schedulen. We hebben automatische node-level autoscaling nodig: nieuwe Hetzner VMs inrichten wanneer er capaciteit nodig is, en ze verwijderen wanneer ze idle zijn.
+
+#### Vergelijkingsmatrix
+
+| Criterium | hetzner-k3s (CLI) | kube-hetzner (Terraform) | Custom Terraform | Handmatig |
+|-----------|-------------------|--------------------------|------------------|-----------|
+| **Licentie** | MIT | MIT | N.v.t. | n.v.t. |
+| **Type** | CLI tool (1 YAML config) | Terraform module | Eigen Terraform | SSH + scripts |
+| **OS** | Ubuntu (default), Debian, others | MicroOS (openSUSE) | Kies zelf | Kies zelf |
+| **Cluster setup** | 2-3 minuten | ~5 minuten | Variabel | 30+ min |
+| **Autoscaling ingebouwd** | Ja (Cluster Autoscaler + CCM + CSI) | Ja (Cluster Autoscaler + CCM + CSI) | Nee (zelf configureren) | Nee |
+| **Auto-upgrades K3s** | Ja (System Upgrade Controller) | Ja (System Upgrade Controller) | Nee | Nee |
+| **IaC in git** | Ja (YAML config) | Ja (Terraform state) | Ja | Nee |
+| **Leercurve** | Laag | Medium (Terraform kennis nodig) | Hoog | Laag |
+| **Flexibiliteit** | Medium | Hoog (190+ variabelen) | Maximaal | Geen |
+| **Community** | ⭐ 3.5k+ GitHub stars | ⭐ 3.8k+ GitHub stars | n.v.t. | n.v.t. |
+| **Multi-cluster** | Nee | Ja (Terraform workspaces) | Ja | Nee |
+| **Production ready** | Ja | Ja | Afhankelijk van implementatie | Nee |
+
+#### Toelichting: Two-tier autoscaling architectuur
+
+Pod scaling en node scaling zijn twee aparte lagen die samenwerken:
+
+**Tier 1 — Pod Autoscaling (HPA + KEDA):**
+- Bewaakt CPU/memory/custom metrics per pod
+- Voegt pod replicas toe of verwijdert ze binnen bestaande nodes
+- Snel (seconden): nieuwe pod start op bestaande node
+- Begrensd door beschikbare node capaciteit
+
+**Tier 2 — Node Autoscaling (Cluster Autoscaler):**
+- Bewaakt pods die niet gescheduled kunnen worden (Pending state)
+- Creëert nieuwe Hetzner VMs via Hetzner Cloud API
+- Cloud-init script installeert automatisch K3s agent en voegt toe aan cluster
+- Verwijdert idle nodes na een configureerbare timeout
+- Trager (30-60s): VM provisioning + K3s join
+
+Flow:
+```
+Load spike → HPA creates pods → Nodes full? → Pending pods
+                                                  ↓
+                              Cluster Autoscaler detecteert Pending pods
+                                                  ↓
+                              Hetzner API: maak nieuwe VM aan
+                                                  ↓
+                              Cloud-init: installeer K3s agent, join cluster
+                                                  ↓
+                              Node ready → Pending pods gescheduled
+```
+
+#### Toelichting per optie
+
+**hetzner-k3s (aanbevolen voor Druppie)**
+
+CLI tool door Vito Botta. Eén YAML config file definieert het hele cluster: masters, workers, autoscaling pools, networking. Geen Terraform nodig. Installeert automatisch: Hetzner CCM, CSI driver, System Upgrade Controller, en Cluster Autoscaler.
+
+```yaml
+# cluster.yaml
+hetzner_token: <token>
+cluster_name: druppie
+kubeconfig_path: "./kubeconfig"
+k3s_version: v1.32.3+k3s1
+
+networking:
+  mode: flannel
+
+masters_pool:
+  instance_type: cpx31
+  instance_count: 3
+  location: fsn1
+
+worker_node_pools:
+- name: workers
+  instance_type: cpx31
+  instance_count: 1
+  location: fsn1
+  autoscaling:
+    enabled: true
+    min_instances: 1
+    max_instances: 10
+```
+
+Sterktes: Ubuntu support, simpelste setup, batteries included, actieve community.
+Zwaktes: Single maintainer, minder flexibel dan Terraform modules.
+
+**kube-hetzner (Terraform module)**
+
+Meest populaire Terraform module voor K3s op Hetzner. Gebruikt MicroOS (openSUSE), een immuut, transactioneel OS ontworpen voor containers. Diepe integratie met auto-upgrades, Longhorn, meerdere CNI opties.
+
+Sterktes: Meest compleet, IaC standaard, multi-cluster, MicroOS security voordelen.
+Zwaktes: Vereist Terraform kennis, MicroOS leercurve, geen Ubuntu.
+
+**Kubernetes Cluster Autoscaler (upstream Hetzner provider)**
+
+Onafhankelijk van provisioning tool: de daadwerkelijke autoscaling wordt uitgevoerd door de officiële Kubernetes Cluster Autoscaler met ingebouwde Hetzner Cloud provider (`--cloud-provider=hetzner`). Dit is upstream Kubernetes, actief onderhouden (commits van mei 2026).
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: cluster-autoscaler
+          image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.0
+          command:
+            - ./cluster-autoscaler
+            - --cloud-provider=hetzner
+            - --nodes=1:10:cpx31:fsn1:workers    # min:max:type:region:pool
+            - --scale-down-delay-after-add=10m
+            - --scale-down-unneeded-time=10m
+            - --scan-interval=10s
+          env:
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud-autoscaler
+                  key: token
+            - name: HCLOUD_CLUSTER_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud-autoscaler
+                  key: clusterConfig
+            - name: HCLOUD_NETWORK
+              value: "druppie-network"
+```
+
+**Hetzner Cloud Controller Manager (CCM)** — Verplichte dependency. Integreert Kubernetes met Hetzner APIs voor node lifecycle, load balancer provisioning, en netwerk routes. De CCM regelt geen autoscaling zelf, het is de brug tussen K8s en Hetzner die de Cluster Autoscaler nodig heeft.
+
+**Karpenter** — NIET beschikbaar voor Hetzner. Er bestaat geen provider en het staat niet op de roadmap. Karpenter ondersteunt alleen AWS, Azure, GCP, en een paar anderen. Geen optie.
+
+#### Beslissing: hetzner-k3s (CLI) + Cluster Autoscaler (upstream)
+
+| Onderdeel | Keuze | Reden |
+|-----------|-------|-------|
+| **Cluster provisioning** | hetzner-k3s CLI | Ubuntu, simpelste setup, alles ingebouwd, 2-3 min cluster |
+| **Node autoscaling** | Kubernetes Cluster Autoscaler (Hetzner provider) | Upstream, production-ready, actief onderhouden |
+| **Cloud integration** | Hetzner CCM | Verplicht — node lifecycle, LB provisioning |
+| **Storage integration** | Hetzner CSI driver | Persistent volumes via Hetzner block storage |
+| **Auto-upgrades** | System Upgrade Controller | K3s en OS updates met rollback |
 
 ---
 

--- a/docs/KUBERNETES-STRATEGY.md
+++ b/docs/KUBERNETES-STRATEGY.md
@@ -1,0 +1,1110 @@
+# ADR: Schaalbare Kubernetes Strategie voor Druppie
+
+> **Status:** Voorstel  
+> **Datum:** 2026-06-02  
+> **Type:** Spike / Architecture Decision Record  
+> **Story:** Story 2 — Spike: schaalbare Kubernetes strategie (3 SP)  
+> **Principe:** Alles open source, geen vendor lock-in
+
+---
+
+## 1. Context
+
+Druppie is een governance platform voor AI-agents met 20+ services: een FastAPI backend, React frontend, 9 MCP-microservices, Keycloak, Gitea, 3 PostgreSQL databases, en een sandbox-infrastructuur die dynamisch Docker-containers spawnt. Het platform draait nu op Docker Compose en heeft een werkend Helm chart voor Kind (lokaal). Deze spike onderzoekt hoe we productie-ready en schaalbaar worden in Kubernetes.
+
+### Uitgangspunten
+
+- **100% open source** — geen proprietary componenten, geen managed cloud services als dependency
+- **Geen vendor lock-in** — draaibaar op elke cloud, on-premises, of bare metal
+- **Portable Helm chart** — dezelfde chart werkt op Kind, K3s, Rancher, OpenShift, vanilla K8s
+
+### Huidige staat
+
+| Wat | Status |
+|-----|--------|
+| Helm chart | Werkend voor Kind, 43 K8s resources, sandbox nog placeholder |
+| Kind cluster config | Single-node dev + multi-node config aanwezig |
+| Docker socket dependency | 3 services (sandbox-manager, module-docker, backend) |
+| Shared volumes (RWX) | `workspace` volume gedeeld door 4 services |
+| Database migraties | Geen — SQLAlchemy `create_all()`, reset = drop + recreate |
+
+---
+
+## 2. Beslissingen
+
+### 2.1 Kubernetes Platform
+
+#### Vergelijkingsmatrix
+
+| Criterium | Kind | K3s | Rancher (RKE2) | OpenShift (OKD) | Vanilla K8s (kubeadm) |
+|-----------|------|-----|-----------------|-----------------|----------------------|
+| **Licentie** | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 (OKD) | Apache 2.0 |
+| **Use case** | Dev/CI | Dev/Edge/Prod | Prod multi-cluster | Enterprise prod | Prod (bare metal) |
+| **Installatie** | 1 commando | 1 commando | UI of CLI | Installer (30+ min) | Handmatig (complex) |
+| **Resource overhead** | ~300MB (in Docker) | ~512MB RAM | ~2GB RAM | ~8GB RAM minimum | ~2GB RAM |
+| **Multi-node** | Ja (in Docker containers) | Ja (agent join) | Ja (UI-managed) | Ja | Ja |
+| **Built-in storage** | Nee | Local-path provisioner | Longhorn (optioneel) | OpenShift Data Foundation | Nee |
+| **Built-in ingress** | Nee (add NGINX) | Traefik (standaard) | NGINX (standaard) | HAProxy (Routes) | Nee |
+| **Built-in monitoring** | Nee | Nee | Prometheus/Grafana via UI | Ingebouwd (Prometheus) | Nee |
+| **Helm support** | Ja | Ja | Ja | Ja (met beperkingen) | Ja |
+| **NetworkPolicy** | Via CNI plugin | Via Flannel/Calico | Via Calico/Cilium | Via OVN-Kubernetes | Via CNI plugin |
+| **Cert management** | Handmatig | Handmatig | Via Rancher UI | Ingebouwd | Handmatig |
+| **RBAC** | Kubernetes native | Kubernetes native | Rancher RBAC + K8s | OpenShift RBAC (strenger) | Kubernetes native |
+| **Updates** | Recreate cluster | `k3s upgrade` | Rancher UI | `oc adm upgrade` | `kubeadm upgrade` |
+| **Community** | Kubernetes SIG | CNCF Sandbox (Rancher Labs) | SUSE/Rancher | Red Hat + community | Kubernetes upstream |
+| **Productie-ready** | Nee | Ja (CNCF certified) | Ja | Ja | Ja (maar veel werk) |
+| **Leercurve** | Laag | Laag | Medium | Hoog | Hoog |
+
+#### Toelichting per platform
+
+**Kind (Kubernetes in Docker)**
+
+Kind draait een volledige Kubernetes cluster als Docker containers op je lokale machine. Het is ontworpen voor het testen van Kubernetes zelf en is daarmee perfect voor CI/CD en lokale development. Kind is geen productie-oplossing: het heeft geen persistent storage, geen HA, en geen cluster lifecycle management. Wij gebruiken het al (`kind/cluster-dev.yaml`) en het werkt goed.
+
+- **Sterkte:** Snelste setup (~30 sec), nul configuratie, perfecte CI match
+- **Zwakte:** Geen persistent storage classes, geen multi-node HA, niet voor productie
+- **Wanneer:** Development, CI pipelines, Helm chart validatie
+
+**K3s**
+
+K3s is een lichtgewicht, CNCF-gecertificeerde Kubernetes distributie gebouwd door Rancher Labs (nu SUSE). Het is een single binary van ~70MB die alles bevat: API server, scheduler, controller, etcd (vervangen door SQLite voor single-node of embedded etcd voor HA), containerd, en Flannel CNI. K3s draait op alles: bare metal, VMs, Raspberry Pi's, edge devices, cloud VMs.
+
+K3s is **niet** een afgezwakte Kubernetes — het is volledige Kubernetes met dezelfde API, dezelfde conformance tests, en dezelfde Helm charts. Het verschil zit in de verpakking: alles in één binary, automatische TLS bootstrapping, en out-of-the-box Traefik ingress + CoreDNS + local-path storage.
+
+- **Sterkte:** Lichtgewicht, snel, CNCF certified, draait overal, makkelijk HA (3 server nodes)
+- **Zwakte:** Minder ecosystem tooling dan RKE2/kubeadm, Traefik ipv NGINX (configureerbaar)
+- **Wanneer:** Productie voor kleine/medium teams, edge deployments, budget-bewust
+
+**Rancher / RKE2**
+
+Rancher is een open source multi-cluster management platform. RKE2 is de onderliggende Kubernetes distributie (opvolger van RKE1), ook wel "RKE Government" genoemd vanwege de focus op security en FIPS compliance. Rancher biedt een web UI voor cluster lifecycle management, monitoring, logging, en RBAC.
+
+Het verschil met K3s: Rancher/RKE2 is bedoeld voor teams die meerdere clusters beheren, enterprise-grade security nodig hebben, of een grafische beheersinterface willen. RKE2 gebruikt containerd (geen Docker), heeft CIS hardening out-of-the-box, en draait standaard met NGINX ingress.
+
+Rancher kan ook externe clusters beheren (EKS, AKS, GKE, of bestaande K3s/kubeadm clusters).
+
+- **Sterkte:** Multi-cluster UI, ingebouwde monitoring/alerting, CIS hardened, Longhorn integratie
+- **Zwakte:** Meer resources, complexer dan K3s, SUSE commerciële support ≠ community
+- **Wanneer:** Meerdere clusters, team >5 personen, enterprise compliance eisen
+
+**OKD (OpenShift Community)**
+
+OKD is de open source upstream van Red Hat OpenShift. Het bouwt voort op Kubernetes maar voegt significant functionaliteit toe: ingebouwde CI/CD (Tekton), image registry, developer console, source-to-image builds, stricter security model (SecurityContextConstraints ipv PodSecurityPolicies), en operator lifecycle management.
+
+OpenShift/OKD wijkt op belangrijke punten af van standaard Kubernetes:
+- Gebruikt Routes ipv Ingress (Ingress wordt vertaald naar Routes)
+- Draait containers standaard als non-root met random UID
+- Heeft eigen CLI (`oc` naast `kubectl`)
+- Vereist aanpassingen aan Dockerfiles (geen `USER root`)
+
+Dit betekent dat onze Helm chart en Dockerfiles aanpassingen nodig hebben voor OKD compatibility. Specifiek: de backend Dockerfile installeert packages als root en de sandbox containers draaien met specifieke UIDs.
+
+- **Sterkte:** Meest volledige enterprise platform, ingebouwd alles, strikte security
+- **Zwakte:** Zware resource footprint (~8GB+), afwijkende standaarden, Dockerfile aanpassingen nodig, steile leercurve
+- **Wanneer:** Enterprise omgevingen met Red Hat ecosysteem, strikte compliance
+
+**Vanilla Kubernetes (kubeadm)**
+
+Upstream Kubernetes geïnstalleerd via `kubeadm`. Je krijgt exact wat het Kubernetes project levert, niets meer. Alles moet je zelf toevoegen: CNI plugin (Calico/Cilium/Flannel), ingress controller, storage provisioner, monitoring, cert management.
+
+- **Sterkte:** Maximale controle, altijd up-to-date met upstream, geen vendor-specifics
+- **Zwakte:** Meeste operationeel werk, alles zelf configureren, cluster upgrades zijn complex
+- **Wanneer:** Teams met diepgaande K8s expertise die maximale controle willen
+
+#### Beslissing
+
+| Omgeving | Platform | Reden |
+|----------|----------|-------|
+| **Development** | Kind | Al ingericht, snelste feedback loop, gratis |
+| **CI/CD** | Kind | Ephemeral clusters in pipeline, geen state nodig |
+| **Staging** | K3s (single-node of 3-node HA) | Lichtgewicht, productie-equivalent, goedkoop |
+| **Productie** | K3s (3-node HA) of RKE2 | Open source, CNCF certified, draait overal |
+
+K3s is de primaire keuze voor staging en productie vanwege de combinatie van lichtgewicht, CNCF conformance, en operationele eenvoud. Bij groei naar meerdere clusters of enterprise eisen: upgrade naar Rancher/RKE2 (dezelfde basis, meer management tooling).
+
+OpenShift/OKD is een optie als het team in een Red Hat ecosysteem zit, maar de Dockerfile aanpassingen en afwijkende standaarden maken het een grotere investering.
+
+---
+
+### 2.2 Hosting Model
+
+#### Vergelijkingsmatrix
+
+| Criterium | Bare metal | Cloud VMs (self-managed K3s) | On-premises VMs | Hybrid |
+|-----------|------------|------------------------------|-----------------|--------|
+| **Vendor lock-in** | Geen | Minimaal (VM = commodity) | Geen | Minimaal |
+| **Kosten** | Hardware CAPEX | ~€100-300/mo (3 VMs) | Hardware CAPEX | Variabel |
+| **Schaalbaarheid** | Fysiek begrensd | Minuten (VM toevoegen) | Fysiek begrensd | Flexibel |
+| **Controle** | Maximaal | Hoog | Maximaal | Medium |
+| **Operationeel** | Alles zelf | OS + K3s zelf, hardware managed | Alles zelf | Gedeeld |
+| **Data residency** | Volledig | Cloud provider afhankelijk | Volledig | Gedeeld |
+| **Open source** | Ja | Ja (K3s op elke VM) | Ja | Ja |
+
+#### Toelichting
+
+Het hosting model is onafhankelijk van de Kubernetes distributie. K3s draait op elke Linux machine — of dat nu een Hetzner VPS van €5/maand is, een dedicated server, een on-premises VM, of een Raspberry Pi.
+
+**Cloud VMs (aanbevolen start):**
+- Huur 3 VMs bij een commodity provider (Hetzner, OVH, Scaleway, DigitalOcean, of ja, ook Azure/AWS/GCP als VMs)
+- Installeer K3s: `curl -sfL https://get.k3s.io | sh -` op de eerste node, join de rest
+- Geen cloud-specifieke services nodig — alles draait in K3s
+- Verhuizen naar een andere provider = nieuwe VMs + K3s install + `helm install`
+
+**On-premises:**
+- Relevant als er data-residency eisen zijn of bestaande hardware beschikbaar is
+- Exact dezelfde K3s setup, alleen op eigen machines
+
+**Beslissing: Start met cloud VMs (commodity provider), K3s installatie. Verhuisbaar naar elke provider of on-prem zonder lock-in.**
+
+---
+
+### 2.3 Schaalbaarheid
+
+#### 2.3.1 Service classificatie
+
+| Service | Type | Replicas (min) | Scaling strategie | Toelichting |
+|---------|------|----------------|-------------------|-------------|
+| Frontend | Stateless | 2 | HPA op CPU (target 70%) | Pure SPA, alleen static files serveren. Schaalt triviaal. |
+| Backend | Semi-stateless* | 2 | HPA op CPU + custom metric | Zwaarste service. Request handling is stateless, maar async webhook callbacks maken multi-replica complex. |
+| MCP modules (9x) | Stateless | 1-2 | HPA op CPU per module | Elke module onafhankelijk schaalbaar. Coding en Docker zijn zwaarder dan registry/llm. |
+| Keycloak | Stateless (state in DB) | 2 | HPA, min 2 voor HA | Java app, 768MB per replica. Actieve JWT sessies overleven downtime. |
+| Gitea | Stateful | 1 | Geen HPA (single writer) | Git bare repos op disk. Multi-replica vereist distributed storage (niet triviaal). |
+| PostgreSQL (3x) | Stateful | 3 (via CNPG) | CloudNativePG operator | 1 primary + 2 read replicas. Operator beheert failover. |
+| Sandbox Control Plane | Stateful (SQLite) | 1 | Geen — single replica | SQLite kan niet gedeeld worden. Migratie naar PostgreSQL nodig voor multi-replica. |
+| Sandbox Manager | Stateless | 1 | Geen — K8s API is bottleneck | Thin orchestrator die K8s Jobs aanmaakt. |
+
+*Backend semi-stateless: `asyncio.create_task()` voor fire-and-forget webhook callbacks. Bij meerdere replicas kan een webhook op een andere replica landen dan waar de agent sessie actief is. Oplossing in §2.5.
+
+#### 2.3.2 HPA (Horizontal Pod Autoscaler)
+
+HPA schaalt het aantal pods horizontaal op basis van metrics. Elke stateless service krijgt een eigen HPA.
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: druppie-backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: druppie-backend
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60    # Wacht 60s voor verdere scale-up
+      policies:
+        - type: Pods
+          value: 2                       # Max 2 pods per keer toevoegen
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300    # 5 min wachten voor scale-down (voorkom oscillatie)
+```
+
+De `behavior` sectie is cruciaal voor AI workloads: zonder stabilization window reageert HPA op elke korte spike, waardoor pods constant op- en afschalen (oscillatie).
+
+#### 2.3.3 VPA (Vertical Pod Autoscaler)
+
+VPA past resource requests/limits per pod aan (meer CPU/RAM per pod ipv meer pods). Wij gebruiken VPA **alleen in recommendation mode** — het geeft advies maar past niets automatisch aan. Reden: VPA in auto-mode herstart pods om nieuwe limits toe te passen, wat onacceptabel is voor langlopende agent sessies.
+
+Workflow: VPA draait mee, we lezen periodiek de recommendations uit, en passen `values.yaml` handmatig aan.
+
+```bash
+kubectl get vpa druppie-backend -o jsonpath='{.status.recommendation}'
+```
+
+#### 2.3.4 KEDA voor bursty LLM workloads
+
+Druppie's LLM calls zijn I/O-bound (wachten op externe API response), niet CPU-bound. CPU-based HPA reageert daardoor te laat op load spikes — de pods wachten op netwerk, niet op CPU.
+
+**KEDA** (Kubernetes Event-Driven Autoscaling, CNCF Graduated, open source) lost dit op door te schalen op applicatie-specifieke metrics in plaats van alleen CPU/memory.
+
+| Aanpak | Metric | Reactiviteit | Complexiteit |
+|--------|--------|-------------|--------------|
+| HPA op CPU | `cpu.utilization` | Traag (I/O-bound = lage CPU) | Laag |
+| HPA op custom metric | `druppie_active_sessions` | Medium | Medium |
+| **KEDA op queue depth** | `druppie_pending_agent_runs` (DB query via Prometheus) | **Snel** | Medium |
+| KEDA scale-to-zero | Zelfde + `minReplicaCount: 0` | Snel | Medium |
+
+KEDA is open source (Apache 2.0), draait als operator in het cluster, en werkt met elke Kubernetes distributie. Het ondersteunt 60+ event sources waaronder Prometheus, PostgreSQL, Redis, en HTTP endpoints.
+
+Concrete toepassing voor Druppie:
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: druppie-backend
+spec:
+  scaleTargetRef:
+    name: druppie-backend
+  minReplicaCount: 2
+  maxReplicaCount: 10
+  cooldownPeriod: 360            # Alleen voor scale-to-zero
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus:9090
+        metricName: druppie_pending_agent_runs
+        query: sum(druppie_pending_agent_runs)
+        threshold: "5"           # Scale up bij >5 pending runs
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Percent
+              value: 50          # Max 50% afschalen per keer
+              periodSeconds: 60
+```
+
+Belangrijk detail: KEDA's `cooldownPeriod` geldt **alleen** bij scale-to-zero (van 0 naar 1 replica). Voor 1-to-N scaling gebruikt KEDA de Kubernetes HPA direct, inclusief de `behavior` settings hierboven. [[bron](https://docs.vllm.ai/projects/production-stack/en/latest/use_cases/autoscaling-keda.html)]
+
+**Fasering:** Fase 1 start met HPA op CPU (simpel, werkt). Fase 2 voegt KEDA toe voor preciezere scaling op basis van daadwerkelijke workload.
+
+---
+
+### 2.4 Database Strategie
+
+#### Vergelijkingsmatrix
+
+| Criterium | Container PG (huidig) | CloudNativePG | CrunchyData PGO | Zalando PG Operator | Managed DB (cloud) |
+|-----------|----------------------|---------------|------------------|---------------------|-------------------|
+| **Licentie** | PostgreSQL License | Apache 2.0 | Apache 2.0 | MIT | Proprietary |
+| **CNCF status** | n.v.t. | Sandbox | Geen | Geen | n.v.t. |
+| **HA (auto-failover)** | Nee | Ja (<30s) | Ja | Ja | Ja |
+| **Streaming replication** | Nee | Ja (sync + async) | Ja (pgBouncer) | Ja (Patroni) | Ja |
+| **Continuous backup** | Nee | Barman (S3/MinIO/GCS) | pgBackRest (S3/MinIO) | WAL-G (S3/MinIO) | Automatisch |
+| **Point-in-time recovery** | Nee | Ja | Ja | Ja | Ja |
+| **Rolling updates** | Nee (downtime) | Ja (zero-downtime) | Ja | Ja | Automatisch |
+| **Monitoring** | Handmatig | PodMonitor + Grafana | pgMonitor | Geen standaard | Cloud dashboard |
+| **Connection pooling** | Nee | PgBouncer (ingebouwd) | PgBouncer (ingebouwd) | Geen standaard | Afhankelijk |
+| **Operationeel effort** | Laag (dev only) | Medium | Hoog | Medium | Laag |
+| **CRD count** | 0 | 6 | 19 | 9 | 0 |
+| **Vendor lock-in** | Nee | Nee | Nee | Nee | **Ja** |
+| **Maturity** | n.v.t. | GA (v1.29+) | GA (v5.7+) | GA (v1.12+) | n.v.t. |
+| **Maintainer** | n.v.t. | EnterpriseDB + community | Crunchy Data | Zalando | Cloud provider |
+
+#### Toelichting per optie
+
+**CloudNativePG (aanbevolen)**
+
+CloudNativePG is de meest Kubernetes-native PostgreSQL operator. "Kubernetes-native" betekent hier: het is ontworpen om PostgreSQL te beheren als een Kubernetes-native resource via CRDs, niet als een wrapper rond bestaande tools. Het is het enige PostgreSQL project met CNCF Sandbox status.
+
+Wat het doet:
+- Beheert de volledige PostgreSQL lifecycle: provisioning, replicatie, failover, backup, restore, upgrades
+- 1 primary + N read replicas met streaming replication
+- Automatische failover bij primary failure (<30s)
+- Continuous backup naar S3-compatible object storage (MinIO, Ceph, of cloud S3)
+- Point-in-time recovery: herstel de database naar elk moment in de tijd
+- Zero-downtime rolling updates voor minor PostgreSQL versies
+- Ingebouwde PgBouncer connection pooling
+- Prometheus metrics export met PodMonitor
+
+Eén CloudNativePG operator beheert alle 3 Druppie databases (app, keycloak, gitea) als aparte Cluster CRDs.
+
+**Belangrijk: Security advisory (mei 2026):**
+CloudNativePG v1.29.1 (8 mei 2026) fixt **CVE-2026-44477** (CVSS v4: 9.4, Critical) — superuser privilege escalation + arbitrary OS command execution via de metrics exporter. Dezelfde release fixt ook drie onafhankelijke HA failover bugs. **Altijd v1.29.1+ gebruiken.** [[bron](https://cloudnative-pg.io/releases/cloudnative-pg-1-29.1-released/)]
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: druppie-db
+spec:
+  instances: 3
+  postgresql:
+    parameters:
+      shared_buffers: "256MB"
+      max_connections: "200"
+  storage:
+    size: 20Gi
+    storageClass: longhorn        # of local-path, of elke CSI driver
+  backup:
+    barmanObjectStore:
+      destinationPath: "s3://druppie-backups/db"
+      endpointURL: "http://minio:9000"   # MinIO voor on-prem S3
+      s3Credentials:
+        accessKeyId:
+          name: minio-creds
+          key: access-key
+        secretAccessKey:
+          name: minio-creds
+          key: secret-key
+    retentionPolicy: "30d"
+  monitoring:
+    enablePodMonitor: true
+```
+
+**CrunchyData PGO**
+
+Crunchy Postgres Operator is ouder en feature-rijker dan CloudNativePG, maar ook complexer. Het gebruikt 19 CRDs (vs 6 voor CNPG) en heeft pgBackRest als backup tool (krachtig maar complexere configuratie). PGO heeft geen CNCF status maar is goed onderhouden door Crunchy Data.
+
+Wanneer PGO overwegen: als je al ervaring hebt met pgBackRest, of specifieke features nodig hebt die CNPG (nog) niet biedt (bijv. pgBouncer connection pooling tuning, multi-cluster replication).
+
+**Zalando PostgreSQL Operator**
+
+De Zalando operator (Patroni-gebaseerd) was een van de eerste PG operators en wordt intern bij Zalando gebruikt voor 1000+ databases. Het is minder actief onderhouden dan CNPG en PGO, en heeft geen ingebouwde backup oplossing (WAL-G moet apart geconfigureerd worden).
+
+**Beslissing: CloudNativePG voor alle omgevingen.**
+
+Reden: CNCF status, laagste operationeel effort van de operators, actieve community, volledige feature set voor Druppie's behoeften. Container PostgreSQL blijft beschikbaar in het Helm chart voor development.
+
+---
+
+### 2.5 High Availability
+
+#### Wat betekent HA concreet voor Druppie?
+
+| Component | Wat gebeurt er bij downtime? | Impact | Minimale HA |
+|-----------|------------------------------|--------|-------------|
+| **PostgreSQL** | Alle API calls falen, agents stoppen, UI toont errors | **Kritiek** | 3 replicas (CNPG auto-failover) |
+| **Backend** | Geen chat, geen agent execution, webhooks falen | **Hoog** | 2+ replicas + PDB |
+| **Keycloak** | Nieuwe logins falen. Bestaande sessies werken door (JWT is self-contained) | Medium | 2 replicas |
+| **Frontend** | Gebruikers zien 502/503 | Medium | 2 replicas |
+| **Gitea** | Git operations falen, agent code pushes gestopt | Medium | 1 replica + PVC + backup |
+| **MCP modules** | Specifieke agent tools onbeschikbaar (bijv. geen file ops zonder module-coding) | Laag-Medium | 1-2 replicas per module |
+| **Sandbox control plane** | Nieuwe sandbox tasks falen, lopende sandboxes draaien door | Medium | 1 replica (SQLite beperking) |
+
+#### HA instrumenten
+
+**PodDisruptionBudget (PDB):** Garandeert dat Kubernetes nooit alle pods tegelijk weghaalt tijdens onderhoud (node drain, rolling update).
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: druppie-backend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: druppie-backend
+```
+
+**Pod Anti-Affinity:** Spreidt pods over verschillende nodes zodat een node failure niet alle replicas raakt.
+
+```yaml
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: druppie-backend
+          topologyKey: kubernetes.io/hostname
+```
+
+**Graceful shutdown:** Backend pods moeten lopende LLM calls afronden voor ze stoppen. Configureer `terminationGracePeriodSeconds: 60` en implementeer SIGTERM handling in de FastAPI app die nieuwe requests weigert maar actieve afrondt.
+
+#### Backend multi-replica uitdaging
+
+Het backend gebruikt `asyncio.create_task()` voor fire-and-forget webhook callbacks van sandboxes. Bij meerdere replicas kan een webhook op een andere replica landen dan waar de agent sessie actief is in memory.
+
+| Oplossing | Complexity | Robuustheid | Extra infra |
+|-----------|------------|-------------|-------------|
+| Sticky sessions (Ingress) | Laag | Fragiel (pod restart = sessie kwijt) | Geen |
+| Redis task queue | Medium | Robuust | Redis |
+| **Database-driven resume** | Medium | **Zeer robuust** | Geen |
+
+**Aanbeveling: Database-driven resume.** De huidige `reconstruct_from_db()` functie in `druppie/agents/message_history.py` rebuildt al agent state vanuit de database. De webhook handler hoeft alleen de ToolCall record in de DB bij te werken — elke backend replica kan de agent vervolgens oppakken en doorgaan. Dit sluit aan bij het bestaande patroon en vereist geen nieuwe infrastructuur.
+
+---
+
+### 2.6 Sandbox Strategie in Kubernetes
+
+Dit is de **meest complexe uitdaging**. De sandbox-manager spawnt Docker containers via de Docker socket, wat in Kubernetes niet native werkt.
+
+#### Vergelijkingsmatrix
+
+| Criterium | Docker socket mount | DinD sidecar | K8s Jobs (handmatig) | agent-sandbox (SIG Apps) | Kata Containers | gVisor | Sysbox |
+|-----------|--------------------|--------------|--------------------|--------------------------|-----------------|--------|--------|
+| **Licentie** | n.v.t. | Apache 2.0 | n.v.t. (K8s native) | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 |
+| **Security** | Slecht (root op host) | Matig | Goed | Goed-Zeer goed | Zeer goed (VM isolatie) | Goed (user-space kernel) | Goed (user namespaces) |
+| **Isolatie level** | Geen (host Docker) | Container-in-container | Pod-level | Pod + runtime | **VM-level (guest kernel)** | Kernel-level (syscall filter) | Kernel-level (user NS) |
+| **Cold start** | ~1-2s | ~3-5s | ~3-5s (pod scheduling) | <1s (WarmPool) | ~150-600ms | ~50-100ms | ~1-2s |
+| **Memory overhead** | 0 | ~100MB | 0 | ~20-50MB (WarmPool) | ~60-120MB per pod | ~20-50MB per pod | ~50MB |
+| **K8s native** | Nee | Nee | Ja | **Ja (CRD-based)** | Ja (RuntimeClass) | Ja (RuntimeClass) | Nee (CRI-O only) |
+| **Warm pool support** | Nee | Nee | Zelf bouwen | **Ja (SandboxWarmPool CRD)** | Nee | Nee | Nee |
+| **Python SDK** | Docker SDK | Docker SDK | kubernetes client | **Ja** | Nee | Nee | Nee |
+| **Maturity** | n.v.t. | Stabiel | Stabiel | **v1alpha1 (v0.4.6)** | Stabiel (3.x) | Stabiel | Community-maintained |
+| **Productie bewezen** | Overal | Veel | Veel | Vroeg stadium | Northflank (2M+ microVMs/mo) | Google (GKE Sandbox) | Beperkt |
+| **Operationele pages** | n.v.t. | Onbekend | Laag | Onbekend | 3.4x vs standaard | Laag | Onbekend |
+
+#### Agent Sandbox (kubernetes-sigs/agent-sandbox) — primaire keuze
+
+Het Kubernetes SIG Apps project **Agent Sandbox** is in november 2025 gelanceerd door Google op KubeCon Atlanta. Het biedt precies wat Druppie nodig heeft: een CRD-gebaseerde operator voor het spawnen van geïsoleerde sandbox-omgevingen voor AI-agents. [[bron](https://kubernetes.io/blog/2026/03/20/running-agents-on-kubernetes-with-agent-sandbox/)]
+
+Het officiële Kubernetes blog beschrijft het probleem: *"While you could theoretically approximate this by stringing together a StatefulSet of size 1, a headless Service, and a PersistentVolumeClaim for every single agent, managing this at scale becomes an operational nightmare."*
+
+Wat Agent Sandbox biedt:
+- **Sandbox CRD:** Creëert een geïsoleerde pod met configurable runtime (gVisor, Kata, of standaard)
+- **SandboxTemplate:** Herbruikbare sandbox definities (resources, security context, volumes)
+- **SandboxClaim:** Request-based model — agents claimen een sandbox uit een pool
+- **SandboxWarmPool:** Pre-warmed pods die klaarstaan, waardoor cold start < 1 seconde
+- **Python SDK:** Directe integratie met onze Python sandbox-manager
+- **Lifecycle management:** Automatische cleanup, TTL, resource tracking
+
+```yaml
+apiVersion: sandbox.k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: druppie-coding-sandbox
+spec:
+  runtimeClassName: gvisor
+  resources:
+    limits:
+      memory: "4Gi"
+      cpu: "2"
+  securityContext:
+    runAsUser: 1000
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+---
+apiVersion: sandbox.k8s.io/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: druppie-warm-sandboxes
+spec:
+  templateRef: druppie-coding-sandbox
+  minReady: 2
+  maxSize: 10
+```
+
+**Risico:** v1alpha1 API kan veranderen voor GA. Mitigatie: fallback op K8s Jobs (zie onder).
+
+#### Fallback: Kubernetes Jobs
+
+Als Agent Sandbox te onvolwassen blijkt, is de fallback om `docker_manager.py` te vervangen door een `k8s_manager.py` die Kubernetes Jobs aanmaakt via de `kubernetes` Python client:
+
+| Docker flag (huidig) | Kubernetes equivalent |
+|---------------------|----------------------|
+| `--memory=4g` | `resources.limits.memory: 4Gi` |
+| `--cpus=2` | `resources.limits.cpu: "2"` |
+| `--cap-drop=ALL --cap-add=NET_RAW` | `securityContext.capabilities` |
+| `--security-opt=no-new-privileges` | `securityContext.allowPrivilegeEscalation: false` |
+| `--network=sandbox-network` | NetworkPolicy (dedicated namespace) |
+| `--pids-limit=4096` | RuntimeClass of cgroup configuratie |
+
+#### Runtime isolatie: gVisor vs Kata Containers
+
+Beide zijn open source runtimes die als `RuntimeClass` in Kubernetes draaien. Agent Sandbox ondersteunt beide.
+
+| Criterium | gVisor (runsc) | Kata Containers (3.x) |
+|-----------|----------------|----------------------|
+| **Hoe het werkt** | User-space kernel die syscalls filtert en vertaalt. Container deelt geen kernel met host. | Elke container draait in een eigen lightweight VM met dedicated guest kernel. |
+| **Isolatie** | Sterk — 370+ syscalls geïmplementeerd in Go, onbekende syscalls geblokkeerd | Zeer sterk — hardware virtualisatie (AMD-V/VT-x), volledige kernel isolatie |
+| **Cold start** | ~50-100ms | ~150-600ms |
+| **Memory overhead** | ~20-50MB per pod | ~60-120MB per pod |
+| **Performance impact** | Laag voor I/O, hoger voor syscall-heavy workloads | 8-12% steady-state overhead |
+| **Compatibility** | Meeste Linux programma's werken, sommige syscalls ontbreken | Vrijwel 100% Linux compatibility (volledige kernel) |
+| **Operationeel** | Simpeler (geen VM management) | Complexer, 3.4x meer on-call pages dan standaard containers |
+| **Productie** | Google GKE Sandbox (miljoenen containers) | Northflank (2M+ microVMs/maand) |
+| **Geschikt voor Druppie** | **Ja** — code execution + git push = I/O bound, niet syscall-heavy | Ja, maar overkill voor huidige use case |
+
+**Aanbeveling: Start met gVisor.** Lagere overhead, simpeler operationeel, voldoende isolatie voor code execution sandboxes. Upgrade naar Kata als er multi-tenant isolatie-eisen komen (bijv. sandboxes van verschillende organisaties op dezelfde nodes).
+
+**Sysbox — niet aanbevolen:**
+- Officieel alleen CRI-O support; containerd integratie "still evolving" (nestybox/sysbox#997)
+- Community-maintained op best-effort basis na Nestybox acquisitie door Docker
+- Deelt host kernel — zwakkere isolatie dan gVisor en Kata
+
+#### Codebase wijzigingen
+
+1. `sandbox-manager`: Vervang `docker_manager.py` door `k8s_manager.py` (Kubernetes Python client of Agent Sandbox SDK)
+2. NetworkPolicy: dedicated `druppie-sandboxes` namespace, alleen communicatie met control-plane
+3. Container registry: sandbox image via registry (Harbor, zie §2.9) ipv `kind load`
+4. Resource limits: Configureerbaar via Helm values (al voorbereid in `values.yaml` als `sandbox.memoryLimit`/`sandbox.cpuLimit`)
+
+---
+
+### 2.7 Shared Volume Strategie (RWX)
+
+Het `workspace` volume wordt gedeeld door 4 services: backend, module-coding, module-docker, module-data-access. Dit vereist ReadWriteMany (RWX) — meerdere pods schrijven naar hetzelfde volume.
+
+#### Vergelijkingsmatrix
+
+| Criterium | NFS server (handmatig) | Longhorn | Rook-Ceph | OpenEBS (Mayastor) | SeaweedFS |
+|-----------|----------------------|----------|-----------|-------------------|-----------|
+| **Licentie** | GPL (NFS kernel) | Apache 2.0 | Apache 2.0 | Apache 2.0 | Apache 2.0 |
+| **CNCF status** | n.v.t. | CNCF Sandbox | CNCF Graduated | CNCF Sandbox | Geen |
+| **RWX support** | Ja (native) | Ja (via NFS export) | Ja (CephFS) | Nee (alleen RWO) | Ja (FUSE mount) |
+| **Performance** | Medium (network I/O) | Medium | Goed | Zeer goed (NVMe) | Medium |
+| **Replicatie** | Nee (single point of failure) | Ja (2-3 replicas) | Ja (configurable) | Ja (sync) | Ja |
+| **Operationeel effort** | Laag | **Laag** (Rancher UI) | Hoog | Medium | Medium |
+| **Disk overhead** | 0% | 2-3x (replica factor) | 2-3x (replica factor) | 2-3x | 1-3x |
+| **Minimale nodes** | 1 | 3 (voor replicatie) | 3 | 3 | 3 |
+| **Geschikt voor Druppie** | Ja (dev/staging) | **Ja** | Ja (maar overkill) | Nee (geen RWX) | Ja |
+
+#### Toelichting
+
+**Longhorn (aanbevolen)**
+
+Longhorn is een CNCF Sandbox distributed block storage system, gebouwd door Rancher Labs. Het biedt replicated block storage met snapshots, backups, en disaster recovery. RWX support werkt via een ingebouwde NFS server per volume.
+
+Waarom Longhorn voor Druppie:
+- Lichtgewicht: ontworpen voor edge en small clusters (past bij K3s)
+- RWX via NFS: elke RWX PVC krijgt automatisch een NFS share-manager pod
+- Eenvoudige installatie: `helm install longhorn longhorn/longhorn`
+- UI dashboard voor volume management
+- Backup naar S3-compatible storage (MinIO)
+- Integreert naadloos met K3s en Rancher
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: druppie-workspace
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 50Gi
+```
+
+**Rook-Ceph** is krachtiger (object + block + file storage) maar vereist meer resources (3+ dedicated storage nodes, meer RAM) en is complexer te beheren. Overkill voor Druppie's workspace volume.
+
+**NFS server** (simple pod met NFS export) werkt voor dev/staging maar is een single point of failure zonder replicatie.
+
+**Fase 2 doel — per-session workspace eliminatie:**
+
+De architectureel betere oplossing is het shared workspace volume volledig te elimineren:
+- Elke agent session krijgt een eigen `emptyDir` of ephemeral PVC
+- MCP modules communiceren via de backend als proxy (geen directe volume access)
+- Dit elimineert de RWX dependency volledig en verbetert de isolatie
+
+---
+
+### 2.8 Deployment Strategie
+
+#### Vergelijkingsmatrix
+
+| Criterium | Helm + CI/CD | ArgoCD | FluxCD |
+|-----------|-------------|--------|--------|
+| **Licentie** | Apache 2.0 | Apache 2.0 | Apache 2.0 |
+| **CNCF status** | CNCF Graduated (Helm) | CNCF Graduated | CNCF Graduated |
+| **Model** | Push-based (CI pusht naar cluster) | Pull-based (cluster pull van git) | Pull-based |
+| **GitOps** | Nee (git = source, niet state) | **Ja** (git = desired state) | **Ja** |
+| **Drift detection** | Nee | **Ja** (auto-detect config drift) | **Ja** |
+| **Rollback** | `helm rollback` (handmatig) | Git revert = auto rollback | Git revert = auto rollback |
+| **Multi-env** | Helm values per env | ApplicationSet | Kustomize overlays |
+| **UI** | Geen | **Web dashboard** | Geen (CLI only) |
+| **Helm support** | Native | Ja (Helm chart rendering) | Ja (HelmRelease CRD) |
+| **Leercurve** | Laag | Medium | Medium |
+| **Extra infra** | Geen | ArgoCD server in cluster | Flux controllers in cluster |
+| **Notificaties** | Via CI (GitHub Actions) | Slack/webhook integratie | Slack/webhook integratie |
+
+#### Toelichting
+
+**Fase 1: Helm + CI/CD (GitHub Actions)**
+
+Het Helm chart bestaat al en werkt op Kind. De snelste weg naar productie is een CI/CD pipeline die:
+1. Docker images bouwt en pusht naar een container registry
+2. `helm upgrade` uitvoert op het K3s cluster
+
+```yaml
+# .github/workflows/deploy.yml
+- name: Deploy to K3s
+  run: |
+    helm upgrade druppie helm/druppie/ \
+      --namespace druppie \
+      --values helm/druppie/values-prod.yaml \
+      --set global.imageRegistry=$REGISTRY/ \
+      --set secrets.zaiApiKey=${{ secrets.ZAI_API_KEY }} \
+      --wait --timeout 600s
+```
+
+Push-based deployment is simpel en werkt, maar heeft nadelen: als iemand handmatig iets wijzigt in het cluster (kubectl edit), detecteert niemand die drift.
+
+**Fase 2: ArgoCD**
+
+ArgoCD maakt het cluster declaratief: de git repository is de single source of truth. ArgoCD vergelijkt continu de gewenste state (git) met de actuele state (cluster) en reconcilieert automatisch.
+
+Voeg ArgoCD toe wanneer:
+- Er meerdere omgevingen zijn (dev/staging/prod) — ApplicationSet maakt dit trivial
+- Het team groeit en er behoefte is aan audit trail (wie deployede wat wanneer)
+- Er drift detection nodig is (voorkomen dat handmatige cluster wijzigingen onopgemerkt blijven)
+
+ArgoCD vs FluxCD: ArgoCD heeft een web dashboard (handig voor teams), FluxCD is meer CLI-driven. Beide zijn CNCF Graduated. ArgoCD is populairder (16k+ GitHub stars) en heeft betere Helm support.
+
+---
+
+### 2.9 Container Registry
+
+#### Vergelijkingsmatrix
+
+| Criterium | Harbor | Gitea Container Registry | Docker Distribution | Zot | GitHub GHCR |
+|-----------|--------|--------------------------|--------------------|----|-------------|
+| **Licentie** | Apache 2.0 | MIT | Apache 2.0 | Apache 2.0 | Proprietary |
+| **CNCF status** | CNCF Graduated | Geen | Geen | Geen | n.v.t. |
+| **Vulnerability scanning** | Ja (Trivy ingebouwd) | Nee | Nee | Ja (Trivy) | Ja |
+| **Image signing** | Ja (Cosign/Notary) | Nee | Nee | Ja (Cosign) | Ja |
+| **RBAC** | Ja (project-based) | Via Gitea users | Nee | Ja | Via GitHub |
+| **Replication** | Ja (multi-registry) | Nee | Nee | Nee | n.v.t. |
+| **Garbage collection** | Ja | Ja | Ja | Ja | Automatisch |
+| **Self-hosted** | Ja | Ja (al in Druppie!) | Ja | Ja | Nee |
+| **Helm chart storage** | Ja (OCI) | Ja (OCI) | Nee | Ja (OCI) | Ja |
+| **Operationeel effort** | Medium | **Laag (al draait)** | Laag | Laag | Geen |
+
+**Beslissing: Gitea Container Registry voor fase 1, Harbor voor fase 2.**
+
+Gitea (die al in Druppie draait) heeft een ingebouwde OCI-compatible container registry. Dit betekent nul extra infrastructuur — we pushen images naar dezelfde Gitea instance die al onze git repos host.
+
+Harbor toevoegen als er vulnerability scanning, image signing, of multi-registry replication nodig is.
+
+---
+
+### 2.10 Networking / Ingress
+
+#### Vergelijkingsmatrix
+
+| Criterium | NGINX Ingress | Traefik | HAProxy Ingress | Cilium Ingress |
+|-----------|--------------|---------|-----------------|----------------|
+| **Licentie** | Apache 2.0 | MIT | Apache 2.0 | Apache 2.0 |
+| **CNCF status** | Geen (K8s SIG) | Geen | Geen | CNCF Graduated |
+| **Protocol** | HTTP/HTTPS/gRPC/WebSocket | HTTP/HTTPS/gRPC/TCP/UDP | HTTP/HTTPS/TCP | HTTP/HTTPS/gRPC |
+| **Auto-discovery** | Via Ingress resources | Via Ingress + IngressRoute CRD | Via Ingress | Via Ingress + Gateway API |
+| **TLS termination** | Ja (cert-manager) | Ja (ingebouwd ACME + cert-manager) | Ja | Ja |
+| **Rate limiting** | Via annotations | Via middleware CRD | Via config | Via CiliumNetworkPolicy |
+| **WAF** | ModSecurity plugin | Nee (apart) | Nee | Nee |
+| **Observability** | Prometheus metrics | Prometheus + Datadog + Jaeger | Prometheus | Hubble (eBPF) |
+| **K3s standaard** | Nee | **Ja** | Nee | Nee |
+| **Performance** | Goed | Goed | Zeer goed | Zeer goed (eBPF) |
+| **Configuratie** | Annotations (kan rommelig worden) | Middleware CRDs (gestructureerd) | Config file | Gateway API (standaard K8s) |
+| **Leercurve** | Laag | Laag-Medium | Medium | Medium-Hoog |
+
+**Beslissing: Traefik (K3s standaard), met NGINX als alternatief.**
+
+K3s installeert Traefik standaard als ingress controller. Ons Helm chart gebruikt nu NGINX (voor Kind), maar Traefik biedt voordelen:
+- Ingebouwde ACME/Let's Encrypt support (geen aparte cert-manager nodig, hoewel cert-manager ook werkt)
+- Middleware CRDs voor rate limiting, headers, auth — schoner dan NGINX annotations
+- Dashboard voor real-time traffic monitoring
+- IngressRoute CRD voor complexere routing regels
+
+Het Helm chart moet beide ondersteunen via `global.ingress.className: traefik | nginx`.
+
+```yaml
+# Traefik IngressRoute (alternatief voor standaard Ingress)
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: druppie
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`druppie.example.com`) && PathPrefix(`/api`)
+      kind: Rule
+      services:
+        - name: druppie-backend
+          port: 8000
+    - match: Host(`druppie.example.com`)
+      kind: Rule
+      services:
+        - name: druppie-frontend
+          port: 5173
+  tls:
+    certResolver: letsencrypt
+```
+
+TLS voor productie via **cert-manager** (open source, CNCF project) + Let's Encrypt:
+
+```bash
+helm install cert-manager jetstack/cert-manager --set installCRDs=true
+```
+
+---
+
+### 2.11 Secrets Management
+
+#### Vergelijkingsmatrix
+
+| Criterium | Helm values (huidig) | Sealed Secrets | External Secrets Operator | HashiCorp Vault | SOPS + age |
+|-----------|---------------------|----------------|---------------------------|-----------------|------------|
+| **Licentie** | Apache 2.0 (Helm) | Apache 2.0 | Apache 2.0 | BSL 1.1 (niet open source!) | Apache 2.0 / MIT |
+| **Versleuteld in git** | Nee (plaintext) | **Ja** (asymmetrisch) | Nee (secrets in extern systeem) | Nee | **Ja** (symmetrisch/asymmetrisch) |
+| **Automatische rotation** | Nee | Nee | **Ja** (sync interval) | **Ja** | Nee |
+| **Audit trail** | Nee | Via git history | Via external store | **Ja (uitgebreid)** | Via git history |
+| **Extra infra nodig** | Geen | Controller in cluster | Controller + external store | **Vault cluster (3+ nodes)** | Geen |
+| **Complexiteit** | Laag | **Laag** | Medium | **Hoog** | **Laag** |
+| **Multi-cluster** | Nee | Nee (per-cluster keys) | Ja | Ja | Ja (zelfde key) |
+| **Backup/recovery** | n.v.t. | Cluster key backup! | Via external store | Vault HA + unsealing | Key file backup |
+| **Druppie secrets** | API keys, DB passwords, HMAC secrets | Idem, versleuteld | Idem, extern beheerd | Idem, Vault managed | Idem, versleuteld |
+
+**Let op: HashiCorp Vault is sinds 2023 NIET meer open source** (BSL 1.1 licentie). Dit conflicteert met ons open source uitgangspunt. OpenBao is de open source fork (MPL 2.0), maar is minder volwassen.
+
+**Beslissing: Sealed Secrets voor fase 1, SOPS + age als alternatief.**
+
+**Sealed Secrets** (Bitnami, v0.27+) werkt als volgt:
+1. Een controller in het cluster genereert een asymmetrisch sleutelpaar
+2. Je versleutelt Kubernetes Secrets lokaal met de publieke sleutel: `kubeseal < secret.yaml > sealed-secret.yaml`
+3. De versleutelde SealedSecret kan veilig in git
+4. De controller in het cluster ontsleutelt het naar een gewone Kubernetes Secret
+
+```bash
+# Secret aanmaken en versleutelen
+kubectl create secret generic druppie-secrets \
+  --from-literal=zai-api-key=sk-xxx \
+  --from-literal=db-password=xxx \
+  --dry-run=client -o yaml | kubeseal > sealed-secrets.yaml
+
+# Commit naar git (veilig — versleuteld)
+git add sealed-secrets.yaml && git commit -m "Add sealed secrets"
+```
+
+**Belangrijk:** Maak een backup van de Sealed Secrets controller private key! Zonder deze key kun je bestaande sealed secrets niet ontsleutelen na een cluster rebuild.
+
+**SOPS + age** is een lichter alternatief: versleutel YAML files direct met `sops` en een `age` key. Geen controller nodig, werkt met Helm via `helm-secrets` plugin. Nadeel: geen automatische sync — je moet na elke wijziging deployen.
+
+---
+
+### 2.12 Monitoring & Observability
+
+#### Vergelijkingsmatrix
+
+| Criterium | kube-prometheus-stack | Victoria Metrics | Grafana Loki (logging) | Jaeger (tracing) |
+|-----------|----------------------|------------------|----------------------|------------------|
+| **Licentie** | Apache 2.0 | Apache 2.0 | AGPL 3.0 | Apache 2.0 |
+| **Functie** | Metrics + alerting | Metrics (Prometheus-compatible) | Log aggregatie | Distributed tracing |
+| **Resource usage** | Medium-Hoog | **Laag** (2-5x efficiënter) | Medium | Laag |
+| **Prometheus-compatible** | Native | Ja (drop-in replacement) | n.v.t. | n.v.t. |
+| **Grafana dashboards** | Ingebouwd | Ja | Ingebouwd | Via Grafana |
+| **Operationeel** | Medium | Laag | Medium | Laag |
+
+**Beslissing: kube-prometheus-stack (Prometheus + Grafana + Alertmanager).**
+
+Dit is de de-facto standaard voor Kubernetes monitoring. Eén `helm install` geeft je:
+- Prometheus voor metrics (CPU, memory, custom app metrics)
+- Grafana voor dashboards
+- Alertmanager voor notificaties (Slack, email)
+- Node-exporter voor host metrics
+- kube-state-metrics voor Kubernetes object metrics
+
+CloudNativePG exporteert automatisch PostgreSQL metrics via PodMonitor. KEDA, Traefik, en Keycloak hebben ook Prometheus endpoints.
+
+---
+
+## 3. Schaalbaarheidsvisie — Architectuur Suggesties
+
+De huidige Druppie-architectuur is ontworpen voor single-instance Docker Compose. Om echt schaalbaar te worden op Kubernetes zijn er architectuurwijzigingen nodig. Deze sectie beschrijft suggesties — geen van deze vereist de huidige codebase als beperking.
+
+### 3.1 Event-Driven Backend (huidige bottleneck elimineren)
+
+**Probleem:** Het backend verwerkt agent sessies synchroon via `asyncio.create_task()`. Dit koppelt webhook ontvangst aan de specifieke replica die de agent draait — een fundamentele belemmering voor horizontale schaalbaarheid.
+
+**Suggestie: Message queue als backbone**
+
+Introduceer een message broker (Redis Streams, NATS, of RabbitMQ — allen open source) als ontkoppelingslaag:
+
+```
+                    ┌─────────────────┐
+   User request ──► │  API Gateway    │ ──► Queue: "agent.start"
+                    │  (FastAPI)      │
+                    └─────────────────┘
+                              │
+                    ┌─────────▼─────────┐
+                    │  Agent Workers    │ ◄── Queue: "agent.start"
+                    │  (N replicas)     │ ──► Queue: "tool.execute"
+                    └───────────────────┘
+                              │
+                    ┌─────────▼─────────┐
+                    │  Tool Workers     │ ◄── Queue: "tool.execute"
+                    │  (N replicas)     │ ──► Queue: "agent.resume"
+                    └───────────────────┘
+```
+
+| Broker | Licentie | Persistence | Throughput | Complexiteit | Aanbeveling |
+|--------|----------|-------------|-----------|--------------|-------------|
+| **Redis Streams** | BSD 3-Clause | Ja (AOF/RDB) | Zeer hoog | Laag | **Fase 2** |
+| **NATS JetStream** | Apache 2.0 | Ja | Zeer hoog | Laag | Alternatief |
+| RabbitMQ | MPL 2.0 | Ja | Hoog | Medium | Alternatief |
+
+Voordelen:
+- Elke backend replica kan elke taak oppakken (geen sticky sessions)
+- Webhook → queue → willekeurige worker pakt het op
+- Scale workers onafhankelijk van API pods
+- Failed workers → message terug in queue → automatic retry
+- Backpressure: als workers vol zijn, groeien de queues, HPA/KEDA schaalt workers op
+
+### 3.2 MCP Module Mesh — Sidecar vs Centralized
+
+**Probleem:** MCP modules zijn nu standalone HTTP services met een shared workspace volume (RWX). Dit creëert een NFS/storage bottleneck en maakt scaling complex.
+
+**Suggestie A: Sidecar pattern**
+
+Draai MCP modules als sidecars naast de backend pod. Elke backend replica heeft zijn eigen set MCP modules:
+
+```
+┌─────────────────────────────────┐
+│  Pod: druppie-backend-xyz       │
+│  ┌──────────┐ ┌──────────────┐  │
+│  │ backend  │ │ module-coding │  │
+│  │          │ │ module-llm    │  │
+│  │          │ │ module-web    │  │
+│  └──────────┘ └──────────────┘  │
+│         (localhost:9001-9011)    │
+│  emptyDir: /workspace           │
+└─────────────────────────────────┘
+```
+
+Voordelen:
+- Geen netwerk latency naar MCP modules (localhost)
+- Geen shared volume nodig (elke pod heeft eigen emptyDir)
+- Schaalt automatisch mee met backend replicas
+- Simpelere NetworkPolicy (alles in één pod)
+
+Nadelen:
+- Meer resources per pod (elke replica draait alle modules)
+- Modules niet onafhankelijk schaalbaar
+- Grotere pod = langzamere scheduling
+
+**Suggestie B: Per-session microservices (geavanceerd)**
+
+Spawn MCP modules on-demand per agent sessie als tijdelijke pods:
+
+```
+Session start → spawn module-coding pod (session-123)
+             → spawn module-docker pod (session-123)
+Session end  → cleanup pods
+```
+
+Dit is wat Agent Sandbox conceptueel biedt — maar dan voor MCP modules ipv sandboxes. Voordelen: perfecte isolatie, geen shared state, schaal = meer sessie-pods.
+
+### 3.3 Database Partitioning
+
+**Probleem:** Eén PostgreSQL database voor alles. Bij groei worden de `tool_calls` en `llm_calls` tabellen enorm (elke agent sessie genereert tientallen records).
+
+**Suggesties:**
+
+| Strategie | Wat | Wanneer |
+|-----------|-----|---------|
+| **Read replicas** | CNPG read-only endpoints voor UI queries | >1000 sessies |
+| **Table partitioning** | Partitioneer `tool_calls` en `llm_calls` op `created_at` (maandelijks) | >100k records |
+| **Archive strategie** | Verplaats oude sessies naar cold storage (S3/MinIO als Parquet) | >6 maanden data |
+| **Aparte DB per concern** | Eigen CNPG cluster voor audit/logging vs operational data | Enterprise scale |
+
+```sql
+-- Voorbeeld: table partitioning op datum
+CREATE TABLE tool_calls (
+    id UUID NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    ...
+) PARTITION BY RANGE (created_at);
+
+CREATE TABLE tool_calls_2026_06 PARTITION OF tool_calls
+    FOR VALUES FROM ('2026-06-01') TO ('2026-07-01');
+```
+
+### 3.4 Sandbox Pool Pre-warming
+
+**Probleem:** Cold start voor sandboxes (pod scheduling + container pull + init) kost 3-10 seconden. Dit voelt traag voor interactieve sessies.
+
+**Suggesties:**
+
+| Strategie | Latency | Cost | Complexiteit |
+|-----------|---------|------|--------------|
+| **Agent Sandbox WarmPool** | <1s | Idle pods kosten resources | Laag (CRD config) |
+| **Pre-pulled images** | ~2-3s (skip pull) | Disk space op nodes | Laag (DaemonSet) |
+| **Snapshot/restore** | ~1-2s | Snapshot storage | Medium |
+| **Dedicated sandbox nodes** | ~3s (geen scheduling contention) | Dedicated hardware | Laag (node taint) |
+
+Agent Sandbox WarmPool is het meest elegant:
+
+```yaml
+apiVersion: sandbox.k8s.io/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: coding-sandboxes
+spec:
+  templateRef: druppie-coding-sandbox
+  minReady: 3       # Altijd 3 warme sandboxes beschikbaar
+  maxSize: 20       # Max 20 totaal
+  ttlSecondsAfterIdle: 600  # Cleanup na 10 min idle
+```
+
+### 3.5 Multi-Tenant Schaalbaarheid
+
+Als Druppie meerdere organisaties moet bedienen:
+
+| Isolation level | Hoe | Overhead | Security |
+|----------------|-----|----------|----------|
+| **Namespace per tenant** | Aparte K8s namespace met ResourceQuota en NetworkPolicy | Laag | Medium |
+| **Node pool per tenant** | Dedicated nodes via taints/tolerations | Hoog | Hoog |
+| **Cluster per tenant** | Aparte K3s clusters via Rancher | Zeer hoog | Zeer hoog |
+| **Virtuele clusters** | vCluster (open source) — virtuele K8s clusters in namespaces | Medium | Hoog |
+
+Voor Druppie is **namespace per tenant + vCluster** de sweet spot: volledige Kubernetes API isolatie zonder de overhead van aparte clusters. vCluster (open source, Loft Labs) creëert virtuele Kubernetes clusters in bestaande namespaces — elke tenant denkt een eigen cluster te hebben.
+
+### 3.6 Control Plane Schaalbaarheid
+
+**Probleem:** De sandbox-control-plane gebruikt SQLite — kan niet over meerdere replicas.
+
+**Suggestie:** Migreer control plane storage naar PostgreSQL (kan dezelfde CNPG cluster gebruiken). Dit maakt multi-replica deployment mogelijk en elimineert de last single-point-of-failure in de architectuur.
+
+Alternatief: als de control plane voornamelijk caching en session state doet, overweeg Redis als backing store (sneller dan PostgreSQL voor key-value lookups, maar minder durable).
+
+---
+
+### Fase 1 — Minimaal Productie-Ready (4-6 weken)
+
+| Item | Werk | Tooling |
+|------|------|---------|
+| K3s cluster setup | 3-node HA cluster op cloud VMs | K3s, Terraform (optioneel) |
+| Container registry | Gitea container registry configureren | Gitea (al aanwezig) |
+| CloudNativePG | Operator v1.29.1+, 3 database clusters | CloudNativePG operator |
+| Longhorn storage | Installatie, RWX PVC voor workspace | Longhorn |
+| Helm chart updates | `values-k3s.yaml` overlay, Traefik config | Helm |
+| TLS certificaten | cert-manager + Let's Encrypt | cert-manager |
+| Sealed Secrets | API keys, DB passwords versleuteld in git | Sealed Secrets |
+| CI/CD pipeline | GitHub Actions: build → push → helm upgrade | GitHub Actions |
+| Monitoring | kube-prometheus-stack installatie | Prometheus, Grafana |
+| Sandbox als K8s Jobs | Refactor sandbox-manager (fallback voor Agent Sandbox) | Kubernetes Python client |
+
+### Fase 2 — Schaalbaar & Operationeel (6-10 weken)
+
+| Item | Werk | Tooling |
+|------|------|---------|
+| Agent Sandbox | Evalueer en adopteer kubernetes-sigs/agent-sandbox | Agent Sandbox operator |
+| HPA voor stateless services | CPU + custom metrics per service | HPA, Prometheus |
+| KEDA | Event-driven autoscaling op queue depth | KEDA |
+| ArgoCD | GitOps deployment pipeline | ArgoCD |
+| Backend multi-replica | Database-driven resume pattern implementeren | Applicatie code |
+| Per-session workspace | Elimineer shared RWX volume | Architectuur refactor |
+| gVisor runtime | RuntimeClass configuratie voor sandboxes | gVisor |
+| Network Policies | Per-namespace isolation | Kubernetes NetworkPolicy |
+| Harbor registry | Vulnerability scanning, image signing | Harbor |
+
+### Fase 3 — Enterprise-Ready (optioneel)
+
+| Item | Werk | Tooling |
+|------|------|---------|
+| Rancher management | Multi-cluster beheer via UI | Rancher |
+| Kata Containers | VM-level isolatie voor multi-tenant | Kata Containers |
+| Database read replicas | CloudNativePG read-only endpoints voor reporting | CloudNativePG |
+| Distributed tracing | Request tracing door alle services | Jaeger |
+| Chaos engineering | Failure testing | Litmus (CNCF) |
+| Backup/DR | Cluster-level backup en disaster recovery | Velero (open source) |
+
+---
+
+## 5. Risico's
+
+| Risico | Impact | Kans | Mitigatie |
+|--------|--------|------|-----------|
+| Agent Sandbox te onvolwassen (v1alpha1) | Sandbox refactor vertraagd | Medium | Start met K8s Jobs als fallback; evalueer Agent Sandbox parallel |
+| Longhorn RWX performance onvoldoende | Trage workspace file operations | Laag | Benchmark vroeg; fallback = NFS server pod |
+| CloudNativePG operationele kennis ontbreekt | Database issues in productie | Medium | Training + runbooks schrijven; test failover scenario's op staging |
+| Backend multi-replica race conditions | Data inconsistentie bij webhooks | Medium | Fase 1 draait single replica; fase 2 implementeert DB-driven resume |
+| K3s cluster management overhead | Meer ops werk dan verwacht | Laag | K3s is minimaal; bij groei upgrade naar Rancher |
+| Sealed Secrets key verloren | Alle secrets ontoegankelijk na cluster rebuild | Medium | Key backup procedure documenteren en testen |
+
+---
+
+## 6. Aannames
+
+1. Het team heeft basis Kubernetes kennis of is bereid dit op te bouwen.
+2. Er is geen strict data-residency vereiste dat een specifieke hosting locatie afdwingt.
+3. De huidige load past op een 3-node cluster (4 vCPU, 16GB RAM per node).
+4. Sandboxes hoeven geen Docker-in-Docker te draaien (alleen code execution + git).
+5. Er is geen 99.99% uptime SLA vereist in fase 1.
+6. Alle tooling moet open source zijn (Apache 2.0, MIT, GPL, MPL — geen BSL of proprietary).
+
+---
+
+## 7. Kostenschatting
+
+### Optie A: Cloud VMs (bijv. Hetzner)
+
+| Component | Specificatie | Geschatte kosten/maand |
+|-----------|-------------|----------------------|
+| Server nodes (3x) | CPX31 (4 vCPU, 8GB RAM, 160GB NVMe) | 3 × €13 = ~€39 |
+| Extra storage | 200GB block storage voor Longhorn | ~€10 |
+| Load balancer | Hetzner LB | ~€6 |
+| Backup storage | 100GB (DB backups via MinIO/S3) | ~€5 |
+| **Totaal** | | **~€60/maand** |
+
+### Optie B: Dedicated servers (hogere performance)
+
+| Component | Specificatie | Geschatte kosten/maand |
+|-----------|-------------|----------------------|
+| Server nodes (3x) | AX42 (8 vCPU, 64GB RAM, 2x512GB NVMe) | 3 × €49 = ~€147 |
+| **Totaal** | | **~€147/maand** |
+
+### Optie C: On-premises (bestaande hardware)
+
+| Component | Specificatie | Kosten |
+|-----------|-------------|--------|
+| Hardware | 3 servers (bestaand) | €0 (al beschikbaar) |
+| Stroom + koeling | Afhankelijk van locatie | Variabel |
+| **Totaal** | | **€0 + stroom** |
+
+Opmerking: Sandbox workloads zijn bursty. Overweeg een aparte worker node die aan/uit gezet wordt voor sandboxes (K3s agent join/leave is triviaal).
+
+---
+
+## 8. Vervolgstappen
+
+1. **Spike: Agent Sandbox evaluatie** — Installeer operator op Kind, test Python SDK als vervanging voor `docker_manager.py`. Fallback: K8s Jobs. Dit is het grootste technische risico.
+2. **K3s staging cluster** — Zet een 3-node K3s HA cluster op (cloud VMs of on-prem). Test het volledige Helm chart.
+3. **CloudNativePG test** — Deploy operator v1.29.1+ op Kind, test HA failover en backup/restore naar MinIO.
+4. **Longhorn benchmark** — Meet RWX performance voor workspace volume (git clone, file write throughput).
+5. **CI/CD pipeline** — GitHub Actions: build → push naar Gitea registry → helm upgrade op K3s.
+6. **Helm chart updates** — `values-k3s.yaml`, Traefik/NGINX toggle, Longhorn StorageClass.
+
+---
+
+## 9. Kanttekeningen bij dit onderzoek
+
+- **Agent Sandbox is v1alpha1** (pre-stable) — API kan significant veranderen voor GA. Fallback op K8s Jobs moet klaarliggen.
+- **CloudNativePG CVE-2026-44477** vereist onmiddellijke patching bij elke productie-inzet.
+- **Sysbox risico:** Containerd integratie is "still evolving" met best-effort community support — niet aanbevolen.
+- **HashiCorp Vault** is geen open source meer (BSL 1.1 sinds 2023). OpenBao (MPL 2.0 fork) is een alternatief maar minder volwassen.
+- **Kostenschattingen** zijn indicatief en gebaseerd op publieke prijzen (juni 2026). Werkelijke kosten variëren per provider en gebruik.
+
+---
+
+## 10. Referenties
+
+### Geverifieerd via deep research (adversarial verification, 23/25 claims bevestigd)
+
+- [Agent Sandbox — Kubernetes blog](https://kubernetes.io/blog/2026/03/20/running-agents-on-kubernetes-with-agent-sandbox/)
+- [Agent Sandbox — Google Open Source blog](https://opensource.googleblog.com/2025/11/unleashing-autonomous-ai-agents-why-kubernetes-needs-a-new-standard-for-agent-execution.html)
+- [Kata Containers + Agent Sandbox integratie](https://katacontainers.io/blog/kata-containers-agent-sandbox-integration/)
+- [CloudNativePG v1.29.1 release notes](https://cloudnative-pg.io/releases/cloudnative-pg-1-29.1-released/)
+- [GKE autoscaling best practices voor LLM inference](https://docs.cloud.google.com/kubernetes-engine/docs/best-practices/machine-learning/inference/autoscaling)
+- [KEDA GPU autoscaling — CNCF blog](https://www.cncf.io/blog/2026/05/27/gpu-autoscaling-on-kubernetes-with-keda-building-an-external-scaler/)
+- [vLLM Production Stack — KEDA autoscaling](https://docs.vllm.ai/projects/production-stack/en/latest/use_cases/autoscaling-keda.html)
+- [Sysbox + K3s integratie](https://docs.k3s.io/blog/2025/09/27/k3s-sysbox)
+
+### Platform documentatie
+
+- [K3s documentatie](https://docs.k3s.io/)
+- [Rancher documentatie](https://ranchermanager.docs.rancher.com/)
+- [OKD documentatie](https://docs.okd.io/)
+- [CloudNativePG documentatie](https://cloudnative-pg.io/documentation/)
+- [Longhorn documentatie](https://longhorn.io/docs/)
+- [KEDA documentatie](https://keda.sh/docs/)
+- [ArgoCD documentatie](https://argo-cd.readthedocs.io/)
+- [Sealed Secrets](https://sealed-secrets.netlify.app/)
+- [Traefik documentatie](https://doc.traefik.io/traefik/)
+- [cert-manager documentatie](https://cert-manager.io/docs/)
+- [Harbor documentatie](https://goharbor.io/docs/)
+- [gVisor documentatie](https://gvisor.dev/docs/)
+
+### Bestaande Druppie resources
+
+- Helm chart: `helm/druppie/`
+- K8s setup guide: `docs/kubernetes.md`
+- Kind cluster config: `kind/cluster-dev.yaml`

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -995,9 +995,80 @@ Note: `CANCELLED` is never set by user actions. It is only used internally by th
 
 ---
 
-## 9. Configuration
+## 9. Kubernetes Deployment
 
-### 9.1 Environment Variables
+### 9.1 Helm Chart
+
+The Helm chart (`helm/druppie/`) deploys the full Druppie platform to Kubernetes. It translates every service from `docker-compose.yml` into native Kubernetes resources:
+
+| Docker Compose Service | Kubernetes Resource |
+|------------------------|---------------------|
+| PostgreSQL databases (3) | StatefulSets with volumeClaimTemplates (5Gi each) |
+| Keycloak, Gitea, Backend, Frontend | Deployments with readiness/liveness probes |
+| MCP modules (8) | Deployments, individually toggleable via `values.yaml` |
+| Init container | Helm post-install hook Job |
+| Shared volumes | PersistentVolumeClaims (workspace 10Gi, dataset 5Gi, sandbox-bundles 5Gi, gitea-data 5Gi) |
+| Bridge network | ClusterIP Services (15) + NetworkPolicies (5) |
+| Port mappings | Ingress with path-based routing via nginx |
+
+### 9.2 Template Helpers
+
+`_helpers.tpl` provides reusable template functions: name/fullname generation, standard Kubernetes labels (app, chart, release), selector labels, image rendering (with `imagePullPolicy: IfNotPresent` for local images), and external URL construction from `global.domain` and `global.ingress.port`.
+
+### 9.3 Ingress and Routing
+
+Two Ingress resources handle all external traffic on a single domain:
+
+**Main ingress** routes by path prefix:
+- `/api` → backend (pass-through, backend expects `/api` prefix)
+- `/realms`, `/resources`, `/admin`, `/js`, `/welcome` → Keycloak
+- `/` → frontend (catch-all)
+
+**Gitea ingress** uses a path rewrite annotation to strip `/git/` before forwarding to Gitea.
+
+### 9.4 NetworkPolicies
+
+Five policies control traffic:
+- `app-net`: allows intra-namespace communication + ingress from `ingress-nginx` namespace + HTTPS egress (port 443) + DNS egress
+- `sandbox-net`: sandbox pods accept ingress only from backend and module-coding
+- `sandbox-inet`: sandbox pods can reach the internet but not private IP ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+- `sandbox-modules`: module-coding accepts ingress only from backend
+- `sandbox-modules-docker`: module-docker accepts ingress only from backend
+
+### 9.5 Init System
+
+A Helm post-install hook Job (`init-job.yaml`) runs `setup_keycloak.py` after Keycloak and Gitea are healthy. It creates the Druppie realm, OAuth clients, roles, and test users. The Job uses init containers that wait for Keycloak and Gitea readiness before running.
+
+### 9.6 Kind Cluster Configs
+
+Two Kind configurations are provided in `kind/`:
+
+| File | Nodes | Port Mapping | Use Case |
+|------|-------|--------------|----------|
+| `cluster-dev.yaml` | 1 control-plane | 9080→80, 8443→443 | Local dev with ingress |
+| `cluster.yaml` | 1 control-plane + 2 workers | 80, 443 + NodePorts 30000-30003 | Multi-node testing |
+
+Both use pod subnet `10.244.0.0/16` and service subnet `10.96.0.0/12`.
+
+### 9.7 Helper Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/setup-kind.sh` | Creates Kind cluster, installs nginx ingress, builds and loads all images |
+| `scripts/build-and-load.sh` | Builds all Docker images and loads them into an existing Kind cluster |
+| `scripts/port-forward.sh` | Sets up kubectl port-forward for direct service access (bypasses ingress) |
+
+### 9.8 Secrets and ConfigMap
+
+A single Secret holds all sensitive values (DB passwords, Keycloak admin creds, Gitea token, LLM API keys). A single ConfigMap holds all non-secret environment variables (service URLs, MCP module URLs, CORS origins, Vite build vars). Both are referenced by deployments via `envFrom`.
+
+Secrets are stored as plaintext in `values.yaml` — intended for local dev only. Production deployments should use an external secrets manager (Vault, AWS Secrets Manager, etc.).
+
+---
+
+## 10. Configuration
+
+### 10.1 Environment Variables
 
 Required in `.env`:
 
@@ -1024,7 +1095,7 @@ Optional:
 | `SANDBOX_MEMORY_LIMIT` | `4g` | Docker memory limit per sandbox container |
 | `SANDBOX_CPU_LIMIT` | `2` | Docker CPU limit per sandbox container |
 
-### 9.2 Configuration Files
+### 10.2 Configuration Files
 
 | File | Purpose |
 |------|---------|
@@ -1038,13 +1109,13 @@ Optional:
 
 ---
 
-## 10. Sandbox Infrastructure (Open-Inspect)
+## 11. Sandbox Infrastructure (Open-Inspect)
 
 > Full documentation: [docs/SANDBOX.md](SANDBOX.md) — covers architecture, OpenCode integration, provider resilience, Kata Containers, and security.
 
 [Open-Inspect](https://github.com/nuno120/background-agents) (our fork, branch `druppie`) is integrated as a git submodule at `background-agents/`. Sandbox containers run OpenCode `v1.2.22` (pinned in `Dockerfile.sandbox`). They provide isolated Docker sandboxes where coding agents can clone a project, write code, run tests, commit, and push — all without touching the shared workspace.
 
-### 10.1 Services
+### 11.1 Services
 
 | Service | Port | Role |
 |---------|------|------|
@@ -1052,7 +1123,7 @@ Optional:
 | `sandbox-manager` | 8000 | Creates/manages sandbox containers, enforces resource limits |
 | `sandbox-image-builder` | — | One-shot build producing `open-inspect-sandbox:latest` |
 
-### 10.2 `execute_coding_task` Built-in Tool
+### 11.2 `execute_coding_task` Built-in Tool
 
 Defined in `druppie/agents/builtin_tools.py`. Delegates a coding task to a sandbox using a **webhook + pause/resume** pattern:
 
@@ -1064,7 +1135,7 @@ Defined in `druppie/agents/builtin_tools.py`. Delegates a coding task to a sandb
 
 **Auth:** HMAC-SHA256 tokens (`{unix_ms_timestamp}.{hmac_sha256_hex_signature}`), verified by Open-Inspect's `verifyInternalToken`.
 
-### 10.3 Status Model
+### 11.3 Status Model
 
 | Level | Status | Meaning |
 |-------|--------|---------|
@@ -1074,7 +1145,7 @@ Defined in `druppie/agents/builtin_tools.py`. Delegates a coding task to a sandb
 | SessionStatus | `paused_sandbox` | Visible in UI as paused |
 | SessionStatus | `paused_crashed` | Visible in UI as crashed |
 
-### 10.4 Sandbox Session Ownership
+### 11.4 Sandbox Session Ownership
 
 The `sandbox_sessions` table maps control plane session IDs to Druppie users:
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,369 @@
+# Kubernetes Deployment Guide
+
+This guide covers everything you need to deploy Druppie on Kubernetes using a local `kind` cluster. It starts with the basics, walks through the full setup, and ends with troubleshooting and production tips.
+
+---
+
+## 1. Kubernetes Basics
+
+Kubernetes is a container orchestrator. It manages many containers across many machines, keeping your applications running even when individual containers crash or machines go down.
+
+### Key Concepts
+
+**Pod**
+The smallest unit in Kubernetes. A pod runs one or more containers that share the same network and storage. In practice, most pods contain a single container.
+
+**Deployment**
+Manages a set of pods. You tell it "keep 3 replicas of this container running" and it handles the rest: starting new pods when they crash, rolling out updates, and rolling back if something breaks.
+
+**StatefulSet**
+Like a Deployment, but designed for databases and other stateful workloads. Each pod gets a stable network identity (like `druppie-db-0`, `druppie-db-1`) and its own persistent storage that survives pod restarts.
+
+**Service**
+An internal load balancer. Pods come and go, but a Service gives them a stable IP address and DNS name so other components can reach them reliably.
+
+**Ingress**
+An HTTP router that maps URLs to Services. Think of it as an nginx reverse proxy that sits at the edge of your cluster and routes `localhost:9080/api/*` to the backend, `localhost:9080/git/*` to Gitea, and so on.
+
+**ConfigMap / Secret**
+Configuration files and passwords that get injected into containers as environment variables or mounted files. ConfigMaps store non-sensitive data; Secrets store passwords and API keys.
+
+**PVC (PersistentVolumeClaim)**
+A request for disk storage. When a pod writes data to a PVC, that data survives even if the pod gets deleted and recreated.
+
+**Namespace**
+An isolated workspace within a cluster. All Druppie resources live in a namespace called `druppie`, keeping them separate from anything else running on the same cluster.
+
+**Job**
+A run-once task. Druppie uses a Job to run the Keycloak setup script on first install.
+
+**NetworkPolicy**
+Firewall rules for pods. Controls which pods can talk to each other and what traffic can leave the cluster. Druppie uses these to lock down database access and control egress.
+
+---
+
+## 2. Architecture Overview
+
+```
+                        localhost:9080
+                              |
+                    [nginx Ingress Controller]
+                              |
+         +--------------------+--------------------+
+         |          |          |          |         |
+    / -> frontend  /api -> backend  /realms -> keycloak  /git -> gitea
+                                    /resources
+                                    /admin
+                                    /js
+                                    /welcome
+```
+
+### Components
+
+| Component | Resource Type | Purpose |
+|-----------|---------------|---------|
+| PostgreSQL (druppie-db) | StatefulSet | Druppie application database |
+| PostgreSQL (keycloak-db) | StatefulSet | Keycloak identity database |
+| PostgreSQL (gitea-db) | StatefulSet | Gitea metadata database |
+| Keycloak | Deployment | OAuth2/OIDC identity provider |
+| Gitea | Deployment | Git repository server |
+| Backend | Deployment | Python/FastAPI REST API |
+| Frontend | Deployment | React SPA served by serve |
+| Module: coding | Deployment | MCP coding tools |
+| Module: docker | Deployment | MCP Docker tools |
+| Module: filesearch | Deployment | MCP file search tools |
+| Module: llm | Deployment | MCP LLM proxy |
+| Module: registry | Deployment | MCP registry tools |
+| Module: vision | Deployment | MCP vision tools |
+| Module: web | Deployment | MCP web tools |
+| Module: archimate | Deployment | MCP architecture tools |
+| Init Job | Job | Runs `setup_keycloak.py` on first install |
+
+### Resource Count
+
+3 StatefulSets + 12 Deployments + 15 Services + 5 NetworkPolicies + 1 Ingress + 1 ConfigMap + 1 Secret + 4 PVCs + 2 Jobs = roughly 43 Kubernetes resources.
+
+---
+
+## 3. Path-Based Routing
+
+The nginx Ingress Controller sits at `localhost:9080` and routes requests based on the URL path:
+
+| Path | Service | Description |
+|------|---------|-------------|
+| `/` | frontend | React SPA. This is the catch-all route, so any path not matched below goes to the frontend. |
+| `/api/*` | backend | REST API. The backend already expects the `/api` prefix, so it passes through as-is. |
+| `/realms/*` | keycloak | Keycloak authentication endpoints (OIDC discovery, token exchange). |
+| `/resources/*` | keycloak | Keycloak static assets (CSS, JS, images). |
+| `/admin/*` | keycloak | Keycloak admin console. |
+| `/js/*` | keycloak | Keycloak JavaScript adapter. |
+| `/welcome/*` | keycloak | Keycloak welcome page. |
+| `/git/*` | gitea | Git web UI. The ingress rewrites the path, stripping the `/git` prefix before forwarding to Gitea. |
+
+---
+
+## 4. Helm Chart Structure
+
+```
+helm/druppie/
+├── Chart.yaml                         # Chart metadata (name, version, appVersion)
+├── values.yaml                        # All configurable values
+└── templates/
+    ├── _helpers.tpl                    # Reusable template helpers
+    ├── secrets.yaml                    # API keys, DB passwords
+    ├── configmap.yaml                  # Environment variables
+    ├── services.yaml                   # 15 ClusterIP services
+    ├── ingress.yaml                    # Path-based routing rules
+    ├── networkpolicy.yaml              # 5 network policies
+    ├── persistentvolumeclaims.yaml     # 4 PVCs (workspace, dataset, gitea, sandbox-bundles)
+    ├── *-statefulset.yaml              # 3 PostgreSQL databases
+    ├── *-deployment.yaml               # 12 deployments (keycloak, gitea, backend, frontend, 8 modules)
+    ├── init-job.yaml                   # Post-install Keycloak setup
+    ├── sandbox-image-builder-job.yaml  # Placeholder for sandbox image
+    └── NOTES.txt                       # Post-install instructions
+```
+
+---
+
+## 5. Setup Guide
+
+### Prerequisites
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| Docker | Runs containers and the kind cluster | [docker.com](https://docker.com) (50GB+ free disk recommended) |
+| kind | Kubernetes cluster inside Docker | `go install sigs.k8s.io/kind@latest` or download from [GitHub releases](https://github.com/kubernetes-sigs/kind/releases) |
+| helm | Kubernetes package manager | `snap install helm --classic` or download from [GitHub releases](https://github.com/helm/helm/releases) |
+| kubectl | Kubernetes command line | `snap install kubectl --classic` |
+
+### Step 1: Clone the repo
+
+```bash
+git clone --branch feature/kubernetes-migration https://github.com/nuno-git/druppie-fork.git druppie-k8s
+cd druppie-k8s
+```
+
+### Step 2: Build Docker images
+
+```bash
+# Backend
+docker build -t druppie-backend:latest .
+
+# Frontend (VITE vars are baked at build time)
+docker build \
+  --build-arg VITE_API_URL=http://localhost:9080 \
+  --build-arg VITE_KEYCLOAK_URL=http://localhost:9080 \
+  --build-arg VITE_KEYCLOAK_REALM=druppie \
+  --build-arg VITE_KEYCLOAK_CLIENT_ID=druppie-frontend \
+  --build-arg VITE_GITEA_URL=http://localhost:9080/git \
+  -t druppie-frontend:latest ./frontend/
+
+# Init
+docker build -t druppie-init:latest -f Dockerfile.init .
+
+# MCP Modules (build context must be druppie/mcp-servers/)
+for mod in coding docker filesearch llm registry vision web archimate; do
+  docker build -t druppie-module-$mod:latest \
+    -f druppie/mcp-servers/module-$mod/Dockerfile \
+    druppie/mcp-servers/
+done
+```
+
+### Step 3: Create the kind cluster
+
+```bash
+kind create cluster --name druppie --config kind/cluster-dev.yaml
+```
+
+### Step 4: Install the nginx Ingress Controller
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=120s
+```
+
+### Step 5: Load images into kind
+
+`kind` runs its own internal Docker daemon, so images built on your host are not visible inside the cluster. You need to load them explicitly.
+
+```bash
+# The backend image is large (~4GB). If /tmp is too small for the transfer,
+# save it to a different path:
+# docker save druppie-backend:latest -o /path/to/backend.tar
+# kind load image-archive /path/to/backend.tar --name druppie
+# rm /path/to/backend.tar
+
+for img in druppie-backend druppie-frontend druppie-init \
+  druppie-module-coding druppie-module-docker druppie-module-filesearch \
+  druppie-module-llm druppie-module-registry druppie-module-vision \
+  druppie-module-web druppie-module-archimate; do
+  kind load docker-image ${img}:latest --name druppie
+done
+```
+
+### Step 6: Install the Helm chart
+
+```bash
+# With an LLM API key
+helm install druppie helm/druppie/ \
+  --namespace druppie --create-namespace --wait --timeout 300s \
+  --set secrets.zaiApiKey="YOUR_ZAI_API_KEY"
+
+# Without an API key (mock LLM mode)
+helm install druppie helm/druppie/ \
+  --namespace druppie --create-namespace --wait --timeout 300s
+```
+
+### Step 7: Initialize Keycloak
+
+The init Job creates the Druppie realm, client, roles, and test users in Keycloak. It is defined as a Helm hook, so it runs automatically during `helm install`. If you need to run it manually:
+
+```bash
+kubectl create configmap druppie-init-scripts \
+  --from-file=setup_keycloak.py=scripts/setup_keycloak.py \
+  --from-file=users.yaml=iac/users.yaml \
+  -n druppie
+
+helm template druppie helm/druppie/ --show-only templates/init-job.yaml -n druppie \
+  | sed '/helm.sh\/hook/d' | kubectl apply -n druppie -f -
+
+kubectl wait --for=condition=complete job/druppie-init -n druppie --timeout=180s
+```
+
+### Step 8: Access the platform
+
+Open http://localhost:9080 in your browser.
+
+Test users:
+
+| Username | Password | Roles |
+|----------|----------|-------|
+| admin | Admin123! | admin |
+| architect | Architect123! | architect |
+| developer | Developer123! | developer |
+
+---
+
+## 6. Configuration Reference
+
+Key values in `helm/druppie/values.yaml`:
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `global.domain` | `localhost` | Domain name for the platform. Change this for production deployments. |
+| `global.ingress.port` | `9080` | External port the ingress listens on. |
+| `secrets.zaiApiKey` | (empty) | LLM provider API key. If empty, the backend runs in mock LLM mode. |
+| `backend.llm.forceProvider` | (empty) | Force a specific LLM provider (options: `zai`, `deepinfra`, etc.). Leave empty for auto-detection. |
+| `keycloak.adminUser` | `admin` | Keycloak master admin username. |
+| `keycloak.adminPassword` | `admin` | Keycloak master admin password. Change this for any non-local deployment. |
+
+---
+
+## 7. Troubleshooting
+
+### ImagePullBackOff on pods
+
+The image was not loaded into the kind cluster. Load it:
+
+```bash
+kind load docker-image <image-name>:latest --name druppie
+```
+
+Then delete the pod so Kubernetes recreates it:
+
+```bash
+kubectl delete pod <pod-name> -n druppie
+```
+
+### 504 Gateway Timeout from the ingress
+
+A NetworkPolicy is likely blocking the ingress controller from reaching the target service. Check the policies:
+
+```bash
+kubectl get networkpolicy -n druppie
+```
+
+Make sure the policy for the affected service allows ingress from the `ingress-nginx` namespace.
+
+### LLM errors (connection refused to external API)
+
+The backend pod needs egress access to reach external LLM APIs. Check that the backend NetworkPolicy includes an egress rule for port 443:
+
+```bash
+kubectl describe networkpolicy -n druppie
+```
+
+### Double `/api` prefix in requests
+
+The Vite build variable `VITE_API_URL` should be set to `http://localhost:9080`, not `http://localhost:9080/api`. The frontend code already appends `/api` to the base URL. If you include it in the build variable, requests go to `/api/api/...`.
+
+### Disk space during image loading
+
+The backend image is roughly 4GB. `kind load docker-image` saves the image to a temporary file in `/tmp` before loading it into the cluster. If `/tmp` is on a small partition, use the archive approach instead:
+
+```bash
+docker save druppie-backend:latest -o /mnt/large-disk/backend.tar
+kind load image-archive /mnt/large-disk/backend.tar --name druppie
+rm /mnt/large-disk/backend.tar
+```
+
+### Pods stuck in CrashLoopBackOff
+
+Check the logs:
+
+```bash
+kubectl logs <pod-name> -n druppie
+```
+
+Common causes: missing environment variables, database not ready yet (wait a minute and check again), or wrong image tag.
+
+---
+
+## 8. Teardown
+
+To delete the entire cluster and all resources:
+
+```bash
+kind delete cluster --name druppie
+```
+
+This removes the kind Docker container, all containers inside it, and all stored data. There is no undo.
+
+To uninstall the Helm release without deleting the cluster:
+
+```bash
+helm uninstall druppie -n druppie
+```
+
+---
+
+## 9. Production Notes
+
+This setup uses `kind` for local development. For a production deployment, you need to change several things:
+
+**Cluster**
+Replace `kind` with a real Kubernetes cluster: AWS EKS, Google GKE, Azure AKS, or an on-prem cluster.
+
+**Databases**
+The StatefulSets running PostgreSQL containers work for development. In production, use a managed database service (RDS, Cloud SQL, Azure Database) or a dedicated PostgreSQL operator. The container-based setup does not handle backups, replication, or failover.
+
+**TLS**
+Add TLS termination using cert-manager. The current ingress only handles plain HTTP on port 9080.
+
+**Secrets**
+Replace the Helm chart secrets with an external secrets manager: HashiCorp Vault, AWS Secrets Manager, or GCP Secret Manager. Helm values are stored in etcd and are visible to anyone with cluster access.
+
+**Domain**
+Set `global.domain` to your actual domain name and configure DNS to point to your cluster's ingress controller.
+
+**Auto-scaling**
+Add HorizontalPodAutoscaler (HPA) resources for the backend and MCP modules. These scale the number of pod replicas based on CPU or memory usage.
+
+**Availability**
+Add PodDisruptionBudgets (PDB) to ensure enough replicas stay available during rolling updates and node maintenance.
+
+**Container registry**
+Push images to a container registry (Docker Hub, ECR, GCR) instead of loading them into the cluster. Update the image references in `values.yaml` to point to the registry URLs.

--- a/helm/druppie/Chart.yaml
+++ b/helm/druppie/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: druppie
+description: Druppie Governance Platform - Kubernetes Helm Chart
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+kubeVersion: ">=1.27.0-0"

--- a/helm/druppie/templates/NOTES.txt
+++ b/helm/druppie/templates/NOTES.txt
@@ -1,0 +1,37 @@
+Druppie Governance Platform has been installed!
+
+== Port-Forward Commands (for kind / local development) ==
+
+  # Backend API
+  kubectl port-forward svc/{{ include "druppie.fullname" . }}-backend 8000:8000 -n {{ .Release.Namespace }}
+
+  # Frontend
+  kubectl port-forward svc/{{ include "druppie.fullname" . }}-frontend 5173:5173 -n {{ .Release.Namespace }}
+
+  # Keycloak
+  kubectl port-forward svc/{{ include "druppie.fullname" . }}-keycloak 8080:8080 -n {{ .Release.Namespace }}
+
+  # Gitea HTTP
+  kubectl port-forward svc/{{ include "druppie.fullname" . }}-gitea 3000:3000 -n {{ .Release.Namespace }}
+
+  # Gitea SSH
+  kubectl port-forward svc/{{ include "druppie.fullname" . }}-gitea 2222:2222 -n {{ .Release.Namespace }}
+
+{{- if .Values.global.ingress.enabled }}
+
+== Ingress ==
+
+  Path-based routing on http://localhost:9080 (no /etc/hosts needed)
+
+  Frontend:     http://localhost:9080/
+  Backend API:  http://localhost:9080/api/
+  Keycloak:     http://localhost:9080/admin/ (or /realms/, /resources/, /js/, /welcome/)
+  Gitea:        http://localhost:9080/git/
+  Health:       http://localhost:9080/health
+  API Docs:     http://localhost:9080/docs
+{{- end }}
+
+== Checking Status ==
+
+  kubectl get pods -n {{ .Release.Namespace }}
+  kubectl get svc -n {{ .Release.Namespace }}

--- a/helm/druppie/templates/_helpers.tpl
+++ b/helm/druppie/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "druppie.name" -}}
+{{- default .Chart.Name .Values.global.instance | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "druppie.fullname" -}}
+{{- if .Values.global.instance }}
+{{- .Values.global.instance | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.global.instance }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "druppie.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "druppie.labels" -}}
+helm.sh/chart: {{ include "druppie.chart" . }}
+{{ include "druppie.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "druppie.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "druppie.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service name helper
+*/}}
+{{- define "druppie.serviceName" -}}
+{{- printf "%s" (include "druppie.fullname" .) }}
+{{- end }}
+
+{{/*
+Image helper: renders a full image reference from registry + repository + tag
+Usage: {{ include "druppie.image" (dict "Values" .Values "image" .Values.backend.image) }}
+*/}}
+{{- define "druppie.image" -}}
+{{- $registry := .Values.global.imageRegistry -}}
+{{- $repo := .image.repository -}}
+{{- $tag := .image.tag | default "latest" -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}

--- a/helm/druppie/templates/_helpers.tpl
+++ b/helm/druppie/templates/_helpers.tpl
@@ -67,3 +67,34 @@ Usage: {{ include "druppie.image" (dict "Values" .Values "image" .Values.backend
 {{- printf "%s:%s" $repo $tag -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+External scheme: http or https based on TLS enabled
+*/}}
+{{- define "druppie.scheme" -}}
+{{- if .Values.global.ingress.tls.enabled -}}
+https
+{{- else -}}
+http
+{{- end -}}
+{{- end -}}
+
+{{/*
+External base URL: scheme://domain(:port if non-standard)
+- TLS enabled → https://domain (standard 443, no port)
+- TLS disabled, port 80 → http://domain (standard 80, no port)
+- TLS disabled, non-standard port → http://domain:port
+*/}}
+{{- define "druppie.externalBaseUrl" -}}
+{{- $scheme := include "druppie.scheme" . -}}
+{{- $domain := .Values.global.domain -}}
+{{- $port := .Values.global.ingress.port | int -}}
+{{- $tlsEnabled := .Values.global.ingress.tls.enabled -}}
+{{- if $tlsEnabled -}}
+{{- printf "%s://%s" $scheme $domain -}}
+{{- else if eq $port 80 -}}
+{{- printf "%s://%s" $scheme $domain -}}
+{{- else -}}
+{{- printf "%s://%s:%d" $scheme $domain $port -}}
+{{- end -}}
+{{- end -}}

--- a/helm/druppie/templates/backend-deployment.yaml
+++ b/helm/druppie/templates/backend-deployment.yaml
@@ -1,0 +1,147 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druppie.fullname" . }}-backend
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+    spec:
+      initContainers:
+        - name: wait-for-druppie-db
+          image: {{ .Values.postgresql.image }}
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ include "druppie.fullname" . }}-druppie-db -p 5432 -U {{ .Values.postgresql.druppie.username }}; do
+                echo "Waiting for druppie-db..."
+                sleep 2
+              done
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+        - name: wait-for-keycloak
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf http://{{ include "druppie.fullname" . }}-keycloak:8080/health/ready; do
+                echo "Waiting for keycloak..."
+                sleep 5
+              done
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+        - name: wait-for-gitea
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf http://{{ include "druppie.fullname" . }}-gitea:3000/api/healthz; do
+                echo "Waiting for gitea..."
+                sleep 5
+              done
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+      containers:
+        - name: backend
+          image: {{ include "druppie.image" (dict "Values" .Values "image" .Values.backend.image) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "druppie.fullname" . }}-config
+            - secretRef:
+                name: {{ include "druppie.fullname" . }}-secrets
+          env:
+            - name: DEV_MODE
+              value: {{ .Values.backend.devMode | quote }}
+            - name: LLM_FORCE_PROVIDER
+              value: {{ .Values.backend.llm.forceProvider | quote }}
+            - name: LLM_FORCE_MODEL
+              value: {{ .Values.backend.llm.forceModel | quote }}
+            - name: FOUNDRY_MODEL
+              value: {{ .Values.backend.foundry.model | quote }}
+            - name: FOUNDRY_API_URL
+              value: {{ .Values.backend.foundry.apiUrl | quote }}
+            - name: GITHUB_APP_ID
+              value: {{ .Values.backend.github.appId | quote }}
+            - name: GITHUB_APP_PRIVATE_KEY_PATH
+              value: {{ .Values.backend.github.appPrivateKeyPath | quote }}
+            - name: GITHUB_APP_INSTALLATION_ID
+              value: {{ .Values.backend.github.appInstallationId | quote }}
+            - name: DRUPPIE_REPO_OWNER
+              value: {{ .Values.backend.github.repoOwner | quote }}
+            - name: DRUPPIE_REPO_NAME
+              value: {{ .Values.backend.github.repoName | quote }}
+            - name: ONESHOT_SANDBOX_RUNTIME
+              value: {{ .Values.sandbox.runtime | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.backend.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: workspace
+              mountPath: /app/workspace
+            - name: sandbox-bundles
+              mountPath: /app/sandbox_bundles
+            {{- if .Values.backend.dockerSocket.enabled }}
+            - name: docker-sock
+              mountPath: /var/run/docker.sock
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.backend.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.backend.port }}
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+      volumes:
+        - name: workspace
+          persistentVolumeClaim:
+            claimName: {{ include "druppie.fullname" . }}-workspace
+        - name: sandbox-bundles
+          persistentVolumeClaim:
+            claimName: {{ include "druppie.fullname" . }}-sandbox-bundles
+        {{- if .Values.backend.dockerSocket.enabled }}
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock
+            type: Socket
+        {{- end }}

--- a/helm/druppie/templates/configmap.yaml
+++ b/helm/druppie/templates/configmap.yaml
@@ -13,11 +13,11 @@ data:
   KEYCLOAK_REALM: "druppie"
   KEYCLOAK_CLIENT_ID: "druppie-backend"
   KEYCLOAK_SERVER_URL: "http://{{ include "druppie.fullname" . }}-keycloak:8080"
-  KEYCLOAK_ISSUER_URL: "http://localhost:9080"
+  KEYCLOAK_ISSUER_URL: "{{ include "druppie.externalBaseUrl" . }}"
 
   # Gitea
   GITEA_INTERNAL_URL: "http://{{ include "druppie.fullname" . }}-gitea:3000"
-  GITEA_URL: "http://localhost:9080/git"
+  GITEA_URL: "{{ include "druppie.externalBaseUrl" . }}/git"
   GITEA_ORG: {{ .Values.gitea.org | quote }}
   GITEA_ADMIN_USER: {{ .Values.gitea.adminUser | quote }}
   GITEA_ADMIN_EMAIL: {{ .Values.gitea.adminEmail | quote }}
@@ -34,9 +34,11 @@ data:
   MCP_WEB_URL: "http://{{ include "druppie.fullname" . }}-module-web:9005"
   MCP_ARCHIMATE_URL: "http://{{ include "druppie.fullname" . }}-module-archimate:9006"
   MCP_REGISTRY_URL: "http://{{ include "druppie.fullname" . }}-module-registry:9007"
+  MCP_LLM_URL: "http://{{ include "druppie.fullname" . }}-module-llm:{{ .Values.modules.llm.port }}"
+  MCP_VISION_URL: "http://{{ include "druppie.fullname" . }}-module-vision:{{ .Values.modules.vision.port }}"
 
   # CORS
-  CORS_ORIGINS: "http://localhost:9080"
+  CORS_ORIGINS: "{{ include "druppie.externalBaseUrl" . }}"
 
   # LLM defaults
   LLM_PROVIDER: {{ .Values.backend.llm.provider | quote }}
@@ -54,8 +56,8 @@ data:
   DRUPPIE_DOCKER_CPU_LIMIT: {{ .Values.sandbox.cpuLimit | quote }}
 
   # Frontend Vite
-  VITE_API_URL: "http://localhost:9080"
-  VITE_KEYCLOAK_URL: "http://localhost:9080"
+  VITE_API_URL: "{{ include "druppie.externalBaseUrl" . }}"
+  VITE_KEYCLOAK_URL: "{{ include "druppie.externalBaseUrl" . }}"
   VITE_KEYCLOAK_REALM: {{ .Values.frontend.vite.keycloakRealm | quote }}
   VITE_KEYCLOAK_CLIENT_ID: {{ .Values.frontend.vite.keycloakClientId | quote }}
-  VITE_GITEA_URL: "http://localhost:9080/git"
+  VITE_GITEA_URL: "{{ include "druppie.externalBaseUrl" . }}/git"

--- a/helm/druppie/templates/configmap.yaml
+++ b/helm/druppie/templates/configmap.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "druppie.fullname" . }}-config
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+data:
+  # Global
+  DRUPPIE_INSTANCE: {{ .Values.global.instance | quote }}
+  DOMAIN: {{ .Values.global.domain | quote }}
+
+  # Keycloak
+  KEYCLOAK_REALM: "druppie"
+  KEYCLOAK_CLIENT_ID: "druppie-backend"
+  KEYCLOAK_SERVER_URL: "http://{{ include "druppie.fullname" . }}-keycloak:8080"
+  KEYCLOAK_ISSUER_URL: "http://localhost:9080"
+
+  # Gitea
+  GITEA_INTERNAL_URL: "http://{{ include "druppie.fullname" . }}-gitea:3000"
+  GITEA_URL: "http://localhost:9080/git"
+  GITEA_ORG: {{ .Values.gitea.org | quote }}
+  GITEA_ADMIN_USER: {{ .Values.gitea.adminUser | quote }}
+  GITEA_ADMIN_EMAIL: {{ .Values.gitea.adminEmail | quote }}
+
+  # Backend
+  BACKEND_URL: "http://{{ include "druppie.fullname" . }}-backend:8000"
+  WORKSPACE_PATH: "/app/workspace"
+  USE_MCP_MICROSERVICES: "true"
+
+  # MCP module URLs
+  MCP_CODING_URL: "http://{{ include "druppie.fullname" . }}-module-coding:9001"
+  MCP_DOCKER_URL: "http://{{ include "druppie.fullname" . }}-module-docker:9002"
+  MCP_FILESEARCH_URL: "http://{{ include "druppie.fullname" . }}-module-filesearch:9004"
+  MCP_WEB_URL: "http://{{ include "druppie.fullname" . }}-module-web:9005"
+  MCP_ARCHIMATE_URL: "http://{{ include "druppie.fullname" . }}-module-archimate:9006"
+  MCP_REGISTRY_URL: "http://{{ include "druppie.fullname" . }}-module-registry:9007"
+
+  # CORS
+  CORS_ORIGINS: "http://localhost:9080"
+
+  # LLM defaults
+  LLM_PROVIDER: {{ .Values.backend.llm.provider | quote }}
+  ZAI_MODEL: {{ .Values.backend.zai.model | quote }}
+  ZAI_BASE_URL: {{ .Values.backend.zai.baseUrl | quote }}
+  DEEPSEEK_MODEL: {{ .Values.backend.deepseek.model | quote }}
+  DEEPSEEK_BASE_URL: {{ .Values.backend.deepseek.baseUrl | quote }}
+  DEEPINFRA_MODEL: {{ .Values.backend.deepinfra.model | quote }}
+  DEEPINFRA_BASE_URL: {{ .Values.backend.deepinfra.baseUrl | quote }}
+
+  # Sandbox
+  DRUPPIE_SANDBOX_RUNTIME: {{ .Values.sandbox.runtime | quote }}
+  DRUPPIE_SANDBOX_IMAGE: {{ .Values.sandbox.image | quote }}
+  DRUPPIE_DOCKER_MEMORY_LIMIT: {{ .Values.sandbox.memoryLimit | quote }}
+  DRUPPIE_DOCKER_CPU_LIMIT: {{ .Values.sandbox.cpuLimit | quote }}
+
+  # Frontend Vite
+  VITE_API_URL: "http://localhost:9080"
+  VITE_KEYCLOAK_URL: "http://localhost:9080"
+  VITE_KEYCLOAK_REALM: {{ .Values.frontend.vite.keycloakRealm | quote }}
+  VITE_KEYCLOAK_CLIENT_ID: {{ .Values.frontend.vite.keycloakClientId | quote }}
+  VITE_GITEA_URL: "http://localhost:9080/git"

--- a/helm/druppie/templates/druppie-db-statefulset.yaml
+++ b/helm/druppie/templates/druppie-db-statefulset.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "druppie.fullname" . }}-druppie-db
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: druppie-db
+spec:
+  serviceName: {{ include "druppie.fullname" . }}-druppie-db
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: druppie-db
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: druppie-db
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgresql.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.druppie.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.druppie.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: DRUPPIE_DB_PASSWORD
+            - name: PGDATA
+              value: "/var/lib/postgresql/data/pgdata"
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.druppie.username }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.druppie.username }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 10
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.druppie.storage }}

--- a/helm/druppie/templates/frontend-deployment.yaml
+++ b/helm/druppie/templates/frontend-deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druppie.fullname" . }}-frontend
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      initContainers:
+        - name: wait-for-backend
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf http://{{ include "druppie.fullname" . }}-backend:{{ .Values.backend.port }}/health; do
+                echo "Waiting for backend..."
+                sleep 5
+              done
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+      containers:
+        - name: frontend
+          image: {{ include "druppie.image" (dict "Values" .Values "image" .Values.frontend.image) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: VITE_API_URL
+              value: "http://localhost:9080"
+            - name: VITE_KEYCLOAK_URL
+              value: "http://localhost:9080"
+            - name: VITE_KEYCLOAK_REALM
+              value: {{ .Values.frontend.vite.keycloakRealm | quote }}
+            - name: VITE_KEYCLOAK_CLIENT_ID
+              value: {{ .Values.frontend.vite.keycloakClientId | quote }}
+            - name: VITE_GITEA_URL
+              value: "http://localhost:9080/git"
+          ports:
+            - name: http
+              containerPort: {{ .Values.frontend.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.frontend.port }}
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.frontend.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"

--- a/helm/druppie/templates/frontend-deployment.yaml
+++ b/helm/druppie/templates/frontend-deployment.yaml
@@ -41,15 +41,15 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
             - name: VITE_API_URL
-              value: "http://localhost:9080"
+              value: "{{ include "druppie.externalBaseUrl" . }}"
             - name: VITE_KEYCLOAK_URL
-              value: "http://localhost:9080"
+              value: "{{ include "druppie.externalBaseUrl" . }}"
             - name: VITE_KEYCLOAK_REALM
               value: {{ .Values.frontend.vite.keycloakRealm | quote }}
             - name: VITE_KEYCLOAK_CLIENT_ID
               value: {{ .Values.frontend.vite.keycloakClientId | quote }}
             - name: VITE_GITEA_URL
-              value: "http://localhost:9080/git"
+              value: "{{ include "druppie.externalBaseUrl" . }}/git"
           ports:
             - name: http
               containerPort: {{ .Values.frontend.port }}

--- a/helm/druppie/templates/gitea-db-statefulset.yaml
+++ b/helm/druppie/templates/gitea-db-statefulset.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "druppie.fullname" . }}-gitea-db
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gitea-db
+spec:
+  serviceName: {{ include "druppie.fullname" . }}-gitea-db
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gitea-db
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: gitea-db
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgresql.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.gitea.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.gitea.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: GITEA_DB_PASSWORD
+            - name: PGDATA
+              value: "/var/lib/postgresql/data/pgdata"
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.gitea.username }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.gitea.username }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 10
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.gitea.storage }}

--- a/helm/druppie/templates/gitea-deployment.yaml
+++ b/helm/druppie/templates/gitea-deployment.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druppie.fullname" . }}-gitea
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gitea
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gitea
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: gitea
+    spec:
+      initContainers:
+        - name: wait-for-db
+          image: {{ .Values.postgresql.image }}
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ include "druppie.fullname" . }}-gitea-db -p 5432 -U {{ .Values.postgresql.gitea.username }}; do
+                echo "Waiting for gitea-db..."
+                sleep 2
+              done
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+      containers:
+        - name: gitea
+          image: {{ .Values.gitea.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: USER_UID
+              value: "1000"
+            - name: USER_GID
+              value: "1000"
+            - name: GITEA__database__DB_TYPE
+              value: "postgres"
+            - name: GITEA__database__HOST
+              value: "{{ include "druppie.fullname" . }}-gitea-db:5432"
+            - name: GITEA__database__NAME
+              value: {{ .Values.postgresql.gitea.database | quote }}
+            - name: GITEA__database__USER
+              value: {{ .Values.postgresql.gitea.username | quote }}
+            - name: GITEA__database__PASSWD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: GITEA_DB_PASSWORD
+            - name: GITEA__server__ROOT_URL
+              value: "http://localhost:9080/git/"
+            - name: GITEA__server__HTTP_PORT
+              value: {{ .Values.gitea.httpPort | quote }}
+            - name: GITEA__server__DOMAIN
+              value: "localhost"
+            - name: GITEA__security__INSTALL_LOCK
+              value: "true"
+            - name: GITEA__service__DISABLE_REGISTRATION
+              value: "false"
+            - name: GITEA__oauth2_client__ACCOUNT_LINKING
+              value: "auto"
+            - name: GITEA__oauth2_client__ENABLE_AUTO_REGISTRATION
+              value: "true"
+            - name: GITEA__oauth2_client__USERNAME
+              value: "email"
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+            - name: ssh
+              containerPort: 22
+              protocol: TCP
+          volumeMounts:
+            - name: gitea-data
+              mountPath: /data
+          livenessProbe:
+            httpGet:
+              path: /api/healthz
+              port: 3000
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "1000m"
+      volumes:
+        - name: gitea-data
+          persistentVolumeClaim:
+            claimName: {{ include "druppie.fullname" . }}-gitea-data

--- a/helm/druppie/templates/gitea-deployment.yaml
+++ b/helm/druppie/templates/gitea-deployment.yaml
@@ -60,11 +60,11 @@ spec:
                   name: {{ include "druppie.fullname" . }}-secrets
                   key: GITEA_DB_PASSWORD
             - name: GITEA__server__ROOT_URL
-              value: "http://localhost:9080/git/"
+              value: "{{ include "druppie.externalBaseUrl" . }}/git/"
             - name: GITEA__server__HTTP_PORT
               value: {{ .Values.gitea.httpPort | quote }}
             - name: GITEA__server__DOMAIN
-              value: "localhost"
+              value: {{ .Values.global.domain | quote }}
             - name: GITEA__security__INSTALL_LOCK
               value: "true"
             - name: GITEA__service__DISABLE_REGISTRATION

--- a/helm/druppie/templates/ingress.yaml
+++ b/helm/druppie/templates/ingress.yaml
@@ -5,10 +5,20 @@ metadata:
   name: {{ include "druppie.fullname" . }}-main
   labels:
     {{- include "druppie.labels" . | nindent 4 }}
+  {{- with .Values.global.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className | default "nginx" }}
+  {{- if .Values.global.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.global.domain }}
+      secretName: {{ .Values.global.ingress.tls.secretName }}
+  {{- end }}
   rules:
-    - host: localhost
+    - host: {{ .Values.global.domain }}
       http:
         paths:
           # Backend API — backend already has /api prefix on all routes
@@ -74,10 +84,19 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/use-regex: "true"
+    {{- with .Values.global.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className | default "nginx" }}
+  {{- if .Values.global.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.global.domain }}
+      secretName: {{ .Values.global.ingress.tls.secretName }}
+  {{- end }}
   rules:
-    - host: localhost
+    - host: {{ .Values.global.domain }}
       http:
         paths:
           - path: /git(/|$)(.*)

--- a/helm/druppie/templates/ingress.yaml
+++ b/helm/druppie/templates/ingress.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.global.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "druppie.fullname" . }}-main
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.global.ingress.className | default "nginx" }}
+  rules:
+    - host: localhost
+      http:
+        paths:
+          # Backend API — backend already has /api prefix on all routes
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "druppie.fullname" . }}-backend
+                port:
+                  number: {{ .Values.backend.port }}
+          # Keycloak — serves its own paths natively (/realms, /resources, /admin, /js, /welcome)
+          - path: /realms
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "druppie.fullname" . }}-keycloak
+                port:
+                  number: 8080
+          - path: /resources
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "druppie.fullname" . }}-keycloak
+                port:
+                  number: 8080
+          - path: /admin
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "druppie.fullname" . }}-keycloak
+                port:
+                  number: 8080
+          - path: /js
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "druppie.fullname" . }}-keycloak
+                port:
+                  number: 8080
+          - path: /welcome
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "druppie.fullname" . }}-keycloak
+                port:
+                  number: 8080
+          # Frontend (catch-all — must be last)
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "druppie.fullname" . }}-frontend
+                port:
+                  number: {{ .Values.frontend.port }}
+---
+# Gitea needs path rewrite (/git/foo → /foo)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "druppie.fullname" . }}-gitea
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: {{ .Values.global.ingress.className | default "nginx" }}
+  rules:
+    - host: localhost
+      http:
+        paths:
+          - path: /git(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "druppie.fullname" . }}-gitea
+                port:
+                  number: {{ .Values.gitea.httpPort }}
+{{- end }}

--- a/helm/druppie/templates/init-job.yaml
+++ b/helm/druppie/templates/init-job.yaml
@@ -100,7 +100,7 @@ spec:
             - name: KEYCLOAK_REALM
               value: "druppie"
             - name: EXTERNAL_HOST
-              value: "localhost"
+              value: {{ .Values.global.domain | quote }}
             - name: INGRESS_PORT
               value: {{ .Values.global.ingress.port | default "9080" | quote }}
           volumeMounts:

--- a/helm/druppie/templates/init-job.yaml
+++ b/helm/druppie/templates/init-job.yaml
@@ -1,0 +1,119 @@
+{{- if .Values.init.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "druppie.fullname" . }}-init
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: init
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: hook-succeeded
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: init
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: wait-for-keycloak
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf http://{{ include "druppie.fullname" . }}-keycloak:8080/health/ready; do
+                echo "Waiting for keycloak..."
+                sleep 5
+              done
+              echo "Keycloak is ready"
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+        - name: wait-for-gitea
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf http://{{ include "druppie.fullname" . }}-gitea:3000/api/healthz; do
+                echo "Waiting for gitea..."
+                sleep 5
+              done
+              echo "Gitea is ready"
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+      containers:
+        - name: init
+          image: {{ include "druppie.image" (dict "Values" .Values "image" .Values.init.image) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: KEYCLOAK_URL
+              value: "http://{{ include "druppie.fullname" . }}-keycloak:8080"
+            - name: KEYCLOAK_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: KEYCLOAK_ADMIN
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: KEYCLOAK_ADMIN_PASSWORD
+            - name: DOMAIN
+              value: {{ .Values.global.domain | quote }}
+            - name: FRONTEND_PORT
+              value: {{ .Values.global.ingress.port | default "9080" | quote }}
+            - name: KEYCLOAK_PORT
+              value: {{ .Values.global.ingress.port | default "9080" | quote }}
+            - name: GITEA_PORT
+              value: {{ .Values.global.ingress.port | default "9080" | quote }}
+            - name: BACKEND_PORT
+              value: {{ .Values.global.ingress.port | default "9080" | quote }}
+            - name: GITEA_URL
+              value: "http://{{ include "druppie.fullname" . }}-gitea:3000"
+            - name: GITEA_ADMIN_USER
+              value: {{ .Values.gitea.adminUser | quote }}
+            - name: GITEA_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: GITEA_ADMIN_PASSWORD
+            - name: GITEA_ADMIN_EMAIL
+              value: {{ .Values.gitea.adminEmail | quote }}
+            - name: KEYCLOAK_INTERNAL_URL
+              value: "http://{{ include "druppie.fullname" . }}-keycloak:8080"
+            - name: KEYCLOAK_REALM
+              value: "druppie"
+            - name: EXTERNAL_HOST
+              value: "localhost"
+            - name: INGRESS_PORT
+              value: {{ .Values.global.ingress.port | default "9080" | quote }}
+          volumeMounts:
+            - name: init-marker
+              mountPath: /init-marker
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      volumes:
+        - name: init-marker
+          emptyDir: {}
+{{- end }}

--- a/helm/druppie/templates/init-job.yaml
+++ b/helm/druppie/templates/init-job.yaml
@@ -7,9 +7,9 @@ metadata:
     {{- include "druppie.labels" . | nindent 4 }}
     app.kubernetes.io/component: init
   annotations:
-    helm.sh/hook: post-install
+    helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 spec:
   backoffLimit: 3
   ttlSecondsAfterFinished: 300
@@ -77,13 +77,13 @@ spec:
             - name: DOMAIN
               value: {{ .Values.global.domain | quote }}
             - name: FRONTEND_PORT
-              value: {{ .Values.global.ingress.port | default "9080" | quote }}
+              value: {{ .Values.frontend.nodePort | default .Values.global.ingress.port | default "9080" | quote }}
             - name: KEYCLOAK_PORT
-              value: {{ .Values.global.ingress.port | default "9080" | quote }}
+              value: {{ .Values.keycloak.nodePort | default .Values.global.ingress.port | default "9080" | quote }}
             - name: GITEA_PORT
-              value: {{ .Values.global.ingress.port | default "9080" | quote }}
+              value: {{ .Values.gitea.nodePort | default .Values.global.ingress.port | default "9080" | quote }}
             - name: BACKEND_PORT
-              value: {{ .Values.global.ingress.port | default "9080" | quote }}
+              value: {{ .Values.backend.nodePort | default .Values.global.ingress.port | default "9080" | quote }}
             - name: GITEA_URL
               value: "http://{{ include "druppie.fullname" . }}-gitea:3000"
             - name: GITEA_ADMIN_USER

--- a/helm/druppie/templates/keycloak-db-statefulset.yaml
+++ b/helm/druppie/templates/keycloak-db-statefulset.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "druppie.fullname" . }}-keycloak-db
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak-db
+spec:
+  serviceName: {{ include "druppie.fullname" . }}-keycloak-db
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: keycloak-db
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: keycloak-db
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgresql.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.keycloak.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.keycloak.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: KEYCLOAK_DB_PASSWORD
+            - name: PGDATA
+              value: "/var/lib/postgresql/data/pgdata"
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.keycloak.username }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgresql.keycloak.username }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 10
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.keycloak.storage }}

--- a/helm/druppie/templates/keycloak-deployment.yaml
+++ b/helm/druppie/templates/keycloak-deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druppie.fullname" . }}-keycloak
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: keycloak
+    spec:
+      initContainers:
+        - name: wait-for-db
+          image: {{ .Values.postgresql.image }}
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ include "druppie.fullname" . }}-keycloak-db -p 5432 -U {{ .Values.postgresql.keycloak.username }}; do
+                echo "Waiting for keycloak-db..."
+                sleep 2
+              done
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+      containers:
+        - name: keycloak
+          image: {{ .Values.keycloak.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          args: ["start-dev"]
+          env:
+            - name: KC_DB
+              value: "postgres"
+            - name: KC_DB_URL
+              value: "jdbc:postgresql://{{ include "druppie.fullname" . }}-keycloak-db:5432/{{ .Values.postgresql.keycloak.database }}"
+            - name: KC_DB_USERNAME
+              value: {{ .Values.postgresql.keycloak.username | quote }}
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: KEYCLOAK_DB_PASSWORD
+            - name: KEYCLOAK_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: KEYCLOAK_ADMIN
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: KEYCLOAK_ADMIN_PASSWORD
+            - name: KC_HOSTNAME
+              value: "localhost"
+            - name: KC_HOSTNAME_PORT
+              value: "9080"
+            - name: KC_HOSTNAME_STRICT
+              value: "false"
+            - name: KC_PROXY
+              value: "edge"
+            - name: KC_PROXY_HEADERS
+              value: "xforwarded"
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+            - name: JAVA_OPTS_APPEND
+              value: "-Xms256m -Xmx512m -XX:MaxGCPauseMillis=100 -Djava.net.preferIPv4Stack=true"
+            - name: KC_CACHE
+              value: "local"
+            - name: KC_CACHE_STACK
+              value: "udp"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+            initialDelaySeconds: {{ .Values.keycloak.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.keycloak.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.keycloak.readinessProbe.failureThreshold }}
+            timeoutSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+            initialDelaySeconds: {{ .Values.keycloak.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.keycloak.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.keycloak.livenessProbe.failureThreshold }}
+            timeoutSeconds: 10
+          resources:
+            {{- toYaml .Values.keycloak.resources | nindent 12 }}

--- a/helm/druppie/templates/keycloak-deployment.yaml
+++ b/helm/druppie/templates/keycloak-deployment.yaml
@@ -68,7 +68,7 @@ spec:
               {{- if .Values.global.ingress.tls.enabled }}
               value: "443"
               {{- else }}
-              value: {{ .Values.global.ingress.port | quote }}
+              value: {{ .Values.keycloak.nodePort | default .Values.global.ingress.port | quote }}
               {{- end }}
             - name: KC_HOSTNAME_STRICT
               value: "false"

--- a/helm/druppie/templates/keycloak-deployment.yaml
+++ b/helm/druppie/templates/keycloak-deployment.yaml
@@ -63,9 +63,13 @@ spec:
                   name: {{ include "druppie.fullname" . }}-secrets
                   key: KEYCLOAK_ADMIN_PASSWORD
             - name: KC_HOSTNAME
-              value: "localhost"
+              value: {{ .Values.global.domain | quote }}
             - name: KC_HOSTNAME_PORT
-              value: "9080"
+              {{- if .Values.global.ingress.tls.enabled }}
+              value: "443"
+              {{- else }}
+              value: {{ .Values.global.ingress.port | quote }}
+              {{- end }}
             - name: KC_HOSTNAME_STRICT
               value: "false"
             - name: KC_PROXY

--- a/helm/druppie/templates/module-archimate-deployment.yaml
+++ b/helm/druppie/templates/module-archimate-deployment.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.modules.archimate.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-archimate
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-archimate
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: module-archimate
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: module-archimate
+    spec:
+      containers:
+        - name: module-archimate
+          image: {{ include "druppie.image" (dict "Values" .Values "image" .Values.modules.archimate.image) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: MODELS_DIR
+              value: "/models"
+            - name: MCP_PORT
+              value: {{ .Values.modules.archimate.port | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.modules.archimate.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: archimate-models
+              mountPath: /models
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.archimate.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.archimate.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      volumes:
+        - name: archimate-models
+          configMap:
+            name: {{ include "druppie.fullname" . }}-archimate-models
+            optional: true
+{{- end }}

--- a/helm/druppie/templates/module-coding-deployment.yaml
+++ b/helm/druppie/templates/module-coding-deployment.yaml
@@ -1,0 +1,137 @@
+{{- if .Values.modules.coding.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-coding
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-coding
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: module-coding
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: module-coding
+    spec:
+      initContainers:
+        - name: wait-for-gitea
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf http://{{ include "druppie.fullname" . }}-gitea:3000/api/healthz; do
+                echo "Waiting for gitea..."
+                sleep 5
+              done
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+      containers:
+        - name: module-coding
+          image: {{ include "druppie.image" (dict "Values" .Values "image" .Values.modules.coding.image) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: WORKSPACE_ROOT
+              value: "/workspaces"
+            - name: MCP_PORT
+              value: {{ .Values.modules.coding.port | quote }}
+            - name: GITEA_INTERNAL_URL
+              value: "http://{{ include "druppie.fullname" . }}-gitea:3000"
+            - name: GITEA_ORG
+              value: {{ .Values.gitea.org | quote }}
+            - name: GITEA_USER
+              value: {{ .Values.gitea.adminUser | quote }}
+            - name: GITEA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: GITEA_ADMIN_PASSWORD
+            - name: GITEA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: GITEA_TOKEN
+            - name: BACKEND_URL
+              value: "http://{{ include "druppie.fullname" . }}-backend:{{ .Values.backend.port }}"
+            - name: INTERNAL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: INTERNAL_API_KEY
+            - name: DRUPPIE_SANDBOX_RUNTIME
+              value: {{ .Values.sandbox.runtime | quote }}
+            - name: DRUPPIE_SANDBOX_CACHE_VOLUME
+              value: "{{ .Values.global.instance }}_sandbox_dep_cache"
+            - name: DRUPPIE_SANDBOX_USER
+              value: {{ .Values.global.instance | quote }}
+            - name: DRUPPIE_SANDBOX_IMAGE
+              value: {{ .Values.sandbox.image | quote }}
+            - name: DRUPPIE_SANDBOX_NETWORK
+              value: "{{ .Values.global.instance }}-sandbox-net"
+            - name: DRUPPIE_SANDBOX_INET_NETWORK
+              value: "{{ .Values.global.instance }}-sandbox-inet"
+            - name: DRUPPIE_SANDBOX_MODULES_NETWORK
+              value: "{{ .Values.global.instance }}-sandbox-modules"
+            - name: DRUPPIE_DOCKER_MEMORY_LIMIT
+              value: {{ .Values.sandbox.memoryLimit | quote }}
+            - name: DRUPPIE_DOCKER_CPU_LIMIT
+              value: {{ .Values.sandbox.cpuLimit | quote }}
+            {{- if .Values.backend.dockerSocket.enabled }}
+            - name: DOCKER_HOST
+              value: "unix:///var/run/docker.sock"
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.modules.coding.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspaces
+            {{- if .Values.backend.dockerSocket.enabled }}
+            - name: docker-sock
+              mountPath: /var/run/docker.sock
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.coding.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.coding.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      volumes:
+        - name: workspace
+          persistentVolumeClaim:
+            claimName: {{ include "druppie.fullname" . }}-workspace
+        {{- if .Values.backend.dockerSocket.enabled }}
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock
+            type: Socket
+        {{- end }}
+{{- end }}

--- a/helm/druppie/templates/module-docker-deployment.yaml
+++ b/helm/druppie/templates/module-docker-deployment.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.modules.docker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-docker
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-docker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: module-docker
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: module-docker
+    spec:
+      containers:
+        - name: module-docker
+          image: {{ include "druppie.image" (dict "Values" .Values "image" .Values.modules.docker.image) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: MCP_PORT
+              value: {{ .Values.modules.docker.port | quote }}
+            - name: WORKSPACE_ROOT
+              value: "/workspaces"
+            - name: DOCKER_NETWORK
+              value: "{{ .Values.global.instance }}-network"
+            - name: DRUPPIE_URL
+              value: "http://{{ include "druppie.fullname" . }}-backend:{{ .Values.backend.port }}"
+            - name: DRUPPIE_MODULE_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: DRUPPIE_MODULE_API_TOKEN
+            - name: DEEPINFRA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: DEEPINFRA_API_KEY
+            {{- if .Values.backend.dockerSocket.enabled }}
+            - name: DOCKER_HOST
+              value: "unix:///var/run/docker.sock"
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.modules.docker.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspaces
+            {{- if .Values.backend.dockerSocket.enabled }}
+            - name: docker-sock
+              mountPath: /var/run/docker.sock
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.docker.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.docker.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      volumes:
+        - name: workspace
+          persistentVolumeClaim:
+            claimName: {{ include "druppie.fullname" . }}-workspace
+        {{- if .Values.backend.dockerSocket.enabled }}
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock
+            type: Socket
+        {{- end }}
+{{- end }}

--- a/helm/druppie/templates/module-filesearch-deployment.yaml
+++ b/helm/druppie/templates/module-filesearch-deployment.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.modules.filesearch.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-filesearch
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-filesearch
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: module-filesearch
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: module-filesearch
+    spec:
+      containers:
+        - name: module-filesearch
+          image: {{ include "druppie.image" (dict "Values" .Values "image" .Values.modules.filesearch.image) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: SEARCH_ROOT
+              value: "/dataset"
+            - name: MCP_PORT
+              value: {{ .Values.modules.filesearch.port | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.modules.filesearch.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: dataset
+              mountPath: /dataset
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.filesearch.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.filesearch.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      volumes:
+        - name: dataset
+          persistentVolumeClaim:
+            claimName: {{ include "druppie.fullname" . }}-dataset
+{{- end }}

--- a/helm/druppie/templates/module-llm-deployment.yaml
+++ b/helm/druppie/templates/module-llm-deployment.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.modules.llm.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-llm
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-llm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: module-llm
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: module-llm
+    spec:
+      containers:
+        - name: module-llm
+          image: {{ include "druppie.image" (dict "Values" .Values "image" .Values.modules.llm.image) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: MCP_PORT
+              value: {{ .Values.modules.llm.port | quote }}
+            - name: ZAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: ZAI_API_KEY
+            - name: ZAI_BASE_URL
+              value: {{ .Values.backend.zai.baseUrl | quote }}
+            - name: ZAI_MODEL
+              value: {{ .Values.backend.zai.model | quote }}
+            - name: DEEPINFRA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: DEEPINFRA_API_KEY
+          ports:
+            - name: http
+              containerPort: {{ .Values.modules.llm.port }}
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - python
+                - -c
+                - "import urllib.request; urllib.request.urlopen('http://localhost:{{ .Values.modules.llm.port }}/health')"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - python
+                - -c
+                - "import urllib.request; urllib.request.urlopen('http://localhost:{{ .Values.modules.llm.port }}/health')"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+{{- end }}

--- a/helm/druppie/templates/module-registry-deployment.yaml
+++ b/helm/druppie/templates/module-registry-deployment.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.modules.registry.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-registry
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: module-registry
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: module-registry
+    spec:
+      containers:
+        - name: module-registry
+          image: {{ include "druppie.image" (dict "Values" .Values "image" .Values.modules.registry.image) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: DATA_DIR
+              value: "/data"
+            - name: MCP_PORT
+              value: {{ .Values.modules.registry.port | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.modules.registry.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: registry-agents
+              mountPath: /data/agents
+              readOnly: true
+            - name: registry-mcp-config
+              mountPath: /data/mcp_config.yaml
+              readOnly: true
+            - name: registry-skills
+              mountPath: /data/skills
+              readOnly: true
+            - name: registry-builtin-tools
+              mountPath: /data/builtin_tools.py
+              readOnly: true
+            - name: registry-mcp-servers
+              mountPath: /data/mcp-servers
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.registry.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.registry.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      volumes:
+        - name: registry-agents
+          configMap:
+            name: {{ include "druppie.fullname" . }}-registry-agents
+            optional: true
+        - name: registry-mcp-config
+          configMap:
+            name: {{ include "druppie.fullname" . }}-registry-mcp-config
+            optional: true
+        - name: registry-skills
+          configMap:
+            name: {{ include "druppie.fullname" . }}-registry-skills
+            optional: true
+        - name: registry-builtin-tools
+          configMap:
+            name: {{ include "druppie.fullname" . }}-registry-builtin-tools
+            optional: true
+        - name: registry-mcp-servers
+          emptyDir: {}
+{{- end }}

--- a/helm/druppie/templates/module-vision-deployment.yaml
+++ b/helm/druppie/templates/module-vision-deployment.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.modules.vision.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-vision
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-vision
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: module-vision
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: module-vision
+    spec:
+      containers:
+        - name: module-vision
+          image: {{ include "druppie.image" (dict "Values" .Values "image" .Values.modules.vision.image) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: MCP_PORT
+              value: {{ .Values.modules.vision.port | quote }}
+            - name: ZAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: ZAI_API_KEY
+            - name: ZAI_BASE_URL
+              value: {{ .Values.backend.zai.baseUrl | quote }}
+            - name: ZAI_VISION_MODEL
+              value: ""
+            - name: DEEPINFRA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "druppie.fullname" . }}-secrets
+                  key: DEEPINFRA_API_KEY
+          ports:
+            - name: http
+              containerPort: {{ .Values.modules.vision.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.vision.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.vision.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+{{- end }}

--- a/helm/druppie/templates/module-web-deployment.yaml
+++ b/helm/druppie/templates/module-web-deployment.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.modules.web.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-web
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: module-web
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: module-web
+    spec:
+      containers:
+        - name: module-web
+          image: {{ include "druppie.image" (dict "Values" .Values "image" .Values.modules.web.image) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: SEARCH_ROOT
+              value: "/dataset"
+            - name: MCP_PORT
+              value: {{ .Values.modules.web.port | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.modules.web.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: dataset
+              mountPath: /dataset
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.web.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.modules.web.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      volumes:
+        - name: dataset
+          persistentVolumeClaim:
+            claimName: {{ include "druppie.fullname" . }}-dataset
+{{- end }}

--- a/helm/druppie/templates/networkpolicy.yaml
+++ b/helm/druppie/templates/networkpolicy.yaml
@@ -1,0 +1,144 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "druppie.fullname" . }}-app-net
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "druppie.selectorLabels" . | nindent 14 }}
+        - namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "druppie.selectorLabels" . | nindent 14 }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 80
+          protocol: TCP
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "druppie.fullname" . }}-sandbox-net
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      network-access: sandbox
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "druppie.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: backend
+        - podSelector:
+            matchLabels:
+              {{- include "druppie.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: module-coding
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "druppie.fullname" . }}-sandbox-inet
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      network-access: sandbox
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "druppie.fullname" . }}-sandbox-modules
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: module-coding
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "druppie.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: backend
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "druppie.fullname" . }}-sandbox-modules-docker
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "druppie.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: module-docker
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "druppie.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: backend

--- a/helm/druppie/templates/persistentvolumeclaims.yaml
+++ b/helm/druppie/templates/persistentvolumeclaims.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "druppie.fullname" . }}-workspace
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: workspace
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.workspace.size }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "druppie.fullname" . }}-dataset
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dataset
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.dataset.size }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "druppie.fullname" . }}-sandbox-bundles
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-bundles
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.sandboxBundles.size }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "druppie.fullname" . }}-gitea-data
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gitea
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.gitea.storage }}
+{{- end }}

--- a/helm/druppie/templates/sandbox-image-builder-job.yaml
+++ b/helm/druppie/templates/sandbox-image-builder-job.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "druppie.fullname" . }}-sandbox-image-builder
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-image-builder
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "druppie.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: sandbox-image-builder
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: builder
+          image: {{ .Values.sandbox.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          command: ["echo", "Sandbox base image should be pre-built and pushed to registry"]
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"

--- a/helm/druppie/templates/secrets.yaml
+++ b/helm/druppie/templates/secrets.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "druppie.fullname" . }}-secrets
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # Database passwords
+  DRUPPIE_DB_PASSWORD: {{ .Values.postgresql.druppie.password | quote }}
+  KEYCLOAK_DB_PASSWORD: {{ .Values.postgresql.keycloak.password | quote }}
+  GITEA_DB_PASSWORD: {{ .Values.postgresql.gitea.password | quote }}
+
+  # Database URLs
+  DATABASE_URL: "postgresql://{{ .Values.postgresql.druppie.username }}:{{ .Values.postgresql.druppie.password }}@{{ include "druppie.fullname" . }}-druppie-db:5432/{{ .Values.postgresql.druppie.database }}"
+
+  # Keycloak
+  KEYCLOAK_ADMIN: {{ .Values.keycloak.adminUser | quote }}
+  KEYCLOAK_ADMIN_PASSWORD: {{ .Values.keycloak.adminPassword | quote }}
+
+  # Gitea
+  GITEA_ADMIN_PASSWORD: {{ .Values.gitea.adminPassword | quote }}
+  GITEA_TOKEN: {{ .Values.secrets.giteaToken | quote }}
+
+  # API Keys
+  ZAI_API_KEY: {{ .Values.secrets.zaiApiKey | quote }}
+  DEEPSEEK_API_KEY: {{ .Values.secrets.deepseekApiKey | quote }}
+  DEEPINFRA_API_KEY: {{ .Values.secrets.deepinfraApiKey | quote }}
+  FOUNDRY_API_KEY: {{ .Values.secrets.foundryApiKey | quote }}
+
+  # Internal
+  INTERNAL_API_KEY: {{ .Values.secrets.internalApiKey | quote }}
+  DRUPPIE_MODULE_API_TOKEN: {{ .Values.secrets.moduleApiToken | quote }}

--- a/helm/druppie/templates/services.yaml
+++ b/helm/druppie/templates/services.yaml
@@ -60,7 +60,7 @@ metadata:
     {{- include "druppie.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak
 spec:
-  type: ClusterIP
+  type: NodePort
   selector:
     {{- include "druppie.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak
@@ -68,6 +68,7 @@ spec:
     - name: http
       port: 8080
       targetPort: http
+      nodePort: 30002
 ---
 # Gitea Service
 apiVersion: v1
@@ -78,7 +79,7 @@ metadata:
     {{- include "druppie.labels" . | nindent 4 }}
     app.kubernetes.io/component: gitea
 spec:
-  type: ClusterIP
+  type: NodePort
   selector:
     {{- include "druppie.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: gitea
@@ -86,6 +87,7 @@ spec:
     - name: http
       port: 3000
       targetPort: http
+      nodePort: 30003
     - name: ssh
       port: 2222
       targetPort: ssh
@@ -99,7 +101,7 @@ metadata:
     {{- include "druppie.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend
 spec:
-  type: ClusterIP
+  type: NodePort
   selector:
     {{- include "druppie.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: backend
@@ -107,6 +109,7 @@ spec:
     - name: http
       port: {{ .Values.backend.port }}
       targetPort: http
+      nodePort: 30000
 ---
 # Frontend Service
 apiVersion: v1
@@ -117,7 +120,7 @@ metadata:
     {{- include "druppie.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend
 spec:
-  type: ClusterIP
+  type: NodePort
   selector:
     {{- include "druppie.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: frontend
@@ -125,6 +128,7 @@ spec:
     - name: http
       port: {{ .Values.frontend.port }}
       targetPort: http
+      nodePort: 30001
 {{- if .Values.modules.coding.enabled }}
 ---
 # Module Coding Service

--- a/helm/druppie/templates/services.yaml
+++ b/helm/druppie/templates/services.yaml
@@ -1,0 +1,287 @@
+# Database Services
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-druppie-db
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: druppie-db
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: druppie-db
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-keycloak-db
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak-db
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak-db
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-gitea-db
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gitea-db
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gitea-db
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+---
+# Keycloak Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-keycloak
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+# Gitea Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-gitea
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gitea
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gitea
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+    - name: ssh
+      port: 2222
+      targetPort: ssh
+---
+# Backend Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-backend
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+  ports:
+    - name: http
+      port: {{ .Values.backend.port }}
+      targetPort: http
+---
+# Frontend Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-frontend
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+  ports:
+    - name: http
+      port: {{ .Values.frontend.port }}
+      targetPort: http
+{{- if .Values.modules.coding.enabled }}
+---
+# Module Coding Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-coding
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-coding
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: module-coding
+  ports:
+    - name: http
+      port: {{ .Values.modules.coding.port }}
+      targetPort: http
+{{- end }}
+{{- if .Values.modules.docker.enabled }}
+---
+# Module Docker Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-docker
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-docker
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: module-docker
+  ports:
+    - name: http
+      port: {{ .Values.modules.docker.port }}
+      targetPort: http
+{{- end }}
+{{- if .Values.modules.filesearch.enabled }}
+---
+# Module Filesearch Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-filesearch
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-filesearch
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: module-filesearch
+  ports:
+    - name: http
+      port: {{ .Values.modules.filesearch.port }}
+      targetPort: http
+{{- end }}
+{{- if .Values.modules.web.enabled }}
+---
+# Module Web Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-web
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-web
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: module-web
+  ports:
+    - name: http
+      port: {{ .Values.modules.web.port }}
+      targetPort: http
+{{- end }}
+{{- if .Values.modules.archimate.enabled }}
+---
+# Module Archimate Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-archimate
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-archimate
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: module-archimate
+  ports:
+    - name: http
+      port: {{ .Values.modules.archimate.port }}
+      targetPort: http
+{{- end }}
+{{- if .Values.modules.registry.enabled }}
+---
+# Module Registry Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-registry
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-registry
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: module-registry
+  ports:
+    - name: http
+      port: {{ .Values.modules.registry.port }}
+      targetPort: http
+{{- end }}
+{{- if .Values.modules.llm.enabled }}
+---
+# Module LLM Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-llm
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-llm
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: module-llm
+  ports:
+    - name: http
+      port: {{ .Values.modules.llm.port }}
+      targetPort: http
+{{- end }}
+{{- if .Values.modules.vision.enabled }}
+---
+# Module Vision Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druppie.fullname" . }}-module-vision
+  labels:
+    {{- include "druppie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: module-vision
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "druppie.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: module-vision
+  ports:
+    - name: http
+      port: {{ .Values.modules.vision.port }}
+      targetPort: http
+{{- end }}

--- a/helm/druppie/values.yaml
+++ b/helm/druppie/values.yaml
@@ -51,6 +51,7 @@ keycloak:
   adminUser: admin
   adminPassword: admin
   hostname: ""
+  nodePort: 8080
   resources:
     requests:
       memory: "384Mi"
@@ -82,6 +83,7 @@ gitea:
   org: druppie
   sshPort: 2222
   httpPort: 3000
+  nodePort: 3000
   storage: 5Gi
 
 # Backend API
@@ -90,6 +92,7 @@ backend:
     repository: druppie-backend
     tag: latest
   port: 8000
+  nodePort: 8000
   resources:
     requests:
       memory: "256Mi"
@@ -132,6 +135,7 @@ frontend:
     repository: druppie-frontend
     tag: latest
   port: 5173
+  nodePort: 5173
   # Vite environment variables
   vite:
     keycloakRealm: druppie

--- a/helm/druppie/values.yaml
+++ b/helm/druppie/values.yaml
@@ -1,0 +1,229 @@
+# Druppie Platform - Helm Values
+# =================================
+
+# Global settings
+global:
+  instance: druppie
+  imagePullPolicy: IfNotPresent
+  # Override for image registry prefix (e.g. "ghcr.io/myorg/")
+  imageRegistry: ""
+  # Domain configuration — controls all external URLs
+  # Local dev: localhost (path-based routing on port 9080)
+  # Production: druppie.example.com
+  domain: localhost
+  # Toggle for ingress (set true for kind/prod, false for bare port-forward)
+  ingress:
+    enabled: true
+    className: nginx
+    port: 9080
+    # TLS config for production
+    tls:
+      enabled: false
+      secretName: ""
+    # Additional annotations (e.g., cert-manager)
+    annotations: {}
+
+# PostgreSQL database defaults
+postgresql:
+  image: postgres:15-alpine
+  druppie:
+    database: druppie
+    username: druppie
+    password: druppie_secret
+    port: 5432
+    storage: 5Gi
+  keycloak:
+    database: keycloak
+    username: keycloak
+    password: keycloak_secret
+    port: 5432
+    storage: 5Gi
+  gitea:
+    database: gitea
+    username: gitea
+    password: gitea_secret
+    port: 5432
+    storage: 5Gi
+
+# Keycloak Identity Provider
+keycloak:
+  image: quay.io/keycloak/keycloak:24.0
+  adminUser: admin
+  adminPassword: admin
+  hostname: ""
+  resources:
+    requests:
+      memory: "384Mi"
+      cpu: "250m"
+    limits:
+      memory: "768Mi"
+      cpu: "1000m"
+  readinessProbe:
+    httpGet:
+      path: /health/ready
+      port: 8080
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    failureThreshold: 15
+  livenessProbe:
+    httpGet:
+      path: /health/ready
+      port: 8080
+    initialDelaySeconds: 90
+    periodSeconds: 30
+    failureThreshold: 10
+
+# Gitea Git Server
+gitea:
+  image: gitea/gitea:1.21
+  adminUser: gitea_admin
+  adminPassword: GiteaAdmin123
+  adminEmail: admin@druppie.local
+  org: druppie
+  sshPort: 2222
+  httpPort: 3000
+  storage: 5Gi
+
+# Backend API
+backend:
+  image:
+    repository: druppie-backend
+    tag: latest
+  port: 8000
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "1000m"
+  devMode: false
+  dockerSocket:
+    enabled: false
+  # LLM configuration
+  llm:
+    provider: zai
+    forceProvider: ""
+    forceModel: ""
+  # LLM provider settings
+  zai:
+    model: glm-4.7
+    baseUrl: https://api.z.ai/api/coding/paas/v4
+  deepseek:
+    model: deepseek-chat
+    baseUrl: https://api.deepseek.com/v1
+  deepinfra:
+    model: Qwen/Qwen3-32B
+    baseUrl: https://api.deepinfra.com/v1
+  foundry:
+    model: GPT-5-MINI
+    apiUrl: ""
+  # GitHub App
+  github:
+    appId: ""
+    appPrivateKeyPath: ""
+    appInstallationId: ""
+    repoOwner: ""
+    repoName: ""
+
+# Frontend
+frontend:
+  image:
+    repository: druppie-frontend
+    tag: latest
+  port: 5173
+  # Vite environment variables
+  vite:
+    keycloakRealm: druppie
+    keycloakClientId: druppie-frontend
+
+# MCP Modules
+modules:
+  coding:
+    enabled: true
+    image:
+      repository: druppie-module-coding
+      tag: latest
+    port: 9001
+  docker:
+    enabled: true
+    image:
+      repository: druppie-module-docker
+      tag: latest
+    port: 9002
+  filesearch:
+    enabled: true
+    image:
+      repository: druppie-module-filesearch
+      tag: latest
+    port: 9004
+  web:
+    enabled: true
+    image:
+      repository: druppie-module-web
+      tag: latest
+    port: 9005
+  archimate:
+    enabled: true
+    image:
+      repository: druppie-module-archimate
+      tag: latest
+    port: 9006
+  registry:
+    enabled: true
+    image:
+      repository: druppie-module-registry
+      tag: latest
+    port: 9007
+  llm:
+    enabled: true
+    image:
+      repository: druppie-module-llm
+      tag: latest
+    port: 9008
+  vision:
+    enabled: true
+    image:
+      repository: druppie-module-vision
+      tag: latest
+    port: 9011
+
+# Init job
+init:
+  enabled: true
+  image:
+    repository: druppie-init
+    tag: latest
+
+# Sandbox configuration
+sandbox:
+  runtime: sysbox-runc
+  image: druppie-sandbox:latest
+  memoryLimit: 4g
+  cpuLimit: "2"
+
+# Networking (ingress config moved to global.ingress)
+
+# Persistence
+persistence:
+  enabled: true
+  storageClass: ""
+  workspace:
+    size: 10Gi
+  dataset:
+    size: 5Gi
+  sandboxBundles:
+    size: 5Gi
+
+# Secrets (override in production)
+secrets:
+  zaiApiKey: ""
+  deepseekApiKey: ""
+  deepinfraApiKey: ""
+  foundryApiKey: ""
+  internalApiKey: druppie-internal-secret-key
+  keycloakClientSecret: ""
+  giteaClientSecret: ""
+  giteaSecretKey: ""
+  giteaToken: ""
+  moduleApiToken: ""

--- a/kind/cluster-dev.yaml
+++ b/kind/cluster-dev.yaml
@@ -1,0 +1,22 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: druppie
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 9080
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 8443
+        protocol: TCP
+networking:
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: "10.96.0.0/12"
+  disableDefaultCNI: false

--- a/kind/cluster.yaml
+++ b/kind/cluster.yaml
@@ -1,0 +1,37 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: druppie
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP
+      # Direct port mappings for development (no ingress needed)
+      - containerPort: 30000  # backend NodePort
+        hostPort: 8000
+        protocol: TCP
+      - containerPort: 30001  # frontend NodePort
+        hostPort: 5173
+        protocol: TCP
+      - containerPort: 30002  # keycloak NodePort
+        hostPort: 8080
+        protocol: TCP
+      - containerPort: 30003  # gitea HTTP NodePort
+        hostPort: 3000
+        protocol: TCP
+  - role: worker
+  - role: worker
+networking:
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: "10.96.0.0/12"
+  disableDefaultCNI: false

--- a/kind/cluster.yaml
+++ b/kind/cluster.yaml
@@ -29,8 +29,6 @@ nodes:
       - containerPort: 30003  # gitea HTTP NodePort
         hostPort: 3000
         protocol: TCP
-  - role: worker
-  - role: worker
 networking:
   podSubnet: "10.244.0.0/16"
   serviceSubnet: "10.96.0.0/12"

--- a/scripts/build-and-load.sh
+++ b/scripts/build-and-load.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 CLUSTER_NAME="druppie"
-SOURCE_DIR="/mnt/HC_Volume_104477633/home_nuno/Documents/druppie-fork"
+SOURCE_DIR="$PROJECT_DIR"
 
 # Colors
 GREEN='\033[0;32m'

--- a/scripts/build-and-load.sh
+++ b/scripts/build-and-load.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build Druppie Docker images and load them into kind cluster
+# Usage: ./scripts/build-and-load.sh [image-name]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+CLUSTER_NAME="druppie"
+SOURCE_DIR="/mnt/HC_Volume_104477633/home_nuno/Documents/druppie-fork"
+
+# Colors
+GREEN='\033[0;32m'
+NC='\033[0m'
+log() { echo -e "${GREEN}[druppie]${NC} $*"; }
+
+build_and_load() {
+    local image_name="$1"
+    local dockerfile="$2"
+    local context="$3"
+
+    log "Building $image_name..."
+    docker build -t "$image_name:latest" -f "$dockerfile" "$context"
+
+    log "Loading $image_name into kind..."
+    kind load docker-image "$image_name:latest" --name "$CLUSTER_NAME"
+}
+
+# Build all images
+build_all() {
+    log "Building all Druppie images..."
+
+    # Backend
+    build_and_load "druppie-backend" "$SOURCE_DIR/Dockerfile" "$SOURCE_DIR"
+
+    # Frontend
+    build_and_load "druppie-frontend" "$SOURCE_DIR/frontend/Dockerfile" "$SOURCE_DIR/frontend"
+
+    # Init
+    build_and_load "druppie-init" "$SOURCE_DIR/Dockerfile.init" "$SOURCE_DIR"
+
+    # MCP Modules - build from mcp-servers context
+    local MCP_DIR="$SOURCE_DIR/druppie/mcp-servers"
+    for module in coding docker filesearch web archimate registry llm vision; do
+        if [ -f "$MCP_DIR/module-$module/Dockerfile" ]; then
+            build_and_load "druppie-module-$module" "$MCP_DIR/module-$module/Dockerfile" "$MCP_DIR"
+        fi
+    done
+
+    # Sandbox image
+    if [ -f "$MCP_DIR/module-coding/Dockerfile.sandbox" ]; then
+        build_and_load "druppie-sandbox" "$MCP_DIR/module-coding/Dockerfile.sandbox" "$MCP_DIR"
+    fi
+
+    log "All images built and loaded!"
+}
+
+case "${1:-all}" in
+    backend)
+        build_and_load "druppie-backend" "$SOURCE_DIR/Dockerfile" "$SOURCE_DIR"
+        ;;
+    frontend)
+        build_and_load "druppie-frontend" "$SOURCE_DIR/frontend/Dockerfile" "$SOURCE_DIR/frontend"
+        ;;
+    module-*)
+        module="${1#module-}"
+        build_and_load "druppie-module-$module" "$SOURCE_DIR/druppie/mcp-servers/module-$module/Dockerfile" "$SOURCE_DIR/druppie/mcp-servers"
+        ;;
+    all)
+        build_all
+        ;;
+    *)
+        echo "Usage: $0 {all|backend|frontend|module-<name>}"
+        echo "  Modules: coding, docker, filesearch, web, archimate, registry, llm, vision"
+        exit 1
+        ;;
+esac

--- a/scripts/port-forward.sh
+++ b/scripts/port-forward.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# NOTE: This is for debugging only. The recommended way is via Ingress.
+# Ensure ingress is enabled: global.ingress.enabled=true
+# Then add to /etc/hosts: 127.0.0.1 druppie.localhost api.druppie.localhost auth.druppie.localhost git.druppie.localhost
+
+NAMESPACE="druppie"
+
+echo "=== Druppie Port-Forward (debug only — use Ingress for normal access) ==="
+echo ""
+echo "  Backend:    http://localhost:8000"
+echo "  Frontend:   http://localhost:5173"
+echo "  Keycloak:   http://localhost:8080"
+echo "  Gitea:      http://localhost:3000"
+echo ""
+echo "Press Ctrl+C to stop."
+echo ""
+
+cleanup() { kill $(jobs -p) 2>/dev/null; }
+trap cleanup EXIT
+
+kubectl port-forward -n "$NAMESPACE" svc/druppie-backend 8000:8000 &
+kubectl port-forward -n "$NAMESPACE" svc/druppie-frontend 5173:5173 &
+kubectl port-forward -n "$NAMESPACE" svc/druppie-keycloak 8080:8080 &
+kubectl port-forward -n "$NAMESPACE" svc/druppie-gitea 3000:3000 &
+
+wait

--- a/scripts/setup-kind.sh
+++ b/scripts/setup-kind.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Druppie Kubernetes - Kind Cluster Setup
+# Usage: ./scripts/setup-kind.sh [create|delete|status]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+CLUSTER_NAME="druppie"
+NAMESPACE="druppie"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[druppie]${NC} $*"; }
+warn() { echo -e "${YELLOW}[warn]${NC} $*"; }
+error() { echo -e "${RED}[error]${NC} $*" >&2; exit 1; }
+
+check_prerequisites() {
+    log "Checking prerequisites..."
+    command -v kind >/dev/null 2>&1 || error "kind not found. Install: https://kind.sigs.k8s.io/docs/user/quick-start/"
+    command -v kubectl >/dev/null 2>&1 || error "kubectl not found. Install: https://kubernetes.io/docs/tasks/tools/"
+    command -v helm >/dev/null 2>&1 || error "helm not found. Install: https://helm.sh/docs/intro/install/"
+    log "All prerequisites met."
+}
+
+create_cluster() {
+    if kind get clusters 2>/dev/null | grep -q "$CLUSTER_NAME"; then
+        warn "Cluster '$CLUSTER_NAME' already exists. Use 'delete' first or 'status'."
+        exit 0
+    fi
+
+    log "Creating kind cluster '$CLUSTER_NAME'..."
+    kind create cluster \
+        --config "$PROJECT_DIR/kind/cluster.yaml" \
+        --image kindest/node:v1.29.2
+
+    log "Waiting for nodes to be ready..."
+    kubectl wait --for=condition=ready nodes --all --timeout=120s
+
+    log "Cluster created successfully!"
+    show_status
+}
+
+delete_cluster() {
+    log "Deleting kind cluster '$CLUSTER_NAME'..."
+    kind delete cluster --name "$CLUSTER_NAME"
+    log "Cluster deleted."
+}
+
+deploy_chart() {
+    log "Building Docker images and loading into kind..."
+    # TODO: Add image build and load commands when Dockerfiles are ready
+
+    log "Creating namespace..."
+    kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+    log "Installing Helm chart..."
+    helm upgrade --install druppie "$PROJECT_DIR/helm/druppie" \
+        --namespace "$NAMESPACE" \
+        --values "$PROJECT_DIR/helm/druppie/values.yaml" \
+        --wait --timeout 10m
+
+    log "Deploy complete!"
+}
+
+show_status() {
+    log "Cluster status:"
+    kubectl cluster-info --context "kind-$CLUSTER_NAME" 2>/dev/null || true
+    echo ""
+    kubectl get nodes
+    echo ""
+    log "Pods (namespace: $NAMESPACE):"
+    kubectl get pods -n "$NAMESPACE" 2>/dev/null || warn "Namespace not yet created"
+    echo ""
+    log "Services (namespace: $NAMESPACE):"
+    kubectl get svc -n "$NAMESPACE" 2>/dev/null || warn "Namespace not yet created"
+    echo ""
+    log "Port-forward commands for local access:"
+    echo "  kubectl port-forward -n $NAMESPACE svc/backend 8000:8000"
+    echo "  kubectl port-forward -n $NAMESPACE svc/frontend 5173:5173"
+    echo "  kubectl port-forward -n $NAMESPACE svc/keycloak 8080:8080"
+    echo "  kubectl port-forward -n $NAMESPACE svc/gitea 3000:3000"
+}
+
+case "${1:-create}" in
+    create)
+        check_prerequisites
+        create_cluster
+        ;;
+    delete)
+        delete_cluster
+        ;;
+    deploy)
+        deploy_chart
+        ;;
+    status)
+        show_status
+        ;;
+    all)
+        check_prerequisites
+        create_cluster
+        deploy_chart
+        ;;
+    *)
+        echo "Usage: $0 {create|delete|deploy|status|all}"
+        exit 1
+        ;;
+esac

--- a/scripts/setup-kind.sh
+++ b/scripts/setup-kind.sh
@@ -51,9 +51,48 @@ delete_cluster() {
     log "Cluster deleted."
 }
 
-deploy_chart() {
+build_and_load_images() {
     log "Building Docker images and loading into kind..."
-    # TODO: Add image build and load commands when Dockerfiles are ready
+
+    _build_one() {
+        local name="$1" dockerfile="$2" context="$3"
+        log "  Building $name..."
+        docker build -q -t "$name:latest" -f "$dockerfile" "$context" >/dev/null
+        kind load docker-image "$name:latest" --name "$CLUSTER_NAME" 2>/dev/null
+    }
+
+    _build_one "druppie-backend"  "$PROJECT_DIR/Dockerfile"           "$PROJECT_DIR"
+    _build_one "druppie-frontend" "$PROJECT_DIR/frontend/Dockerfile"  "$PROJECT_DIR/frontend"
+    _build_one "druppie-init"     "$PROJECT_DIR/Dockerfile.init"      "$PROJECT_DIR"
+
+    local MCP_DIR="$PROJECT_DIR/druppie/mcp-servers"
+    for module in coding docker filesearch web archimate registry llm vision; do
+        if [ -f "$MCP_DIR/module-$module/Dockerfile" ]; then
+            _build_one "druppie-module-$module" "$MCP_DIR/module-$module/Dockerfile" "$MCP_DIR"
+        fi
+    done
+
+    log "All images built and loaded into kind."
+}
+
+install_nginx_ingress() {
+    if ! kubectl get ns ingress-nginx >/dev/null 2>&1 || \
+       ! kubectl get pods -n ingress-nginx -l app.kubernetes.io/component=controller --field-selector=status.phase=Running -o name 2>/dev/null | grep -q .; then
+        log "Installing NGINX Ingress Controller..."
+        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+        log "Waiting for ingress controller..."
+        kubectl wait --namespace ingress-nginx \
+            --for=condition=ready pod \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=120s
+    else
+        log "NGINX Ingress Controller already running."
+    fi
+}
+
+deploy_chart() {
+    build_and_load_images
+    install_nginx_ingress
 
     log "Creating namespace..."
     kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[druppie]${NC} $*"; }
+warn() { echo -e "${YELLOW}[warn]${NC} $*"; }
+err()  { echo -e "${RED}[error]${NC} $*" >&2; }
+
+CLUSTER_NAME="druppie"
+NAMESPACE="druppie"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+stop_docker_compose() {
+    if docker compose ps --status running -q 2>/dev/null | grep -q .; then
+        log "Stopping Docker Compose services..."
+        docker compose --profile dev --profile init --profile infra --profile prod down 2>/dev/null || true
+    fi
+}
+
+stop_kind() {
+    if kind get clusters 2>/dev/null | grep -q "$CLUSTER_NAME"; then
+        log "Deleting kind cluster '$CLUSTER_NAME'..."
+        kind delete cluster --name "$CLUSTER_NAME"
+    fi
+}
+
+stop_all() {
+    stop_docker_compose
+    stop_kind
+}
+
+check_kind_prerequisites() {
+    local missing=()
+    command -v kind    >/dev/null 2>&1 || missing+=("kind")
+    command -v kubectl >/dev/null 2>&1 || missing+=("kubectl")
+    command -v helm    >/dev/null 2>&1 || missing+=("helm")
+    if [ ${#missing[@]} -gt 0 ]; then
+        err "Missing tools: ${missing[*]}"
+        err "Install them before using Kubernetes mode."
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Docker Compose mode
+# ---------------------------------------------------------------------------
+
+start_docker() {
+    stop_all
+    log "Starting Druppie with Docker Compose (dev profile)..."
+    docker compose --profile dev --profile init up -d
+    echo ""
+    log "Druppie is starting up. Services:"
+    echo ""
+    echo -e "  ${CYAN}Frontend${NC}   http://localhost:${FRONTEND_PORT:-5273}"
+    echo -e "  ${CYAN}Backend${NC}    http://localhost:${BACKEND_PORT:-8100}"
+    echo -e "  ${CYAN}Keycloak${NC}   http://localhost:${KEYCLOAK_PORT:-8180}"
+    echo -e "  ${CYAN}Gitea${NC}      http://localhost:${GITEA_PORT:-3100}"
+    echo -e "  ${CYAN}Adminer${NC}    http://localhost:${ADMINER_PORT:-8081}"
+    echo ""
+    log "View logs: docker compose logs -f"
+}
+
+# ---------------------------------------------------------------------------
+# Kubernetes (kind) mode
+# ---------------------------------------------------------------------------
+
+build_and_load_images() {
+    log "Building Docker images and loading into kind..."
+
+    build_one() {
+        local name="$1" dockerfile="$2" context="$3"
+        log "  Building $name..."
+        docker build -q -t "$name:latest" -f "$dockerfile" "$context" >/dev/null
+        kind load docker-image "$name:latest" --name "$CLUSTER_NAME" 2>/dev/null
+    }
+
+    build_one "druppie-backend"  "$SCRIPT_DIR/Dockerfile"      "$SCRIPT_DIR"
+    build_one "druppie-frontend" "$SCRIPT_DIR/frontend/Dockerfile" "$SCRIPT_DIR/frontend"
+    build_one "druppie-init"     "$SCRIPT_DIR/Dockerfile.init"  "$SCRIPT_DIR"
+
+    local MCP_DIR="$SCRIPT_DIR/druppie/mcp-servers"
+    for module in coding docker filesearch web archimate registry llm vision; do
+        if [ -f "$MCP_DIR/module-$module/Dockerfile" ]; then
+            build_one "druppie-module-$module" "$MCP_DIR/module-$module/Dockerfile" "$MCP_DIR"
+        fi
+    done
+
+    log "All images built and loaded into kind."
+}
+
+install_nginx_ingress() {
+    if ! kubectl get ns ingress-nginx >/dev/null 2>&1 || \
+       ! kubectl get pods -n ingress-nginx -l app.kubernetes.io/component=controller --field-selector=status.phase=Running -o name 2>/dev/null | grep -q .; then
+        log "Installing NGINX Ingress Controller..."
+        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+        log "Waiting for ingress controller to be ready..."
+        kubectl wait --namespace ingress-nginx \
+            --for=condition=ready pod \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=120s
+    else
+        log "NGINX Ingress Controller already running."
+    fi
+}
+
+deploy_helm_chart() {
+    log "Creating namespace..."
+    kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+    log "Installing Helm chart..."
+    helm upgrade --install druppie "$SCRIPT_DIR/helm/druppie" \
+        --namespace "$NAMESPACE" \
+        --values "$SCRIPT_DIR/helm/druppie/values.yaml" \
+        --wait --timeout 10m
+
+    log "Helm deploy complete!"
+}
+
+wait_for_pods() {
+    log "Waiting for pods to be ready (timeout 5m)..."
+    local deadline=$((SECONDS + 300))
+    while [ $SECONDS -lt $deadline ]; do
+        local not_ready
+        not_ready=$(kubectl get pods -n "$NAMESPACE" --no-headers 2>/dev/null \
+            | grep -v Completed \
+            | grep -v Running \
+            | grep -cv "^$" || true)
+        if [ "$not_ready" -eq 0 ] 2>/dev/null; then
+            log "All pods running!"
+            return 0
+        fi
+        sleep 5
+    done
+    warn "Some pods are not ready yet. Check: kubectl get pods -n $NAMESPACE"
+}
+
+start_kubernetes() {
+    check_kind_prerequisites
+    stop_all
+
+    log "Starting Druppie with Kubernetes (kind)..."
+    echo ""
+
+    # 1. Create cluster if needed
+    if kind get clusters 2>/dev/null | grep -q "$CLUSTER_NAME"; then
+        log "Kind cluster '$CLUSTER_NAME' already exists, reusing."
+    else
+        log "Creating kind cluster '$CLUSTER_NAME'..."
+        kind create cluster \
+            --config "$SCRIPT_DIR/kind/cluster.yaml" \
+            --image kindest/node:v1.29.2
+        log "Waiting for nodes..."
+        kubectl wait --for=condition=ready nodes --all --timeout=120s
+    fi
+
+    # 2. Build and load images
+    build_and_load_images
+
+    # 3. Install ingress controller
+    install_nginx_ingress
+
+    # 4. Deploy helm chart
+    deploy_helm_chart
+
+    # 5. Wait for pods
+    wait_for_pods
+
+    echo ""
+    log "Druppie is running on Kubernetes!"
+    echo ""
+    echo -e "  ${CYAN}All services${NC}  http://localhost:9080"
+    echo -e "    /          Frontend"
+    echo -e "    /api       Backend API"
+    echo -e "    /realms    Keycloak"
+    echo -e "    /git       Gitea"
+    echo ""
+    echo -e "  ${CYAN}Status${NC}   kubectl get pods -n $NAMESPACE"
+    echo -e "  ${CYAN}Logs${NC}     kubectl logs -n $NAMESPACE -f deploy/druppie-backend"
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Stop mode
+# ---------------------------------------------------------------------------
+
+do_stop() {
+    log "Stopping all Druppie services..."
+    stop_all
+    log "Everything stopped."
+}
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+do_status() {
+    echo -e "${BOLD}=== Druppie Status ===${NC}"
+    echo ""
+
+    # Docker Compose
+    local compose_running
+    compose_running=$(docker compose ps --status running -q 2>/dev/null | wc -l || echo 0)
+    if [ "$compose_running" -gt 0 ]; then
+        echo -e "  ${GREEN}Docker Compose${NC}: $compose_running container(s) running"
+        docker compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null | head -25
+    else
+        echo -e "  ${YELLOW}Docker Compose${NC}: not running"
+    fi
+    echo ""
+
+    # Kind
+    if kind get clusters 2>/dev/null | grep -q "$CLUSTER_NAME"; then
+        echo -e "  ${GREEN}Kind cluster${NC}: running"
+        kubectl get nodes 2>/dev/null | sed 's/^/    /'
+        echo ""
+        echo "  Pods:"
+        kubectl get pods -n "$NAMESPACE" --no-headers 2>/dev/null | sed 's/^/    /' || echo "    (none)"
+    else
+        echo -e "  ${YELLOW}Kind cluster${NC}: not running"
+    fi
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Interactive menu
+# ---------------------------------------------------------------------------
+
+show_menu() {
+    echo ""
+    echo -e "${BOLD}=== Druppie Startup ===${NC}"
+    echo ""
+    echo -e "  ${CYAN}1${NC}) Docker Compose  (dev mode, hot reload)"
+    echo -e "  ${CYAN}2${NC}) Kubernetes      (kind cluster + Helm)"
+    echo -e "  ${CYAN}3${NC}) Stop all"
+    echo -e "  ${CYAN}4${NC}) Status"
+    echo -e "  ${CYAN}q${NC}) Quit"
+    echo ""
+    read -rp "Choose [1-4/q]: " choice
+    case "$choice" in
+        1) start_docker ;;
+        2) start_kubernetes ;;
+        3) do_stop ;;
+        4) do_status ;;
+        q|Q) exit 0 ;;
+        *) err "Invalid choice: $choice"; show_menu ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+# Source .env if it exists (for port vars)
+if [ -f "$SCRIPT_DIR/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/.env"
+    set +a
+fi
+
+case "${1:-}" in
+    docker)     start_docker ;;
+    kubernetes|k8s) start_kubernetes ;;
+    stop)       do_stop ;;
+    status)     do_status ;;
+    "")         show_menu ;;
+    *)
+        echo "Usage: $0 {docker|kubernetes|stop|status}"
+        echo "  Or run without arguments for interactive menu."
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Kubernetes Migration — 2/3 stories complete ✅

| Story | Title | Points | Status |
|-------|-------|--------|--------|
| **Story 1** | Druppie draaien in Kind (basic, niet schaalbaar) | 2 | ✅ Done |
| **Story 2** | Spike: schaalbare Kubernetes strategie | 3 | ✅ Done |
| Story 3 | Implementation (production K3s + CNPG + autoscaling) | — | 🔜 Next |

---

## Summary

Full Helm chart for deploying Druppie on Kubernetes, verified with Kind cluster + Playwright e2e. Includes a comprehensive spike with research document and final architecture decision record.

## What's added (39 files)

### Helm chart (`helm/druppie/`)
- 25 templates: 3 StatefulSets, 12 Deployments, 15 Services, 5 NetworkPolicies, Ingress, ConfigMap, Secret, 4 PVCs, 2 Jobs
- Path-based ingress routing on `localhost:9080` — no `/etc/hosts` needed
- Working OAuth login flow via Keycloak, verified with Playwright e2e

### Kind configs (`kind/`)
- `cluster-dev.yaml` — lightweight dev cluster (3 worker nodes)
- `cluster.yaml` — fuller local setup

### Helper scripts (`scripts/`)
- `setup-kind.sh` — create Kind cluster with NGINX ingress
- `build-and-load.sh` — build images and load into Kind
- `port-forward.sh` — quick port-forward for debugging

### Documentation
- **`docs/KUBERNETES-STRATEGY.md`** (1332 lines) — Spike research document: comparison matrices, trade-off analysis, and technical deep-dives
- **`docs/ADR-KUBERNETES.md`** (774 lines) — Spike beslissingsdocument: 13 formal architecture decisions (4.1–4.13) with rationale and rejected alternatives
- **`docs/kubernetes.md`** (369 lines) — Practical getting-started guide
- Updated `docs/FEATURES.md`, `docs/TECHNICAL.md`, `docs/BACKLOG.md`

### Root
- `start.sh` — one-command Kind setup + build + deploy

## Architecture

```
┌─ Ingress (NGINX, localhost:9080) ───────────────────────────┐
│  / → frontend    /api → backend    /realms|/resources → KC  │
│  /git → gitea    /admin|/js|/welcome → keycloak             │
└─────────────────────────────────────────────────────────────┘

Services: backend, frontend, keycloak, gitea, 9 MCP modules
Databases: 3× PostgreSQL StatefulSets (druppie, keycloak, gitea)
Init job: setup_keycloak.py (realm, users, roles, OAuth clients)
Networking: NetworkPolicies with egress for LLM API access
```

## Story 1 — Druppie draaien in Kind ✅

> Als dev team willen we Druppie minimaal werkend krijgen op een lokaal Kubernetes cluster (Kind), zodat we de basis van Kubernetes en deployment begrijpen.

**Delivered:**
- Kind cluster setup with config files
- Full Helm chart (25 templates)
- Build scripts that create and load images into Kind
- Working OAuth login flow verified end-to-end
- Single instance, no autoscaling — "het werkt"

## Story 2 — Spike: schaalbare Kubernetes strategie ✅

> Als dev team willen we onderzoeken hoe we Druppie schaalbaar en productie-ready kunnen maken in Kubernetes, zodat we een onderbouwde technische richting kiezen.

**Delivered (analysis only, no implementation):**

| Research Question | Decision | ADR |
|---|---|---|
| Kubernetes omgeving? | **K3s** (CNCF certified, 1 binary, Hetzner VMs) | 4.2 |
| Hosting? | **Hetzner Cloud VMs** (no vendor lock-in, ~€86/mo base) | 4.1 |
| Database schaalbaar? | **CloudNativePG** (auto-failover <30s, built-in PgBouncer) | 4.3 |
| Schaalbaarheid? | **HPA + KEDA** (CPU + queue depth based) | 4.4 |
| High availability? | **3-server etcd quorum + PDB + anti-affinity** | 4.11 |
| Deployment strategie? | **PR-based CI/CD** (ArgoCD in Phase 2) | 4.9 |
| Networking? | **Traefik + cert-manager** (K3s default) | 4.5 |
| Monitoring? | **kube-prometheus-stack** | 4.7 |
| Secrets? | **Sealed Secrets** (encrypted in git) | 4.6 |
| Node autoscaling? | **Cluster Autoscaler** (Hetzner provider) | 4.13 |
| MCP modules? | **Shared volume, fixed replicas** (temporary, rebuilding as built-in tools) | 4.10 |

**Two spike deliverables:**
- `KUBERNETES-STRATEGY.md` — the research (comparison matrices, trade-offs, deep-dives)
- `ADR-KUBERNETES.md` — the final beslissingsdocument (formal decisions, rationale, rejected alternatives)

## How to test

```bash
# One-command setup
./start.sh

# Or step by step:
kind create cluster --name druppie --config kind/cluster-dev.yaml
./scripts/build-and-load.sh
kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
helm install druppie helm/druppie/ --namespace druppie --create-namespace --wait
# Access http://localhost:9080 — login: admin / Admin123!
```