### PR TITLE
fix: project detail page returns 500 (fixes #53)

### DIFF
--- a/druppie/repositories/project_repository.py
+++ b/druppie/repositories/project_repository.py
@@ -102,10 +102,11 @@ class ProjectRepository(BaseRepository):
             name=project.name,
             description=project.description,
             repo_url=project.repo_url,
+            repo_name=project.repo_name,
+            repo_owner=project.repo_owner,
             created_at=project.created_at,
             # ProjectDetail specific
             owner_id=project.owner_id,
-            repo_name=project.repo_name,
             token_usage=TokenUsage(
                 prompt_tokens=stats.prompt_tokens,
                 completion_tokens=stats.completion_tokens,


### PR DESCRIPTION
## Summary
- `ProjectRepository.get_detail()` omitted `repo_owner` when constructing `ProjectDetail`, causing a Pydantic validation error
- Clicking a project link in the session view (e.g. "digitale HR collega") returned a 500 Internal Server Error
- Also moved `repo_name` into the inherited `ProjectSummary` fields section for consistency

> **Note:** After merging, manually close #53 — auto-close won't trigger because this PR targets `colab-dev`, not `main`.

## Test plan
- [ ] Click a project link in a session's header bar — should navigate to the project detail page without error
- [ ] Verify the project detail page shows all fields (name, repo URL, sessions, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)