### PR TITLE
Allow combining multiple choice and custom answers in HITL questions

### DIFF
--- a/druppie/api/routes/questions.py
+++ b/druppie/api/routes/questions.py
@@ -74,6 +74,7 @@ async def _resume_workflow_after_answer(
     session_id: UUID,
     question_id: UUID,
     answer: str,
+    selected_choices: list[int] | None = None,
 ) -> None:
     """Resume workflow in background using run_session_task for DB lifecycle."""
 
@@ -82,6 +83,7 @@ async def _resume_workflow_after_answer(
             session_id=session_id,
             question_id=question_id,
             answer=answer,
+            selected_choices=selected_choices,
         )
 
     await run_session_task(session_id, task, "resume_after_answer")
@@ -146,6 +148,7 @@ async def answer_question(
                 session_id=question.session_id,
                 question_id=question_id,
                 answer=request.answer,
+                selected_choices=request.selected_choices,
             ),
             name=f"resume-answer-{question_id}",
         )

--- a/druppie/execution/orchestrator.py
+++ b/druppie/execution/orchestrator.py
@@ -679,6 +679,7 @@ class Orchestrator:
         session_id: UUID,
         question_id: UUID,
         answer: str,
+        selected_choices: list[int] | None = None,
     ) -> UUID:
         """Resume execution after a HITL question is answered.
 
@@ -714,7 +715,7 @@ class Orchestrator:
             return session_id
 
         # Step 2: Complete the HITL tool call (saves answer to DB)
-        status = await tool_executor.complete_after_answer(question_id, answer)
+        status = await tool_executor.complete_after_answer(question_id, answer, selected_choices)
 
         # Step 2.5: Detect and update language from HITL answer (only if detection succeeds)
         human_input = HumanInput(answer, self.language_detector)

--- a/druppie/execution/tool_executor.py
+++ b/druppie/execution/tool_executor.py
@@ -656,7 +656,9 @@ class ToolExecutor:
             return await self._execute_builtin_tool(tool_call)
         return await self._execute_mcp_tool(tool_call)
 
-    async def complete_after_answer(self, question_id: UUID, answer: str) -> str:
+    async def complete_after_answer(
+        self, question_id: UUID, answer: str, selected_choices: list[int] | None = None
+    ) -> str:
         """Complete a HITL tool after the user answers.
 
         Called when user submits an answer to a question in the UI.
@@ -664,6 +666,7 @@ class ToolExecutor:
         Args:
             question_id: ID of the answered Question record
             answer: User's answer
+            selected_choices: Indices of selected multiple-choice options
 
         Returns:
             Final status: completed
@@ -675,7 +678,7 @@ class ToolExecutor:
             return ToolCallStatus.FAILED
 
         # Update question with answer
-        self.question_repo.update_answer(question_id, answer)
+        self.question_repo.update_answer(question_id, answer, selected_choices)
 
         # Get associated tool call
         tool_call_id = question.tool_call_id
@@ -684,12 +687,21 @@ class ToolExecutor:
             return ToolCallStatus.FAILED
 
         # Build result that will be passed back to agent
+        choices = None
+        if question.choices:
+            try:
+                choices = [c["text"] if isinstance(c, dict) else c for c in question.choices]
+            except (TypeError, KeyError):
+                choices = question.choices
+
         result = {
             "status": "answered",
             "answer": answer,
             "question": question.question,
             "question_type": question.question_type,
         }
