### PR TITLE
fix: make LLM fallback sticky per session (#76)

### DIFF
--- a/druppie/agents/runtime.py
+++ b/druppie/agents/runtime.py
@@ -62,10 +62,11 @@ class Agent:
     Context (language, project info) is always provided by the caller (orchestrator).
     """
 
-    def __init__(self, agent_id: str, db: "DBSession | None" = None):
+    def __init__(self, agent_id: str, db: "DBSession | None" = None, session_id: str | None = None):
         self.id = agent_id
         self.definition = self._load_definition(agent_id)
         self._db = db
+        self._session_id = session_id
         self._llm = None
         self._tool_executor = None
         self._mcp_config = None
@@ -107,7 +108,7 @@ class Agent:
     def llm(self):
         """Get LLM instance configured from agent definition (lazy loaded)."""
         if self._llm is None:
-            self._llm = get_llm_service().create_llm_for_agent(self.definition)
+            self._llm = get_llm_service().create_llm_for_agent(self.definition, session_id=self._session_id)
         return self._llm
 
     @property

--- a/druppie/execution/orchestrator.py
+++ b/druppie/execution/orchestrator.py
@@ -455,7 +455,7 @@ class Orchestrator:
         )
 
         # Create and run agent
-        agent = Agent(agent_id, db=self.execution_repo.db)
+        agent = Agent(agent_id, db=self.execution_repo.db, session_id=str(session_id))
         try:
             result = await agent.run(
                 prompt=prompt,
@@ -657,7 +657,7 @@ class Orchestrator:
 
         # Step 5: Build fresh context and continue the agent
         context = self.build_project_context(session_id)
-        agent = Agent(agent_run.agent_id, db=db)
+        agent = Agent(agent_run.agent_id, db=db, session_id=str(session_id))
         result = await agent.continue_run(
             session_id=session_id,
             agent_run_id=agent_run.id,
@@ -759,7 +759,7 @@ class Orchestrator:
 
         # Step 5: Build fresh context and continue the agent
         context = self.build_project_context(session_id)
-        agent = Agent(agent_run.agent_id, db=db)
+        agent = Agent(agent_run.agent_id, db=db, session_id=str(session_id))
         result = await agent.continue_run(
             session_id=session_id,
             agent_run_id=agent_run.id,
@@ -832,7 +832,7 @@ class Orchestrator:
                 # Already RUNNING — just continue it
                 db = self.execution_repo.db
                 context = self.build_project_context(session_id)
-                agent = Agent(orphan_run.agent_id, db=db)
+                agent = Agent(orphan_run.agent_id, db=db, session_id=str(session_id))
                 try:
                     result = await agent.continue_run(
                         session_id=session_id,
@@ -882,7 +882,7 @@ class Orchestrator:
         # Build fresh context and continue the agent
         db = self.execution_repo.db
         context = self.build_project_context(session_id)
-        agent = Agent(paused_run.agent_id, db=db)
+        agent = Agent(paused_run.agent_id, db=db, session_id=str(session_id))
         try:
             result = await agent.continue_run(
                 session_id=session_id,
@@ -1001,7 +1001,7 @@ class Orchestrator:
         # Build fresh context and continue the agent
         db = self.execution_repo.db
         context = self.build_project_context(session_id)
-        agent = Agent(agent_run.agent_id, db=db)
+        agent = Agent(agent_run.agent_id, db=db, session_id=str(session_id))
         try:
             result = await agent.continue_run(
                 session_id=session_id,

--- a/druppie/llm/fallback.py
+++ b/druppie/llm/fallback.py
@@ -4,6 +4,11 @@ ANY LLMError from the primary triggers fallback, including AuthenticationError.
 This is correct for cross-provider fallback: if provider A's auth fails,
 provider B (a completely different service) may work fine.
 
+Sticky degraded mode: after the first fallback in a session, subsequent calls
+try the primary once (no litellm retries) and fall back instantly on any error.
+Within the same agent run, the primary is skipped entirely after a failure.
+On a new agent run (same session), the primary gets one more chance.
+
 Interaction with existing retry layers:
     AgentLoop._call_llm() retry loop (3 attempts, exponential backoff)
       -> FallbackLLM.achat()
@@ -22,12 +27,26 @@ logger = structlog.get_logger()
 
 
 class FallbackLLM(BaseLLM):
-    """LLM wrapper that falls back to a secondary LLM on any error."""
+    """LLM wrapper that falls back to a secondary LLM on any error.
 
-    def __init__(self, primary: BaseLLM, fallback: BaseLLM):
+    Tracks degraded state per session so that once a fallback occurs,
+    subsequent calls avoid slow retries on the broken primary.
+    """
+
+    _degraded_sessions: set[str] = set()
+
+    def __init__(self, primary: BaseLLM, fallback: BaseLLM, session_id: str | None = None):
         self._primary = primary
         self._fallback = fallback
         self._active: BaseLLM = primary
+        self._session_id = session_id
+        self._degraded = session_id in self._degraded_sessions if session_id else False
+        self._primary_failed_this_run = False
+
+    @classmethod
+    def clear_session(cls, session_id: str) -> None:
+        """Remove degraded state for a session (e.g. when session ends)."""
+        cls._degraded_sessions.discard(session_id)
 
     # ------------------------------------------------------------------
     # Properties — delegate to primary
@@ -54,6 +73,42 @@ class FallbackLLM(BaseLLM):
         """Return whichever LLM last served a request."""
         return self._active
 
+    @property
+    def degraded(self) -> bool:
+        return self._degraded
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _enter_degraded(self) -> None:
+        self._degraded = True
+        self._primary_failed_this_run = True
+        if self._session_id:
+            self._degraded_sessions.add(self._session_id)
+
+    def _try_primary_no_retries(self, call, *args):
+        """Call primary with litellm retries disabled. Returns response or raises."""
+        saved = getattr(self._primary, "max_retries", None)
+        if saved is not None:
+            self._primary.max_retries = 0
+        try:
+            return call(*args)
+        finally:
+            if saved is not None:
+                self._primary.max_retries = saved
+
+    async def _atry_primary_no_retries(self, call, *args):
+        """Async version of _try_primary_no_retries."""
+        saved = getattr(self._primary, "max_retries", None)
+        if saved is not None:
+            self._primary.max_retries = 0
+        try:
+            return await call(*args)
+        finally:
+            if saved is not None:
+                self._primary.max_retries = saved
+
     # ------------------------------------------------------------------
     # Chat methods — primary with fallback
     # ------------------------------------------------------------------
@@ -63,6 +118,31 @@ class FallbackLLM(BaseLLM):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
     ) -> LLMResponse:
+        if self._primary_failed_this_run:
+            response = self._fallback.chat(messages, tools)
+            self._active = self._fallback
+            return response
+
+        if self._degraded:
+            try:
+                response = self._try_primary_no_retries(
+                    self._primary.chat, messages, tools,
+                )
+                self._active = self._primary
+                return response
+            except LLMError as e:
+                logger.warning(
+                    "llm_degraded_fallback",
+                    primary_provider=self._primary.provider_name,
+                    fallback_provider=self._fallback.provider_name,
+                    error_type=type(e).__name__,
+                    error=str(e)[:200],
+                )
+                self._primary_failed_this_run = True
+                response = self._fallback.chat(messages, tools)
+                self._active = self._fallback
+                return response
+
         try:
             response = self._primary.chat(messages, tools)
             self._active = self._primary
@@ -75,6 +155,7 @@ class FallbackLLM(BaseLLM):
                 error_type=type(e).__name__,
                 error=str(e)[:200],
             )
+            self._enter_degraded()
             response = self._fallback.chat(messages, tools)
             self._active = self._fallback
             return response
@@ -85,6 +166,31 @@ class FallbackLLM(BaseLLM):
         tools: list[dict[str, Any]] | None = None,
         max_tokens: int | None = None,
     ) -> LLMResponse:
+        if self._primary_failed_this_run:
+            response = await self._fallback.achat(messages, tools, max_tokens)
+            self._active = self._fallback
+            return response
+
+        if self._degraded:
+            try:
+                response = await self._atry_primary_no_retries(
+                    self._primary.achat, messages, tools, max_tokens,
+                )
+                self._active = self._primary
+                return response
+            except LLMError as e:
+                logger.warning(
+                    "llm_degraded_fallback",
+                    primary_provider=self._primary.provider_name,
+                    fallback_provider=self._fallback.provider_name,
+                    error_type=type(e).__name__,
+                    error=str(e)[:200],
+                )
+                self._primary_failed_this_run = True
+                response = await self._fallback.achat(messages, tools, max_tokens)
+                self._active = self._fallback
+                return response
+
         try:
             response = await self._primary.achat(messages, tools, max_tokens)
             self._active = self._primary
@@ -97,6 +203,7 @@ class FallbackLLM(BaseLLM):
                 error_type=type(e).__name__,
                 error=str(e)[:200],
             )
+            self._enter_degraded()
             response = await self._fallback.achat(messages, tools, max_tokens)
             self._active = self._fallback
             return response

--- a/druppie/llm/service.py
+++ b/druppie/llm/service.py
@@ -104,7 +104,7 @@ class LLMService:
         """Get all loaded profiles (for status endpoint)."""
         return get_profiles()
 
-    def create_llm_for_agent(self, agent_def: "AgentDefinition") -> BaseLLM:
+    def create_llm_for_agent(self, agent_def: "AgentDefinition", session_id: str | None = None) -> BaseLLM:
         """Create an LLM instance using the model resolution chain.
 
         Resolution order: override → profile → global default.
@@ -142,7 +142,7 @@ class LLMService:
                     model=resolved.fallback_model,
                     temperature=agent_def.temperature,
                 )
