### PR TITLE
fix(tests-page): filtering respecteren bij run + test results kunnen verwijderen (#197, #165)

### DIFF
--- a/druppie/api/routes/evaluations_tests.py
+++ b/druppie/api/routes/evaluations_tests.py
@@ -480,6 +480,18 @@ async def list_tags(
     return service.list_tags()
 
 
+@router.delete("/evaluations/test-batches/{batch_id}")
+async def delete_test_batch(
+    batch_id: str,
+    service: EvaluationService = Depends(get_evaluation_service),
+    user: dict = Depends(require_admin),
+):
+    """Delete a test result batch and all of its test runs."""
+    count = service.delete_test_batch(batch_id)
+    logger.info("test_batch_deleted_via_api", batch_id=batch_id, deleted_count=count, user_id=user.get("sub"))
+    return {"success": True, "deleted_count": count, "message": f"Deleted {count} test run(s)"}
+
+
 @router.delete("/evaluations/test-users")
 async def delete_test_users(
     service: EvaluationService = Depends(get_evaluation_service),

--- a/druppie/api/routes/evaluations_tests.py
+++ b/druppie/api/routes/evaluations_tests.py
@@ -492,6 +492,29 @@ async def delete_test_batch(
     return {"success": True, "deleted_count": count, "message": f"Deleted {count} test run(s)"}
 
 
+@router.delete("/evaluations/test-batches")
+async def delete_all_test_batches(
+    service: EvaluationService = Depends(get_evaluation_service),
+    user: dict = Depends(require_admin),
+):
+    """Delete all test batches and their runs."""
+    count = service.delete_all_test_batches()
+    logger.info("all_test_batches_deleted_via_api", deleted_count=count, user_id=user.get("sub"))
+    return {"success": True, "deleted_count": count, "message": f"Deleted {count} test run(s)"}
+
+
+@router.delete("/evaluations/test-runs/{test_run_id}")
+async def delete_test_run(
+    test_run_id: UUID,
+    service: EvaluationService = Depends(get_evaluation_service),
+    user: dict = Depends(require_admin),
+):
+    """Delete a single test run."""
+    service.delete_test_run(test_run_id)
+    logger.info("test_run_deleted_via_api", test_run_id=str(test_run_id), user_id=user.get("sub"))
+    return {"success": True, "message": "Test run deleted"}
+
+
 @router.delete("/evaluations/test-users")
 async def delete_test_users(
     service: EvaluationService = Depends(get_evaluation_service),

--- a/druppie/repositories/evaluation_repository.py
+++ b/druppie/repositories/evaluation_repository.py
@@ -372,6 +372,39 @@ class EvaluationRepository(BaseRepository):
 
         return count
 
+    def delete_test_batch(self, batch_id: str) -> int:
+        """Delete a test result batch and all of its test runs.
+
+        Handles both real batches (TestRun.batch_id == batch_id) and the
+        single unbatched runs that list_test_batches surfaces using the run's
+        own id as the batch_id. Child tags/assertion results cascade via ORM.
+
+        Returns:
+            Number of test runs deleted (0 if nothing matched).
+        """
+        runs = self.db.query(TestRun).filter(TestRun.batch_id == batch_id).all()
+        if not runs:
+            # Unbatched run surfaced with its own id as the batch_id
+            try:
+                run_uuid = UUID(str(batch_id))
+            except (ValueError, TypeError):
+                run_uuid = None
+            if run_uuid is not None:
+                run = self.db.query(TestRun).filter(TestRun.id == run_uuid).first()
+                if run:
+                    runs = [run]
+
+        for run in runs:
+            self.db.delete(run)
+
+        # Remove the batch metadata row if present
+        batch = self.db.query(TestBatchRun).filter(TestBatchRun.id == batch_id).first()
+        if batch:
+            self.db.delete(batch)
+
+        self.db.flush()
+        return len(runs)
+
     # =========================================================================
     # AGGREGATION METHODS
     # =========================================================================

--- a/druppie/repositories/evaluation_repository.py
+++ b/druppie/repositories/evaluation_repository.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import joinedload, subqueryload
 
 from ..db.models import BenchmarkRun, EvaluationResult, TestBatchRun, TestRun, TestRunTag
 from ..db.models.test_assertion_result import TestAssertionResult
+from ..db.models.test_running_status import TestRunningStatus
 from .base import BaseRepository
 
 
@@ -396,14 +397,33 @@ class EvaluationRepository(BaseRepository):
 
         for run in runs:
             self.db.delete(run)
+        self.db.flush()
 
-        # Remove the batch metadata row if present
-        batch = self.db.query(TestBatchRun).filter(TestBatchRun.id == batch_id).first()
-        if batch:
-            self.db.delete(batch)
-
+        # Remove running-status rows (FK to test_batch_runs) then the batch
+        self.db.query(TestRunningStatus).filter(TestRunningStatus.run_id == batch_id).delete()
+        self.db.query(TestBatchRun).filter(TestBatchRun.id == batch_id).delete()
         self.db.flush()
         return len(runs)
+
+    def delete_test_run(self, test_run_id: UUID) -> bool:
+        """Delete a single test run by ID. Child tags/assertions cascade via ORM."""
+        run = self.db.query(TestRun).filter(TestRun.id == test_run_id).first()
+        if not run:
+            return False
+        self.db.delete(run)
+        self.db.flush()
+        return True
+
+    def delete_all_test_batches(self) -> int:
+        """Delete all test runs, batch metadata, and running status rows."""
+        count = self.db.query(TestRun).count()
+        self.db.query(TestAssertionResult).delete()
+        self.db.query(TestRunTag).delete()
+        self.db.query(TestRun).delete()
+        self.db.query(TestRunningStatus).delete()
+        self.db.query(TestBatchRun).delete()
+        self.db.flush()
+        return count
 
     # =========================================================================
     # AGGREGATION METHODS

--- a/druppie/services/evaluation_service.py
+++ b/druppie/services/evaluation_service.py
@@ -171,6 +171,25 @@ class EvaluationService:
         logger.info("test_batch_deleted", batch_id=batch_id, deleted_count=count)
         return count
 
+    def delete_test_run(self, test_run_id: UUID) -> None:
+        """Delete a single test run.
+
+        Raises:
+            NotFoundError: If the test run does not exist.
+        """
+        deleted = self.eval_repo.delete_test_run(test_run_id)
+        if not deleted:
+            raise NotFoundError("test_run", str(test_run_id))
+        self.eval_repo.commit()
+        logger.info("test_run_deleted", test_run_id=str(test_run_id))
+
+    def delete_all_test_batches(self) -> int:
+        """Delete all test batches and their runs."""
+        count = self.eval_repo.delete_all_test_batches()
+        self.eval_repo.commit()
+        logger.info("all_test_batches_deleted", deleted_count=count)
+        return count
+
     @staticmethod
     def run_unit_tests() -> dict:
         """Run pytest unit tests and return parsed results."""

--- a/druppie/services/evaluation_service.py
+++ b/druppie/services/evaluation_service.py
@@ -158,6 +158,19 @@ class EvaluationService:
         """Get all unique tags with test run counts."""
         return self.eval_repo.list_tags()
 
+    def delete_test_batch(self, batch_id: str) -> int:
+        """Delete a test result batch and all of its test runs.
+
+        Raises:
+            NotFoundError: If no test runs matched the batch.
+        """
+        count = self.eval_repo.delete_test_batch(batch_id)
+        if count == 0:
+            raise NotFoundError("test_batch", batch_id)
+        self.eval_repo.commit()
+        logger.info("test_batch_deleted", batch_id=batch_id, deleted_count=count)
+        return count
+
     @staticmethod
     def run_unit_tests() -> dict:
         """Run pytest unit tests and return parsed results."""

--- a/frontend/src/pages/Evaluations.jsx
+++ b/frontend/src/pages/Evaluations.jsx
@@ -27,6 +27,7 @@ import {
 } from '../services/api'
 
 import { TestSelectorModal, RunProgress, UnitTestsSection } from './evaluations/TestRunner'
+import { filterTests } from './evaluations/helpers'
 import TestResults from './evaluations/TestResults'
 import TestRunDetail from './evaluations/TestRunDetail'
 import useTestPolling from './evaluations/useTestPolling'
@@ -50,6 +51,7 @@ export default function Evaluations() {
   const [selectAll, setSelectAll] = useState(true)
   const [selectedTests, setSelectedTests] = useState(new Set())
   const [inputValues, setInputValues] = useState({})
+  const [searchQuery, setSearchQuery] = useState('')
 
   // Shared run state
   const [isRunning, setIsRunning] = useState(false)
@@ -60,16 +62,10 @@ export default function Evaluations() {
   const [deletingUsers, setDeletingUsers] = useState(false)
   const [runProgress, setRunProgress] = useState(null)
 
-  // Effective selected count for display (respects mode filter when selectAll)
+  // Effective selected count for display (respects both the mode filter and the
+  // search query when selectAll, so the count matches what actually runs)
   const effectiveCount = selectAll
-    ? (modeFilter === 'all'
-        ? availableTests.length
-        : availableTests.filter((t) => {
-            if (modeFilter === 'manual') return t.manual_input
-            if (modeFilter === 'tool') return t.type === 'tool'
-            if (modeFilter === 'agent') return t.type === 'agent' && !t.manual_input
-            return t.type === modeFilter && !t.manual_input
-          }).length)
+    ? filterTests(availableTests, modeFilter, searchQuery).length
     : selectedTests.size
 
   // Polling hook
@@ -125,16 +121,12 @@ export default function Evaluations() {
     try {
       const options = { execute: true, judge: judgeEnabled }
 
-      if (selectAll && modeFilter === 'all') {
+      if (selectAll && modeFilter === 'all' && !searchQuery.trim()) {
         options.run_all = true
       } else if (selectAll) {
-        // selectAll with a mode filter — resolve to specific test names
-        const filtered = availableTests.filter((t) => {
-          if (modeFilter === 'manual') return t.manual_input
-          if (modeFilter === 'tool') return t.type === 'tool'
-          if (modeFilter === 'agent') return t.type === 'agent' && !t.manual_input
-          return t.type === modeFilter && !t.manual_input
-        })
+        // selectAll with a mode filter and/or search query — resolve to the
+        // specific test names that are actually visible/matching
+        const filtered = filterTests(availableTests, modeFilter, searchQuery)
         options.test_names = filtered.map((t) => t.name)
       } else if (selectedTests.size === 1) {
         options.test_name = [...selectedTests][0]
@@ -335,12 +327,14 @@ export default function Evaluations() {
           setSelectedTests={setSelectedTests}
           modeFilter={modeFilter}
           setModeFilter={setModeFilter}
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
           inputValues={inputValues}
           setInputValues={setInputValues}
           judgeEnabled={judgeEnabled}
           setJudgeEnabled={setJudgeEnabled}
           onRun={handleRun}
-          onClose={() => setShowSelector(false)}
+          onClose={() => { setShowSelector(false); setSearchQuery('') }}
           isRunning={isRunning}
         />
       )}

--- a/frontend/src/pages/evaluations/TestResults.jsx
+++ b/frontend/src/pages/evaluations/TestResults.jsx
@@ -20,7 +20,7 @@ import {
   BarChart3,
   Trash2,
 } from 'lucide-react'
-import { getTestBatches, getTags, deleteTestBatch } from '../../services/api'
+import { getTestBatches, getTags, deleteTestBatch, deleteTestRun, deleteAllTestBatches } from '../../services/api'
 import { formatDate, formatDuration, StatusBadge, ResultsBanner } from './helpers'
 
 const TestResults = ({ refreshKey, onSelectRun, isRunning, runResult, setRunResult }) => {
@@ -35,6 +35,8 @@ const TestResults = ({ refreshKey, onSelectRun, isRunning, runResult, setRunResu
   const [initialExpanded, setInitialExpanded] = useState(false)
   const [retryKey, setRetryKey] = useState(0)
   const [deletingBatch, setDeletingBatch] = useState(null)
+  const [deletingRun, setDeletingRun] = useState(null)
+  const [deletingAll, setDeletingAll] = useState(false)
 
   const fetchTags = async () => {
     try {
@@ -93,40 +95,85 @@ const TestResults = ({ refreshKey, onSelectRun, isRunning, runResult, setRunResu
     }
   }
 
+  const handleDeleteRun = async (runId, e) => {
+    e.stopPropagation()
+    if (!window.confirm('Delete this test run? This cannot be undone.')) return
+    setDeletingRun(runId)
+    try {
+      await deleteTestRun(runId)
+      setRetryKey((k) => k + 1)
+    } catch (err) {
+      alert('Failed to delete test run: ' + err.message)
+    } finally {
+      setDeletingRun(null)
+    }
+  }
+
+  const handleDeleteAll = async () => {
+    if (!window.confirm('Delete ALL test results? This cannot be undone.')) return
+    setDeletingAll(true)
+    try {
+      await deleteAllTestBatches()
+      setRetryKey((k) => k + 1)
+    } catch (err) {
+      alert('Failed to delete all test results: ' + err.message)
+    } finally {
+      setDeletingAll(false)
+    }
+  }
+
   return (
     <div className="space-y-3">
       {/* Results banner */}
       <ResultsBanner result={runResult} onDismiss={() => setRunResult(null)} />
 
       {/* Filter bar */}
-      {tags.length > 0 && (
+      <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <Filter className="w-4 h-4 text-gray-400" />
-          <select
-            value={selectedTag || ''}
-            onChange={(e) => {
-              setSelectedTag(e.target.value || null)
-              setPage(1)
-            }}
-            className="px-3 py-1.5 border rounded text-sm bg-white focus:outline-none focus:ring-2 focus:ring-purple-500"
-          >
-            <option value="">All tags</option>
-            {tags.map((t) => (
-              <option key={t.tag} value={t.tag}>
-                {t.tag} ({t.count})
-              </option>
-            ))}
-          </select>
-          {selectedTag && (
-            <button
-              onClick={() => { setSelectedTag(null); setPage(1) }}
-              className="text-xs text-gray-500 hover:text-gray-700 underline"
-            >
-              Clear filter
-            </button>
+          {tags.length > 0 && (
+            <>
+              <Filter className="w-4 h-4 text-gray-400" />
+              <select
+                value={selectedTag || ''}
+                onChange={(e) => {
+                  setSelectedTag(e.target.value || null)
+                  setPage(1)
+                }}
+                className="px-3 py-1.5 border rounded text-sm bg-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+              >
+                <option value="">All tags</option>
+                {tags.map((t) => (
+                  <option key={t.tag} value={t.tag}>
+                    {t.tag} ({t.count})
+                  </option>
+                ))}
+              </select>
+              {selectedTag && (
+                <button
+                  onClick={() => { setSelectedTag(null); setPage(1) }}
+                  className="text-xs text-gray-500 hover:text-gray-700 underline"
+                >
+                  Clear filter
+                </button>
+              )}
+            </>
           )}
         </div>
-      )}
+        {batches.length > 0 && (
+          <button
+            onClick={handleDeleteAll}
+            disabled={deletingAll}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red-600 bg-red-50 border border-red-200 rounded hover:bg-red-100 disabled:opacity-50 transition-colors"
+          >
+            {deletingAll ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <Trash2 className="w-3.5 h-3.5" />
+            )}
+            Delete All
+          </button>
+        )}
+      </div>
 
       {/* Loading state */}
       {loading && (
@@ -232,6 +279,7 @@ const TestResults = ({ refreshKey, onSelectRun, isRunning, runResult, setRunResu
                             <th className="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase">Judge</th>
                             <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Duration</th>
                             <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Tags</th>
+                            <th className="px-4 py-2 w-10"></th>
                           </tr>
                         </thead>
                         <tbody>
@@ -286,6 +334,20 @@ const TestResults = ({ refreshKey, onSelectRun, isRunning, runResult, setRunResu
                                     <span className="text-gray-400 text-xs">-</span>
                                   )}
                                 </div>
+                              </td>
+                              <td className="px-4 py-2.5">
+                                <button
+                                  onClick={(e) => handleDeleteRun(run.id, e)}
+                                  disabled={deletingRun === run.id}
+                                  title="Delete this test run"
+                                  className="text-gray-400 hover:text-red-600 disabled:opacity-50 transition-colors"
+                                >
+                                  {deletingRun === run.id ? (
+                                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                                  ) : (
+                                    <Trash2 className="w-3.5 h-3.5" />
+                                  )}
+                                </button>
                               </td>
                             </tr>
                           ))}

--- a/frontend/src/pages/evaluations/TestResults.jsx
+++ b/frontend/src/pages/evaluations/TestResults.jsx
@@ -18,8 +18,9 @@ import {
   Clock,
   Filter,
   BarChart3,
+  Trash2,
 } from 'lucide-react'
-import { getTestBatches, getTags } from '../../services/api'
+import { getTestBatches, getTags, deleteTestBatch } from '../../services/api'
 import { formatDate, formatDuration, StatusBadge, ResultsBanner } from './helpers'
 
 const TestResults = ({ refreshKey, onSelectRun, isRunning, runResult, setRunResult }) => {
@@ -33,6 +34,7 @@ const TestResults = ({ refreshKey, onSelectRun, isRunning, runResult, setRunResu
   const [expandedBatches, setExpandedBatches] = useState(new Set())
   const [initialExpanded, setInitialExpanded] = useState(false)
   const [retryKey, setRetryKey] = useState(0)
+  const [deletingBatch, setDeletingBatch] = useState(null)
 
   const fetchTags = async () => {
     try {
@@ -75,6 +77,20 @@ const TestResults = ({ refreshKey, onSelectRun, isRunning, runResult, setRunResu
       next.add(batchId)
     }
     setExpandedBatches(next)
+  }
+
+  const handleDeleteBatch = async (batchId, e) => {
+    e.stopPropagation()
+    if (!window.confirm('Delete this test result and all its runs? This cannot be undone.')) return
+    setDeletingBatch(batchId)
+    try {
+      await deleteTestBatch(batchId)
+      setRetryKey((k) => k + 1)
+    } catch (err) {
+      alert('Failed to delete test result: ' + err.message)
+    } finally {
+      setDeletingBatch(null)
+    }
   }
 
   return (
@@ -184,6 +200,18 @@ const TestResults = ({ refreshKey, onSelectRun, isRunning, runResult, setRunResu
                       <span className="text-xs text-gray-500">
                         {formatDate(batch.started_at)}
                       </span>
+                      <button
+                        onClick={(e) => handleDeleteBatch(batch.batch_id, e)}
+                        disabled={deletingBatch === batch.batch_id}
+                        title="Delete this test result"
+                        className="flex items-center text-gray-400 hover:text-red-600 disabled:opacity-50 transition-colors"
+                      >
+                        {deletingBatch === batch.batch_id ? (
+                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                        ) : (
+                          <Trash2 className="w-3.5 h-3.5" />
+                        )}
+                      </button>
                       {expanded ? (
                         <ChevronUp className="w-4 h-4 text-gray-400" />
                       ) : (

--- a/frontend/src/pages/evaluations/TestRunner.jsx
+++ b/frontend/src/pages/evaluations/TestRunner.jsx
@@ -21,7 +21,7 @@ import {
   Search,
 } from 'lucide-react'
 import { runUnitTests } from '../../services/api'
-import { formatDuration } from './helpers'
+import { filterTests, formatDuration } from './helpers'
 
 // ---- Full-screen Test Selector Modal ----
 
@@ -35,6 +35,8 @@ export const TestSelectorModal = ({
   setSelectedTests,
   modeFilter,
   setModeFilter,
+  searchQuery,
+  setSearchQuery,
   onRun,
   onClose,
   isRunning,
@@ -44,7 +46,10 @@ export const TestSelectorModal = ({
   setJudgeEnabled,
 }) => {
   const [expandedTests, setExpandedTests] = useState(new Set())
-  const [searchQuery, setSearchQuery] = useState('')
+
+  // Tests currently visible given the mode filter + search query. Selection
+  // counts and the run resolution key off this so they match what's shown.
+  const visibleTests = filterTests(tests, modeFilter, searchQuery)
 
   const toggleTest = (name) => {
     const next = new Set(selectedTests)
@@ -58,7 +63,7 @@ export const TestSelectorModal = ({
         setExpandedTests((prev) => new Set([...prev, name]))
       }
     }
-    if (next.size === tests.length) {
+    if (next.size === visibleTests.length) {
       setSelectAll(true)
       setSelectedTests(new Set())
     } else {
@@ -88,7 +93,7 @@ export const TestSelectorModal = ({
     setExpandedTests(next)
   }
 
-  const effectiveCount = selectAll ? tests.length : selectedTests.size
+  const effectiveCount = selectAll ? visibleTests.length : selectedTests.size
   const canRun = !isRunning && effectiveCount > 0 && !loading && !error
 
   return (
@@ -156,27 +161,11 @@ export const TestSelectorModal = ({
                   onChange={toggleAll}
                   className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 w-4 h-4"
                 />
-                <span className="font-semibold text-sm">Select All ({tests.length} tests)</span>
+                <span className="font-semibold text-sm">Select All ({visibleTests.length} tests)</span>
               </label>
 
               {/* Individual tests */}
-              {tests.filter((t) => {
-                if (modeFilter === 'all') return true
-                if (modeFilter === 'manual') return t.manual_input
-                if (modeFilter === 'tool') return t.type === 'tool'
-                if (modeFilter === 'agent') return t.type === 'agent' && !t.manual_input
-                return t.type === modeFilter && !t.manual_input
-              }).filter((t) => {
-                if (!searchQuery.trim()) return true
-                const q = searchQuery.toLowerCase()
-                return (
-                  t.name.toLowerCase().includes(q) ||
-                  (t.description && t.description.toLowerCase().includes(q)) ||
-                  (t.tags && t.tags.some((tag) => tag.toLowerCase().includes(q))) ||
-                  (t.agents && t.agents.some((a) => a.toLowerCase().includes(q))) ||
-                  (t.message && t.message.toLowerCase().includes(q))
-                )
-              }).map((test) => {
+              {visibleTests.map((test) => {
                 const checked = selectAll || selectedTests.has(test.name)
                 const expanded = expandedTests.has(test.name)
                 const testType = test.type
@@ -338,6 +327,12 @@ export const TestSelectorModal = ({
                   </div>
                 )
               })}
+
+              {visibleTests.length === 0 && (
+                <div className="text-center py-8 text-sm text-gray-400">
+                  No tests match the current filter{searchQuery.trim() ? ` "${searchQuery.trim()}"` : ''}.
+                </div>
+              )}
             </>
           )}
         </div>
@@ -362,7 +357,7 @@ export const TestSelectorModal = ({
           <div className="flex items-center gap-3">
             {(() => {
               const hasAgent = selectAll
-                ? tests.some((t) => t.type === 'agent')
+                ? visibleTests.some((t) => t.type === 'agent')
                 : tests.some((t) => selectedTests.has(t.name) && t.type === 'agent')
               return hasAgent ? (
                 <label className="flex items-center gap-1.5 cursor-pointer">

--- a/frontend/src/pages/evaluations/helpers.jsx
+++ b/frontend/src/pages/evaluations/helpers.jsx
@@ -9,6 +9,31 @@ export const formatDate = (dateStr) => {
   }
 }
 
+// Filter the available tests by mode (all/agent/tool/manual/...) and a free-text
+// search query. Shared by the selector list, the selection counts, and the run
+// resolution so what you see, what's counted, and what runs all stay in sync.
+export const filterTests = (tests, modeFilter = 'all', searchQuery = '') => {
+  const q = searchQuery.trim().toLowerCase()
+  const matchesMode = (t) => {
+    if (modeFilter === 'all') return true
+    if (modeFilter === 'manual') return t.manual_input
+    if (modeFilter === 'tool') return t.type === 'tool'
+    if (modeFilter === 'agent') return t.type === 'agent' && !t.manual_input
+    return t.type === modeFilter && !t.manual_input
+  }
+  const matchesSearch = (t) => {
+    if (!q) return true
+    return (
+      t.name.toLowerCase().includes(q) ||
+      (t.description && t.description.toLowerCase().includes(q)) ||
+      (t.tags && t.tags.some((tag) => tag.toLowerCase().includes(q))) ||
+      (t.agents && t.agents.some((a) => a.toLowerCase().includes(q))) ||
+      (t.message && t.message.toLowerCase().includes(q))
+    )
+  }
+  return tests.filter((t) => matchesMode(t) && matchesSearch(t))
+}
+
 export const formatDuration = (ms) => {
   if (ms === null || ms === undefined) return '-'
   if (ms < 1000) return `${ms}ms`

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -345,6 +345,9 @@ export const getTags = () =>
 export const deleteTestUsers = () =>
   request('/api/evaluations/test-users', { method: 'DELETE' })
 
+export const deleteTestBatch = (batchId) =>
+  request(`/api/evaluations/test-batches/${encodeURIComponent(batchId)}`, { method: 'DELETE' })
+
 export const runTests = (options = {}) =>
   request('/api/evaluations/run-tests', {
     method: 'POST',

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -348,6 +348,12 @@ export const deleteTestUsers = () =>
 export const deleteTestBatch = (batchId) =>
   request(`/api/evaluations/test-batches/${encodeURIComponent(batchId)}`, { method: 'DELETE' })
 
+export const deleteAllTestBatches = () =>
+  request('/api/evaluations/test-batches', { method: 'DELETE' })
+
+export const deleteTestRun = (testRunId) =>
+  request(`/api/evaluations/test-runs/${encodeURIComponent(testRunId)}`, { method: 'DELETE' })
+
 export const runTests = (options = {}) =>
   request('/api/evaluations/run-tests', {
     method: 'POST',


### PR DESCRIPTION
## Wat & waarom

Deze PR lost **2 issues** op de admin Tests/Evaluations-pagina op:

Closes #197
Closes #165

### #197 — Test filtering werkte niet door op de run
De zoekbalk leefde alleen ín `TestSelectorModal` en filterde enkel de getoonde lijst. De "Select All"-telling en de run-logica negeerden de zoekterm, waardoor "run alle testen" tóch alles draaide.
- `searchQuery` naar de `Evaluations`-parent getild (net als `modeFilter`) en gereset bij sluiten van de modal, zodat de losse Run-knop nooit een verborgen filter erft.
- Gedeelde helper `filterTests(tests, modeFilter, searchQuery)` toegevoegd en consistent toegepast op de lijst, de "Select All"-telling, de footer-telling én de run-resolutie.
- `run_all` wordt nu alleen gebruikt zonder mode-filter én zonder zoekterm.
- "No tests match"-lege staat toegevoegd.

### #165 — Test results konden niet verwijderd worden
De feature ontbrak end-to-end; gespiegeld op het bestaande benchmark-run delete-patroon.
- repo: `delete_test_batch()` (werkt voor echte batches én losse ongebatchte runs)
- service: `delete_test_batch()` met `NotFoundError` + commit/logging
- route: `DELETE /evaluations/test-batches/{batch_id}` (admin only)
- `api.js`: `deleteTestBatch()`
- `TestResults.jsx`: prullenbak-knop per batch met bevestiging + refresh

## Testplan

Herbouwen en naar de testpagina:
- [ ] Stack herbouwen: `sudo docker compose --profile dev --profile init up -d --build`
- [ ] Inloggen als **admin** (`admin` / `Admin123!`)
- [ ] Ga naar **Tests** → `/admin/evaluations`

**#197 — filtering werkt door op de run** (open Run Tests → Select Tests):
- [ ] Typ in de zoekbalk → lijst filtert
- [ ] "Select All (N tests)" toont het **gefilterde** aantal
- [ ] Footer "X tests selected" matcht het gefilterde aantal
- [ ] Run met actieve zoekterm → alleen de **gefilterde** tests draaien (niet alle)
- [ ] Zoekterm zonder matches → "No tests match…" + Run uitgeschakeld
- [ ] Modal sluiten → losse Run-knop draait weer alles/mode (geen verborgen filter)

**#165 — test results verwijderen:**
- [ ] Elke entry in **Test Results** heeft een prullenbak-icoon
- [ ] Klik → bevestiging → entry verdwijnt en lijst ververst
- [ ] Werkt voor een meervoudige batch én een losse (ongebatchte) run

🤖 Generated with [Claude Code](https://claude.com/claude-code)