+        if selected_choices is not None and choices:
+            result["selected_choices"] = [choices[i] for i in selected_choices if i < len(choices)]
 
         # Update tool call with result
         self.execution_repo.update_tool_call(

--- a/frontend/src/components/chat/HITLQuestionMessage.jsx
+++ b/frontend/src/components/chat/HITLQuestionMessage.jsx
@@ -6,18 +6,18 @@
  * When answered, shows the question with a green check.
  *
  * When `question.allowOther` is truthy and the question has choices,
- * an extra "Other" button is rendered below the choices. Clicking it
- * replaces the buttons with a textarea for a free-text answer.
+ * a free-text textarea is shown below the choices. The user can select
+ * choices AND type a custom answer — both are submitted together.
  */
 
 import { useState, useRef, useEffect } from 'react'
-import { Loader2, Send, X } from 'lucide-react'
+import { Loader2, Send, ChevronDown, ChevronUp } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { getAgentConfig, getAgentMessageColors } from '../../utils/agentConfig'
 import { chatMarkdownComponents } from './ChatHelpers'
 
-const HITLQuestionMessage = ({ question, onChoiceSelect, onSubmitChoices, isAnswering, answered = false }) => {
+const HITLQuestionMessage = ({ question, onSubmitAnswer, isAnswering, answered = false }) => {
   const agentId = question.agent_id || 'unknown'
   const agentConfig = getAgentConfig(agentId)
   const AgentIcon = agentConfig.icon
@@ -26,8 +26,8 @@ const HITLQuestionMessage = ({ question, onChoiceSelect, onSubmitChoices, isAnsw
   const hasOptions = question.choices && question.choices.length > 0
 
   const [selectedIndices, setSelectedIndices] = useState(new Set())
-  const [showFreeText, setShowFreeText] = useState(false)
   const [freeText, setFreeText] = useState('')
+  const [showFreeText, setShowFreeText] = useState(false)
   const freeTextRef = useRef(null)
 
   useEffect(() => {
@@ -48,17 +48,29 @@ const HITLQuestionMessage = ({ question, onChoiceSelect, onSubmitChoices, isAnsw
     })
   }
 
-  const handleSubmitChoices = () => {
-    if (selectedIndices.size === 0) return
+  const canSubmit = selectedIndices.size > 0 || freeText.trim().length > 0
+
+  const handleSubmit = () => {
+    if (!canSubmit) return
     const indices = [...selectedIndices].sort((a, b) => a - b)
-    const answerText = indices.map((i) => question.choices[i]).join(', ')
-    onSubmitChoices?.({ indices, answerText })
+    const choiceTexts = indices.map((i) => question.choices[i])
+    const custom = freeText.trim()
+
+    const parts = [...choiceTexts]
+    if (custom) parts.push(custom)
+    const answerText = parts.join(', ')
+
+    onSubmitAnswer?.({
+      indices: indices.length > 0 ? indices : null,
+      answerText,
+      customText: custom || null,
+    })
   }
 
-  const handleFreeTextSubmit = () => {
-    const trimmed = freeText.trim()
-    if (!trimmed) return
-    onChoiceSelect?.(trimmed)
+  const submitLabel = () => {
+    const count = selectedIndices.size + (freeText.trim() ? 1 : 0)
+    if (count === 0) return 'Submit'
+    return `Submit (${count})`
   }
 
   return (
@@ -80,7 +92,7 @@ const HITLQuestionMessage = ({ question, onChoiceSelect, onSubmitChoices, isAnsw
           </div>
         )}
 
-        {hasOptions && !answered && !showFreeText && (
+        {hasOptions && !answered && (
           <div className="mt-2 space-y-1.5">
             {question.choices.map((option, index) => {
               const isSelected = selectedIndices.has(index)
@@ -99,18 +111,51 @@ const HITLQuestionMessage = ({ question, onChoiceSelect, onSubmitChoices, isAnsw
                 </button>
               )
             })}
-            {question.allowOther && (
+
+            {question.allowOther && !showFreeText && (
               <button
                 onClick={() => setShowFreeText(true)}
                 disabled={isAnswering}
-                className="w-full text-left px-3 py-2 rounded-lg border border-dashed border-gray-300 bg-gray-50 text-sm text-gray-500 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="w-full text-left px-3 py-2 rounded-lg border border-dashed border-gray-300 bg-gray-50 text-sm text-gray-500 hover:border-gray-400 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1.5"
               >
-                Other (type your answer)
+                <ChevronDown className="w-3.5 h-3.5" />
+                Add a custom answer
               </button>
             )}
+
+            {question.allowOther && showFreeText && (
+              <div className="space-y-1.5">
+                <button
+                  onClick={() => { setShowFreeText(false); setFreeText('') }}
+                  disabled={isAnswering}
+                  className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600 transition-colors"
+                >
+                  <ChevronUp className="w-3 h-3" />
+                  Hide custom answer
+                </button>
+                <div className="flex items-end gap-2 border border-gray-200 rounded-lg px-3 py-2 bg-white focus-within:border-gray-300 transition-colors">
+                  <textarea
+                    ref={freeTextRef}
+                    value={freeText}
+                    onChange={(e) => setFreeText(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && !e.shiftKey && !isAnswering) {
+                        e.preventDefault()
+                        handleSubmit()
+                      }
+                    }}
+                    placeholder="Type your answer..."
+                    rows={2}
+                    disabled={isAnswering}
+                    className="flex-1 resize-none bg-transparent outline-none text-sm leading-6 min-w-0"
+                  />
+                </div>
+              </div>
+            )}
+
             <button
-              onClick={handleSubmitChoices}
-              disabled={selectedIndices.size === 0 || isAnswering}
+              onClick={handleSubmit}
+              disabled={!canSubmit || isAnswering}
               className="w-full px-3 py-2 rounded-lg bg-gray-900 text-white text-sm font-medium hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             >
               {isAnswering ? (
@@ -119,23 +164,23 @@ const HITLQuestionMessage = ({ question, onChoiceSelect, onSubmitChoices, isAnsw
                   Submitting…
                 </span>
               ) : (
-                `Submit${selectedIndices.size > 0 ? ` (${selectedIndices.size})` : ''}`
+                submitLabel()
               )}
             </button>
           </div>
         )}
 
-        {showFreeText && !answered && (
-          <div className="mt-2 space-y-2">
+        {/* Questions without choices — free-text only */}
+        {!hasOptions && !answered && (
+          <div className="mt-2">
             <div className="flex items-end gap-2 border border-gray-200 rounded-lg px-3 py-2 bg-white focus-within:border-gray-300 transition-colors">
               <textarea
-                ref={freeTextRef}
                 value={freeText}
                 onChange={(e) => setFreeText(e.target.value)}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && !e.shiftKey && !isAnswering) {
                     e.preventDefault()
-                    handleFreeTextSubmit()
+                    handleSubmit()
                   }
                 }}
                 placeholder="Type your answer..."
@@ -144,7 +189,7 @@ const HITLQuestionMessage = ({ question, onChoiceSelect, onSubmitChoices, isAnsw
                 className="flex-1 resize-none bg-transparent outline-none text-sm leading-6 min-w-0"
               />
               <button
-                onClick={handleFreeTextSubmit}
+                onClick={handleSubmit}
                 disabled={!freeText.trim() || isAnswering}
                 className="flex-shrink-0 p-1.5 rounded-lg bg-gray-900 text-white hover:bg-gray-700 disabled:opacity-30 transition-colors"
               >
@@ -155,14 +200,6 @@ const HITLQuestionMessage = ({ question, onChoiceSelect, onSubmitChoices, isAnsw
                 )}
               </button>
             </div>
-            <button
-              onClick={() => { setShowFreeText(false); setFreeText('') }}
-              disabled={isAnswering}
-              className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600 transition-colors"
-            >
-              <X className="w-3 h-3" />
-              Back to options
-            </button>
           </div>
         )}
       </div>

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -290,8 +290,7 @@ const TimelineQuestion = ({ tc, agentId, sessionId }) => {
     <>
       <HITLQuestionMessage
         question={questionData}
-        onChoiceSelect={(answer) => answerMut.mutate({ questionId: tc.question_id, answer })}
-        onSubmitChoices={({ indices, answerText }) => answerMut.mutate({ questionId: tc.question_id, answer: answerText, selectedChoices: indices })}
+        onSubmitAnswer={({ indices, answerText }) => answerMut.mutate({ questionId: tc.question_id, answer: answerText, selectedChoices: indices })}
         isAnswering={answerMut.isPending}
         answered={isAnswered}
       />


### PR DESCRIPTION
## Summary

- **Combined answer mode**: HITL multiple-choice questions now allow users to select predefined choices AND type a custom answer simultaneously. Previously these were mutually exclusive — clicking "Other" replaced the choice buttons with a textarea.
- **Unified UI**: The "Other" toggle is replaced with an "Add a custom answer" expander below the choice buttons. When expanded, the textarea appears alongside the choices. The submit button count reflects all selections (e.g. "Submit (3)" for 2 choices + 1 custom answer).
- **Unified callback**: The two separate submission paths (`onChoiceSelect` for free-text, `onSubmitChoices` for choices) are merged into a single `onSubmitAnswer` callback that always sends both selected indices and the combined answer text.
- **Agent receives selected choices**: The tool call result sent back to the agent now includes a `selected_choices` field with the text of the selected predefined options, so the agent can distinguish between predefined selections and custom input.

### Files changed

| File | Change |
|------|--------|
| `frontend/src/components/chat/HITLQuestionMessage.jsx` | Rewrote to show choices and free-text together; unified submit logic |
| `frontend/src/components/chat/SessionDetail.jsx` | Replaced two callbacks with single `onSubmitAnswer` |
| `druppie/api/routes/questions.py` | Thread `selected_choices` through background task |
| `druppie/execution/orchestrator.py` | Forward `selected_choices` to `complete_after_answer` |
| `druppie/execution/tool_executor.py` | Accept `selected_choices`, pass to repo, include in agent result |

## Test plan

- [ ] Open a session with a pending multiple-choice HITL question
- [ ] Select one or more choices and submit — verify it works as before
- [ ] Click "Add a custom answer" to expand the textarea, type a custom answer, and submit **without** selecting any choices — verify it submits the custom text
- [ ] Select choices **and** type a custom answer, then submit — verify the answer combines both (e.g. "Option A, Option B, my custom text")
- [ ] Verify the submit button label updates to reflect total count (choices + custom)
- [ ] Click "Hide custom answer" — verify the textarea collapses and custom text is cleared
- [ ] Test a free-text-only HITL question (no choices) — verify the standalone textarea still works
- [ ] Verify the answer appears correctly in the chat timeline after submission
- [ ] Check that the agent receives `selected_choices` in the tool result when choices are selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)