-                result = FallbackLLM(primary, fallback)
+                result = FallbackLLM(primary, fallback, session_id=session_id)
                 has_fallback = True
 
         logger.info(

--- a/druppie/tests/test_fallback_degraded.py
+++ b/druppie/tests/test_fallback_degraded.py
@@ -1,0 +1,304 @@
+"""Tests for FallbackLLM sticky degraded mode.
+
+Simulates the scenario from issue #76: primary model is unavailable,
+verify that after the first fallback, subsequent calls avoid slow retries.
+"""
+
+import asyncio
+
+from druppie.llm.base import BaseLLM, LLMError, LLMResponse, ServerError
+from druppie.llm.fallback import FallbackLLM
+
+
+class MockLLM(BaseLLM):
+    """Mock LLM that can be configured to fail or succeed."""
+
+    def __init__(self, name: str, should_fail: bool = False):
+        self._name = name
+        self.should_fail = should_fail
+        self.call_count = 0
+        self.max_retries = 3
+
+    @property
+    def model(self) -> str:
+        return self._name
+
+    @property
+    def model_name(self) -> str:
+        return self._name
+
+    @property
+    def provider_name(self) -> str:
+        return self._name
+
+    def chat(self, messages, tools=None):
+        self.call_count += 1
+        if self.should_fail:
+            raise ServerError(f"{self._name} is down", provider=self._name)
+        return LLMResponse(content=f"response from {self._name}", provider=self._name, model=self._name)
+
+    async def achat(self, messages, tools=None, max_tokens=None):
+        self.call_count += 1
+        if self.should_fail:
+            raise ServerError(f"{self._name} is down", provider=self._name)
+        return LLMResponse(content=f"response from {self._name}", provider=self._name, model=self._name)
+
+    def get_call_history(self):
+        return []
+
+    def clear_call_history(self):
+        pass
+
+
+def test_normal_mode_uses_primary():
+    """When primary works, fallback is never called."""
+    primary = MockLLM("primary")
+    fallback = MockLLM("fallback")
+    llm = FallbackLLM(primary, fallback, session_id="sess-1")
+
+    resp = llm.chat([{"role": "user", "content": "hi"}])
+
+    assert resp.provider == "primary"
+    assert primary.call_count == 1
+    assert fallback.call_count == 0
+    assert not llm.degraded
+
+    FallbackLLM.clear_session("sess-1")
+
+
+def test_first_failure_activates_fallback_and_degrades():
+    """First primary failure falls back and enters degraded mode."""
+    primary = MockLLM("primary", should_fail=True)
+    fallback = MockLLM("fallback")
+    llm = FallbackLLM(primary, fallback, session_id="sess-2")
+
+    resp = llm.chat([{"role": "user", "content": "hi"}])
+
+    assert resp.provider == "fallback"
+    assert primary.call_count == 1
+    assert fallback.call_count == 1
+    assert llm.degraded
+    assert "sess-2" in FallbackLLM._degraded_sessions
+
+    FallbackLLM.clear_session("sess-2")
+
+
+def test_same_run_skips_primary_after_failure():
+    """Within the same agent run, primary is skipped entirely after failure."""
+    primary = MockLLM("primary", should_fail=True)
+    fallback = MockLLM("fallback")
+    llm = FallbackLLM(primary, fallback, session_id="sess-3")
+
+    # Call 1: primary fails, falls back
+    llm.chat([{"role": "user", "content": "msg1"}])
+    assert primary.call_count == 1
+    assert fallback.call_count == 1
+
+    # Calls 2-5: primary should be skipped entirely
+    for i in range(4):
+        resp = llm.chat([{"role": "user", "content": f"msg{i+2}"}])
+        assert resp.provider == "fallback"
+
+    assert primary.call_count == 1  # never called again
+    assert fallback.call_count == 5
+
+    FallbackLLM.clear_session("sess-3")
+
+
+def test_new_run_probes_primary_once_in_degraded_mode():
+    """New agent run in same session: probes primary once (no retries), then falls back."""
+    session_id = "sess-4"
+    primary1 = MockLLM("primary", should_fail=True)
+    fallback1 = MockLLM("fallback")
+
+    # Agent run 1: triggers degraded mode
+    llm1 = FallbackLLM(primary1, fallback1, session_id=session_id)
+    llm1.chat([{"role": "user", "content": "hi"}])
+    assert llm1.degraded
+
+    # Agent run 2: new FallbackLLM, same session — should start degraded
+    primary2 = MockLLM("primary", should_fail=True)
+    fallback2 = MockLLM("fallback")
+    llm2 = FallbackLLM(primary2, fallback2, session_id=session_id)
+
+    assert llm2.degraded  # starts degraded from session state
+
+    # Call 1: probes primary once, fails, instant fallback
+    resp = llm2.chat([{"role": "user", "content": "msg1"}])
+    assert resp.provider == "fallback"
+    assert primary2.call_count == 1
+    assert primary2.max_retries == 3  # restored after probe
+
+    # Call 2: skips primary entirely (failed this run)
+    resp = llm2.chat([{"role": "user", "content": "msg2"}])
+    assert resp.provider == "fallback"
+    assert primary2.call_count == 1  # not called again
+
+    FallbackLLM.clear_session(session_id)
+
+
+def test_degraded_probe_disables_retries():
+    """In degraded mode, the primary probe has max_retries=0."""
+    session_id = "sess-5"
+
+    # First run: enter degraded
+    p1 = MockLLM("primary", should_fail=True)
+    f1 = MockLLM("fallback")
+    llm1 = FallbackLLM(p1, f1, session_id=session_id)
+    llm1.chat([{"role": "user", "content": "hi"}])
+
+    # Second run: check retries are disabled during probe
+    p2 = MockLLM("primary", should_fail=True)
+    p2.max_retries = 3
+    f2 = MockLLM("fallback")
+    llm2 = FallbackLLM(p2, f2, session_id=session_id)
+
+    retries_during_call = []
+    original_chat = p2.chat
+
+    def spy_chat(messages, tools=None):
+        retries_during_call.append(p2.max_retries)
+        return original_chat(messages, tools)
+
+    p2.chat = spy_chat
+    llm2.chat([{"role": "user", "content": "probe"}])
+
+    assert retries_during_call == [0]  # retries were disabled
+    assert p2.max_retries == 3  # restored after
+
+    FallbackLLM.clear_session(session_id)
+
+
+def test_primary_recovers_in_degraded_mode():
+    """If primary recovers during a degraded probe, use it."""
+    session_id = "sess-6"
+
+    # First run: enter degraded
+    p1 = MockLLM("primary", should_fail=True)
+    f1 = MockLLM("fallback")
+    llm1 = FallbackLLM(p1, f1, session_id=session_id)
+    llm1.chat([{"role": "user", "content": "hi"}])
+
+    # Second run: primary is back
+    p2 = MockLLM("primary", should_fail=False)
+    f2 = MockLLM("fallback")
+    llm2 = FallbackLLM(p2, f2, session_id=session_id)
+
+    resp = llm2.chat([{"role": "user", "content": "hello"}])
+    assert resp.provider == "primary"
+    assert p2.call_count == 1
+    assert f2.call_count == 0
+
+    FallbackLLM.clear_session(session_id)
+
+
+def test_different_session_not_degraded():
+    """Degraded state is per-session, doesn't leak to other sessions."""
+    # Session A: enter degraded
+    pa = MockLLM("primary", should_fail=True)
+    fa = MockLLM("fallback")
+    llm_a = FallbackLLM(pa, fa, session_id="sess-A")
+    llm_a.chat([{"role": "user", "content": "hi"}])
+    assert llm_a.degraded
+
+    # Session B: should NOT be degraded
+    pb = MockLLM("primary", should_fail=False)
+    fb = MockLLM("fallback")
+    llm_b = FallbackLLM(pb, fb, session_id="sess-B")
+    assert not llm_b.degraded
+
+    resp = llm_b.chat([{"role": "user", "content": "hi"}])
+    assert resp.provider == "primary"
+
+    FallbackLLM.clear_session("sess-A")
+    FallbackLLM.clear_session("sess-B")
+
+
+def test_clear_session_removes_degraded():
+    """clear_session removes the degraded state."""
+    session_id = "sess-7"
+    p = MockLLM("primary", should_fail=True)
+    f = MockLLM("fallback")
+    llm = FallbackLLM(p, f, session_id=session_id)
+    llm.chat([{"role": "user", "content": "hi"}])
+    assert session_id in FallbackLLM._degraded_sessions
+
+    FallbackLLM.clear_session(session_id)
+    assert session_id not in FallbackLLM._degraded_sessions
+
+    # New instance should not be degraded
+    p2 = MockLLM("primary", should_fail=False)
+    f2 = MockLLM("fallback")
+    llm2 = FallbackLLM(p2, f2, session_id=session_id)
+    assert not llm2.degraded
+
+
+def test_async_degraded_flow():
+    """Same degraded behavior works for async achat()."""
+    session_id = "sess-8"
+
+    async def run():
+        # Run 1: enter degraded
+        p1 = MockLLM("primary", should_fail=True)
+        f1 = MockLLM("fallback")
+        llm1 = FallbackLLM(p1, f1, session_id=session_id)
+        resp = await llm1.achat([{"role": "user", "content": "hi"}])
+        assert resp.provider == "fallback"
+        assert llm1.degraded
+
+        # Run 1, call 2: skip primary
+        resp = await llm1.achat([{"role": "user", "content": "hi2"}])
+        assert resp.provider == "fallback"
+        assert p1.call_count == 1  # only called once
+
+        # Run 2: probe primary once, fail, instant fallback
+        p2 = MockLLM("primary", should_fail=True)
+        f2 = MockLLM("fallback")
+        llm2 = FallbackLLM(p2, f2, session_id=session_id)
+        assert llm2.degraded
+
+        resp = await llm2.achat([{"role": "user", "content": "msg1"}])
+        assert resp.provider == "fallback"
+        assert p2.call_count == 1
+
+        # Run 2, call 2: skip primary
+        resp = await llm2.achat([{"role": "user", "content": "msg2"}])
+        assert p2.call_count == 1
+
+        FallbackLLM.clear_session(session_id)
+
+    asyncio.run(run())
+
+
+def test_no_session_id_works_without_persistence():
+    """Without session_id, degraded mode still works within the run but doesn't persist."""
+    primary = MockLLM("primary", should_fail=True)
+    fallback = MockLLM("fallback")
+    llm = FallbackLLM(primary, fallback)  # no session_id
+
+    llm.chat([{"role": "user", "content": "hi"}])
+    assert llm.degraded
+
+    # Second call: skips primary (same run)
+    llm.chat([{"role": "user", "content": "hi2"}])
+    assert primary.call_count == 1
+
+    # New instance without session_id: NOT degraded (no persistence)
+    p2 = MockLLM("primary", should_fail=False)
+    f2 = MockLLM("fallback")
+    llm2 = FallbackLLM(p2, f2)
+    assert not llm2.degraded
+
+
+if __name__ == "__main__":
+    test_normal_mode_uses_primary()
+    test_first_failure_activates_fallback_and_degrades()
+    test_same_run_skips_primary_after_failure()
+    test_new_run_probes_primary_once_in_degraded_mode()
+    test_degraded_probe_disables_retries()
+    test_primary_recovers_in_degraded_mode()
+    test_different_session_not_degraded()
+    test_clear_session_removes_degraded()
+    test_async_degraded_flow()
+    test_no_session_id_works_without_persistence()
+    print("\nAll 10 tests passed!")


### PR DESCRIPTION
## Summary

Fixes the slow LLM fallback issue where every LLM call paid the full retry penalty on an unavailable primary model before falling back.

- **Made `FallbackLLM` session-aware**: after the first fallback in a session, the primary is marked as degraded for that session
- **Within the same agent run**: primary is skipped entirely after failure — all subsequent calls go straight to the fallback
- **On a new agent run (same session)**: primary gets one retry-free probe (litellm `max_retries=0`). If it fails, instant fallback. If it succeeds, the primary is used
- **Different sessions are isolated**: degraded state does not leak across sessions
- Wired `session_id` through `orchestrator → Agent → LLMService → FallbackLLM` so all 6 Agent instantiation sites pass the session context

## Root cause

`FallbackLLM.achat()` always tried `self._primary` first on every call, with full litellm retries (`num_retries=3`, 300s timeout). The `_active` field tracked which LLM last succeeded but was never used for routing. With `max_iterations=10` per agent and multiple agents per message, every call repeated the full primary-timeout-then-fallback cycle.

## Changed files

- `druppie/llm/fallback.py` — sticky degraded mode with per-session tracking
- `druppie/llm/service.py` — pass `session_id` to `FallbackLLM`
- `druppie/agents/runtime.py` — accept and forward `session_id`
- `druppie/execution/orchestrator.py` — pass `session_id` at all 6 Agent instantiation sites
- `druppie/tests/test_fallback_degraded.py` — 10 tests covering normal, degraded, recovery, async, and session isolation

## Test plan

- [x] 10 unit tests covering all degraded mode scenarios pass
- [ ] Manual test: configure a profile with an unavailable primary model, send multiple messages, verify fallback is near-instant after the first failure

## Linked issue

Closes #76

> **Reminder**: close #76 manually after merging if it doesn't auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)