### PR TITLE
fix: mermaid diagrams in PDF exports

### DIFF
--- a/frontend/src/components/ArchimateBlock.jsx
+++ b/frontend/src/components/ArchimateBlock.jsx
@@ -18,13 +18,8 @@
 import { useEffect, useState, useRef, useCallback, useContext } from 'react'
 import { AlertTriangle, Code, Eye, ZoomIn, ZoomOut, Maximize2 } from 'lucide-react'
 import { ProjectRepoContext } from './chat/ChatHelpers'
-import { getProjectFile, getProjectFileFromWorkspace, getProjectFileChanges } from '../services/api'
-import {
-  parseEmbedSpec,
-  parseArchimateXML,
-  computeLayout,
-  renderViewToSVG,
-} from './archimate/archimateParser'
+import { parseEmbedSpec } from './archimate/archimateParser'
+import { renderArchimateSpecToSvg } from './archimate/archimateRender'
 
 // --- Interactive pan/zoom (same UX as MermaidBlock) -----------------------
 
@@ -130,61 +125,14 @@ const ArchimateBlock = ({ code, highlightIds }) => {
       return
     }
 
-    const branch = repo.default_branch || 'main'
     setState({ status: 'loading', svg: null, error: null })
-
-    // Source the .archimate file from the session workspace when we have
-    // one — the architect's commit may not have reached Gitea yet during
-    // an approval preview. Fall back to the Gitea ref when the workspace
-    // copy is missing (e.g. older sessions or post-merge browsing).
-    const fetchArchimateFile = async () => {
-      if (repo.session_id) {
-        try {
-          return await getProjectFileFromWorkspace(repo.id, repo.session_id, spec.file)
-        } catch (err) {
-          if (err.status && err.status !== 404) throw err
-        }
-      }
-      return getProjectFile(repo.id, spec.file, branch)
-    }
 
     ;(async () => {
       try {
-        // Fetch the current file and the last-commit identifier-diff in parallel.
-        // The diff feeds delta-highlighting: any element/connection whose
-        // identifier appeared in the latest commit is rendered with an accent.
-        // The diff is Gitea-only — if the file isn't committed yet there is
-        // nothing to diff against, hence the silent catch.
-        const [response, changes] = await Promise.all([
-          fetchArchimateFile(),
-          getProjectFileChanges(repo.id, spec.file, branch).catch(() => null),
-        ])
-        const xml = response?.content ?? response
-        if (typeof xml !== 'string') {
-          throw new Error('Unexpected response shape from project file API')
-        }
-        const model = parseArchimateXML(xml)
-        const view = model.views.get(spec.viewId)
-        if (!view) {
-          throw new Error(`View '${spec.viewId}' not found in ${spec.file}`)
-        }
-        const laidOut = await computeLayout(view)
-        const deltaIds = new Set([
-          ...(highlightIds || []),
-          ...((changes?.added_identifiers) || []),
-        ])
-        const svg = renderViewToSVG(laidOut, model, {
-          highlightIds: deltaIds.size ? deltaIds : undefined,
-        })
+        const { svg, viewName, changeCount, lastCommitMessage } =
+          await renderArchimateSpecToSvg(code, repo, { highlightIds })
         if (!cancelled) {
-          setState({
-            status: 'ready',
-            svg,
-            error: null,
-            viewName: view.name,
-            changeCount: (changes?.added_identifiers || []).length,
-            lastCommitMessage: changes?.last_commit_message,
-          })
+          setState({ status: 'ready', svg, error: null, viewName, changeCount, lastCommitMessage })
         }
       } catch (err) {
         if (!cancelled) {

--- a/frontend/src/components/archimate/archimateRender.js
+++ b/frontend/src/components/archimate/archimateRender.js
@@ -1,0 +1,70 @@
+/**
+ * Shared resolver for ```archimate code blocks → SVG string.
+ *
+ * Used by both ArchimateBlock (chat) and the PDF export (downloadDesign.js)
+ * so they render identically. Sources the .archimate XML from the session
+ * workspace first (the architect's commit may not have reached Gitea yet
+ * during an approval preview) and falls back to the Gitea ref.
+ *
+ * The returned SVG uses native <text> labels (no <foreignObject>), so it
+ * survives the browser's image-context sandbox when rasterised for a PDF.
+ */
+
+import { getProjectFile, getProjectFileFromWorkspace, getProjectFileChanges } from '../../services/api'
+import { parseEmbedSpec, parseArchimateXML, computeLayout, renderViewToSVG } from './archimateParser'
+
+/**
+ * Resolve an archimate embed spec to an SVG string.
+ *
+ * @param {string} code  the code-block body (`view-id:` / `file:` spec)
+ * @param {{id:string, default_branch?:string, session_id?:string}} repo
+ * @param {{highlightIds?:Iterable<string>}} [opts]
+ * @returns {Promise<{svg:string, viewName:string, changeCount:number, lastCommitMessage?:string}>}
+ */
+export async function renderArchimateSpecToSvg(code, repo, opts = {}) {
+  const spec = parseEmbedSpec(code)
+  if (!spec) throw new Error('Missing view-id in code block')
+  if (!repo?.id) throw new Error('No project context — open this TD inside a project session')
+
+  const branch = repo.default_branch || 'main'
+
+  const fetchArchimateFile = async () => {
+    if (repo.session_id) {
+      try {
+        return await getProjectFileFromWorkspace(repo.id, repo.session_id, spec.file)
+      } catch (err) {
+        if (err.status && err.status !== 404) throw err
+      }
+    }
+    return getProjectFile(repo.id, spec.file, branch)
+  }
+
+  const [response, changes] = await Promise.all([
+    fetchArchimateFile(),
+    getProjectFileChanges(repo.id, spec.file, branch).catch(() => null),
+  ])
+  const xml = response?.content ?? response
+  if (typeof xml !== 'string') {
+    throw new Error('Unexpected response shape from project file API')
+  }
+
+  const model = parseArchimateXML(xml)
+  const view = model.views.get(spec.viewId)
+  if (!view) throw new Error(`View '${spec.viewId}' not found in ${spec.file}`)
+
+  const laidOut = await computeLayout(view)
+  const deltaIds = new Set([
+    ...(opts.highlightIds || []),
+    ...((changes?.added_identifiers) || []),
+  ])
+  const svg = renderViewToSVG(laidOut, model, {
+    highlightIds: deltaIds.size ? deltaIds : undefined,
+  })
+
+  return {
+    svg,
+    viewName: view.name,
+    changeCount: (changes?.added_identifiers || []).length,
+    lastCommitMessage: changes?.last_commit_message,
+  }
+}

--- a/frontend/src/components/chat/ApprovalCard.jsx
+++ b/frontend/src/components/chat/ApprovalCard.jsx
@@ -6,7 +6,7 @@
  * a contact popup to find users who can approve.
  */
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import { Link } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -30,7 +30,7 @@ import {
   Clock,
 } from 'lucide-react'
 import { getUsersByRole } from '../../services/api'
-import { chatMarkdownComponents, SourceFileContext } from './ChatHelpers'
+import { chatMarkdownComponents, SourceFileContext, ProjectRepoContext } from './ChatHelpers'
 import DownloadMenu from './DownloadMenu'
 import { downloadAsMarkdown, downloadContentAsPdf } from '../../utils/downloadDesign'
 
@@ -117,7 +117,7 @@ const FilePreviewModal = ({ files, onClose }) => {
                       onDownloadPdf={async () => {
                         setPdfLoading((prev) => ({ ...prev, [path]: true }))
                         try {
-                          await downloadContentAsPdf(content, path)
+                          await downloadContentAsPdf(content, path, repo)
                         } finally {
                           setPdfLoading((prev) => ({ ...prev, [path]: false }))
                         }
@@ -210,6 +210,7 @@ const getToolInfo = (toolName) => {
 }
 
 const ApprovalCard = ({ approval, onApprove, onReject, isProcessing, currentUserId, sessionId, userRoles = [], chatInline = false, resolved = false }) => {
+  const repo = useContext(ProjectRepoContext)
   const [showRejectInput, setShowRejectInput] = useState(false)
   const [rejectReason, setRejectReason] = useState('')
   const [showNewContent, setShowNewContent] = useState(false)
@@ -422,7 +423,7 @@ const ApprovalCard = ({ approval, onApprove, onReject, isProcessing, currentUser
                   onDownloadMd={() => downloadAsMarkdown(newContent, filePath)}
                   onDownloadPdf={async () => {
                     setCardPdfLoading(true)
-                    try { await downloadContentAsPdf(newContent, filePath) }
+                    try { await downloadContentAsPdf(newContent, filePath, repo) }
                     finally { setCardPdfLoading(false) }
                   }}
                 />

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -2,7 +2,7 @@
  * Session Detail - right panel when a session is selected in Chat
  */
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useContext } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Send, CheckCircle, XCircle, Shield, ShieldOff, Loader2, ExternalLink, MessageSquare, FileCode, FilePlus, StopCircle, PlayCircle, ArrowUp, AlertTriangle, Terminal, ChevronDown, ChevronRight, Calendar } from 'lucide-react'
 import { Link } from 'react-router-dom'
@@ -65,6 +65,7 @@ const getToolLabel = (toolName) => {
 const InlineApproval = ({ tc, sessionId, sessionUserId }) => {
   const queryClient = useQueryClient()
   const user = getUserInfo()
+  const repo = useContext(ProjectRepoContext)
   const [rejectMode, setRejectMode] = useState(false)
   const [rejectReason, setRejectReason] = useState('')
   const [showFilePreview, setShowFilePreview] = useState(false)
@@ -170,7 +171,7 @@ const InlineApproval = ({ tc, sessionId, sessionUserId }) => {
                       onDownloadMd={() => downloadAsMarkdown(content, filePath)}
                       onDownloadPdf={async () => {
                         setPdfDownloading(true)
-                        try { await downloadContentAsPdf(content, filePath) }
+                        try { await downloadContentAsPdf(content, filePath, repo) }
                         finally { setPdfDownloading(false) }
                       }}
                     />

--- a/frontend/src/utils/downloadDesign.js
+++ b/frontend/src/utils/downloadDesign.js
@@ -116,6 +116,58 @@ async function downloadElementAsPdf(element, path) {
   pdf.save(filename)
 }
 
+// Browsers skip <foreignObject> when rendering SVG as <img> (security sandbox).
+// Mermaid puts text labels in <foreignObject> by default (htmlLabels:true).
+// Convert them to native SVG <text> so they survive rasterisation.
+function foreignObjectsToText(svgString) {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(svgString, 'image/svg+xml')
+  const NS = 'http://www.w3.org/2000/svg'
+
+  for (const fo of [...doc.querySelectorAll('foreignObject')]) {
+    const rawText = fo.textContent.trim()
+    if (!rawText) { fo.remove(); continue }
+
+    const x = parseFloat(fo.getAttribute('x')) || 0
+    const y = parseFloat(fo.getAttribute('y')) || 0
+    const w = parseFloat(fo.getAttribute('width')) || 0
+    const h = parseFloat(fo.getAttribute('height')) || 0
+
+    const sizeMatch = fo.innerHTML.match(/font-size:\s*([\d.]+)/i)
+    const fontSize = sizeMatch ? parseFloat(sizeMatch[1]) : 14
+    const lines = rawText.split(/\n/).map(l => l.trim()).filter(Boolean)
+
+    const text = doc.createElementNS(NS, 'text')
+    text.setAttribute('x', String(x + w / 2))
+    text.setAttribute('text-anchor', 'middle')
+    text.setAttribute('font-family', '"trebuchet ms", verdana, arial, sans-serif')
+    text.setAttribute('font-size', String(fontSize))
+    text.setAttribute('fill', '#333')
+
+    if (lines.length <= 1) {
+      text.setAttribute('y', String(y + h / 2))
+      text.setAttribute('dominant-baseline', 'central')
+      text.textContent = lines[0] || ''
+    } else {
+      const lineH = fontSize * 1.3
+      const totalH = lines.length * lineH
+      const startY = y + (h - totalH) / 2 + fontSize * 0.85
+      for (let i = 0; i < lines.length; i++) {
+        const tspan = doc.createElementNS(NS, 'tspan')
+        tspan.setAttribute('x', String(x + w / 2))
+        tspan.setAttribute('y', String(startY + i * lineH))
+        tspan.textContent = lines[i]
+        text.appendChild(tspan)
+      }
+    }
+
+    fo.parentNode.insertBefore(text, fo)
+    fo.remove()
+  }
+
+  return new XMLSerializer().serializeToString(doc)
+}
+
 async function renderMermaidForPdf(container) {
   const codeBlocks = container.querySelectorAll('pre > code.language-mermaid')
   if (codeBlocks.length === 0) return
@@ -140,10 +192,11 @@ async function renderMermaidForPdf(container) {
     try {
       const { svg } = await mermaid.render(id, code)
 
-      // Strip <foreignObject> to prevent canvas taint when rasterising
-      const cleanSvg = svg.replace(/<foreignObject[\s\S]*?<\/foreignObject>/gi, '')
+      // Convert any <foreignObject> labels to SVG <text> so they survive
+      // the browser's image-context sandbox (htmlLabels:false may not
+      // take effect if mermaid was already initialised with htmlLabels:true)
+      const cleanSvg = foreignObjectsToText(svg)
 
-      // Blob URL: same-origin (no taint) and avoids btoa Unicode edge-cases
       const svgBlob = new Blob([cleanSvg], { type: 'image/svg+xml;charset=utf-8' })
       const svgUrl = URL.createObjectURL(svgBlob)
 
@@ -171,7 +224,6 @@ async function renderMermaidForPdf(container) {
         replacement.height = h
         replacement.style.cssText = 'max-width:100%;height:auto;display:block;margin:16px 0;'
 
-        // Guarantee the browser has decoded the pixels before html2canvas runs
         await replacement.decode().catch(() => {})
 
         pre.replaceWith(replacement)

--- a/frontend/src/utils/downloadDesign.js
+++ b/frontend/src/utils/downloadDesign.js
@@ -116,7 +116,6 @@ async function downloadElementAsPdf(element, path) {
   pdf.save(filename)
 }
 
-// Pre-render mermaid code blocks to raster images for reliable PDF capture.
 async function renderMermaidForPdf(container) {
   const codeBlocks = container.querySelectorAll('pre > code.language-mermaid')
   if (codeBlocks.length === 0) return
@@ -137,32 +136,52 @@ async function renderMermaidForPdf(container) {
     const code = codeEl.textContent.trim()
     if (!code) continue
 
+    const id = `pdf-mermaid-${++counter}-${Date.now()}`
     try {
-      const id = `pdf-mermaid-${++counter}-${Date.now()}`
       const { svg } = await mermaid.render(id, code)
 
-      const dataUrl = `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svg)))}`
-      const img = new Image()
-      await new Promise((resolve, reject) => {
-        img.onload = resolve
-        img.onerror = reject
-        img.src = dataUrl
-      })
+      // Strip <foreignObject> to prevent canvas taint when rasterising
+      const cleanSvg = svg.replace(/<foreignObject[\s\S]*?<\/foreignObject>/gi, '')
 
-      const c = document.createElement('canvas')
-      c.width = img.naturalWidth * 2
-      c.height = img.naturalHeight * 2
-      const ctx = c.getContext('2d')
-      ctx.fillStyle = '#ffffff'
-      ctx.fillRect(0, 0, c.width, c.height)
-      ctx.drawImage(img, 0, 0, c.width, c.height)
+      // Blob URL: same-origin (no taint) and avoids btoa Unicode edge-cases
+      const svgBlob = new Blob([cleanSvg], { type: 'image/svg+xml;charset=utf-8' })
+      const svgUrl = URL.createObjectURL(svgBlob)
 
-      const replacement = document.createElement('img')
-      replacement.src = c.toDataURL('image/png')
-      replacement.style.cssText = 'max-width:100%;height:auto;display:block;margin:16px 0;'
-      pre.replaceWith(replacement)
-    } catch {
-      // Keep the raw code block if mermaid rendering fails
+      try {
+        const img = new Image()
+        await new Promise((resolve, reject) => {
+          img.onload = resolve
+          img.onerror = reject
+          img.src = svgUrl
+        })
+
+        const w = img.naturalWidth || 800
+        const h = img.naturalHeight || 600
+        const c = document.createElement('canvas')
+        c.width = w * 2
+        c.height = h * 2
+        const ctx = c.getContext('2d')
+        ctx.fillStyle = '#ffffff'
+        ctx.fillRect(0, 0, c.width, c.height)
+        ctx.drawImage(img, 0, 0, c.width, c.height)
+
+        const replacement = document.createElement('img')
+        replacement.src = c.toDataURL('image/png')
+        replacement.width = w
+        replacement.height = h
+        replacement.style.cssText = 'max-width:100%;height:auto;display:block;margin:16px 0;'
+
+        // Guarantee the browser has decoded the pixels before html2canvas runs
+        await replacement.decode().catch(() => {})
+
+        pre.replaceWith(replacement)
+      } finally {
+        URL.revokeObjectURL(svgUrl)
+      }
+    } catch (err) {
+      console.warn(`[PDF] mermaid block ${counter} failed:`, err)
+      document.querySelector(`#d${id}`)?.remove()
+      document.querySelector(`#${id}`)?.remove()
     }
   }
 

--- a/frontend/src/utils/downloadDesign.js
+++ b/frontend/src/utils/downloadDesign.js
@@ -117,55 +117,30 @@ async function downloadElementAsPdf(element, path) {
 }
 
 // Browsers skip <foreignObject> when rendering SVG as <img> (security sandbox).
-// Mermaid puts text labels in <foreignObject> by default (htmlLabels:true).
-// Convert them to native SVG <text> so they survive rasterisation.
+// Mermaid puts text labels inside <foreignObject> by default (htmlLabels:true).
+// Replace each one with a native SVG <text> so labels survive rasterisation.
+// Uses regex on the raw SVG string to avoid DOMParser/XMLSerializer round-trip
+// which can corrupt namespaces and break the image load.
 function foreignObjectsToText(svgString) {
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(svgString, 'image/svg+xml')
-  const NS = 'http://www.w3.org/2000/svg'
+  return svgString.replace(
+    /<foreignObject([^>]*)>([\s\S]*?)<\/foreignObject>/gi,
+    (_match, attrs, content) => {
+      const tmp = document.createElement('div')
+      tmp.innerHTML = content
+      const text = tmp.textContent.trim()
+      if (!text) return ''
 
-  for (const fo of [...doc.querySelectorAll('foreignObject')]) {
-    const rawText = fo.textContent.trim()
-    if (!rawText) { fo.remove(); continue }
+      const w = parseFloat((attrs.match(/width="([^"]+)"/) || [])[1]) || 0
+      const h = parseFloat((attrs.match(/height="([^"]+)"/) || [])[1]) || 0
+      const x = parseFloat((attrs.match(/\bx="([^"]+)"/) || [])[1]) || 0
+      const y = parseFloat((attrs.match(/\by="([^"]+)"/) || [])[1]) || 0
+      const fontSize = parseFloat((content.match(/font-size:\s*([\d.]+)/i) || [])[1]) || 14
 
-    const x = parseFloat(fo.getAttribute('x')) || 0
-    const y = parseFloat(fo.getAttribute('y')) || 0
-    const w = parseFloat(fo.getAttribute('width')) || 0
-    const h = parseFloat(fo.getAttribute('height')) || 0
+      const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
-    const sizeMatch = fo.innerHTML.match(/font-size:\s*([\d.]+)/i)
-    const fontSize = sizeMatch ? parseFloat(sizeMatch[1]) : 14
-    const lines = rawText.split(/\n/).map(l => l.trim()).filter(Boolean)
-
-    const text = doc.createElementNS(NS, 'text')
-    text.setAttribute('x', String(x + w / 2))
-    text.setAttribute('text-anchor', 'middle')
-    text.setAttribute('font-family', '"trebuchet ms", verdana, arial, sans-serif')
-    text.setAttribute('font-size', String(fontSize))
-    text.setAttribute('fill', '#333')
-
-    if (lines.length <= 1) {
-      text.setAttribute('y', String(y + h / 2))
-      text.setAttribute('dominant-baseline', 'central')
-      text.textContent = lines[0] || ''
-    } else {
-      const lineH = fontSize * 1.3
-      const totalH = lines.length * lineH
-      const startY = y + (h - totalH) / 2 + fontSize * 0.85
-      for (let i = 0; i < lines.length; i++) {
-        const tspan = doc.createElementNS(NS, 'tspan')
-        tspan.setAttribute('x', String(x + w / 2))
-        tspan.setAttribute('y', String(startY + i * lineH))
-        tspan.textContent = lines[i]
-        text.appendChild(tspan)
-      }
-    }
-
-    fo.parentNode.insertBefore(text, fo)
-    fo.remove()
-  }
-
-  return new XMLSerializer().serializeToString(doc)
+      return `<text x="${x + w / 2}" y="${y + h / 2}" text-anchor="middle" dominant-baseline="central" font-family="'trebuchet ms', verdana, arial, sans-serif" font-size="${fontSize}" fill="#333">${escaped}</text>`
+    },
+  )
 }
 
 async function renderMermaidForPdf(container) {

--- a/frontend/src/utils/downloadDesign.js
+++ b/frontend/src/utils/downloadDesign.js
@@ -177,6 +177,56 @@ function foreignObjectsToText(svgString) {
   )
 }
 
+// Content column inside the PDF container (800px − 2×48px padding). Diagrams
+// are rasterised to fill this width (scaled down only when they'd be too tall),
+// so they never come out tiny. The canvas renders at 2× for crisp output.
+const PDF_CONTENT_WIDTH = 704
+const PDF_MAX_DIAGRAM_HEIGHT = 900
+
+// Rasterise an SVG string to a page-width <img> for reliable PDF capture.
+// Shared by the mermaid and archimate renderers. Drawing the (vector) SVG onto
+// a larger canvas keeps it sharp even when the source diagram is small.
+async function svgToPdfImage(svgString) {
+  const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' })
+  const svgUrl = URL.createObjectURL(svgBlob)
+  try {
+    const img = new Image()
+    await new Promise((resolve, reject) => {
+      img.onload = resolve
+      img.onerror = reject
+      img.src = svgUrl
+    })
+
+    const iw = img.naturalWidth || 800
+    const ih = img.naturalHeight || 600
+    let displayW = PDF_CONTENT_WIDTH
+    let displayH = Math.round(ih * (displayW / iw))
+    if (displayH > PDF_MAX_DIAGRAM_HEIGHT) {
+      displayH = PDF_MAX_DIAGRAM_HEIGHT
+      displayW = Math.round(iw * (displayH / ih))
+    }
+
+    const scale = 2
+    const c = document.createElement('canvas')
+    c.width = displayW * scale
+    c.height = displayH * scale
+    const ctx = c.getContext('2d')
+    ctx.fillStyle = '#ffffff'
+    ctx.fillRect(0, 0, c.width, c.height)
+    ctx.drawImage(img, 0, 0, c.width, c.height)
+
+    const replacement = document.createElement('img')
+    replacement.src = c.toDataURL('image/png')
+    replacement.width = displayW
+    replacement.height = displayH
+    replacement.style.cssText = 'max-width:100%;height:auto;display:block;margin:16px 0;'
+    await replacement.decode().catch(() => {})
+    return replacement
+  } finally {
+    URL.revokeObjectURL(svgUrl)
+  }
+}
+
 async function renderMermaidForPdf(container) {
   const codeBlocks = container.querySelectorAll('pre > code.language-mermaid')
   if (codeBlocks.length === 0) return
@@ -206,39 +256,8 @@ async function renderMermaidForPdf(container) {
       // take effect if mermaid was already initialised with htmlLabels:true)
       const cleanSvg = foreignObjectsToText(svg)
 
-      const svgBlob = new Blob([cleanSvg], { type: 'image/svg+xml;charset=utf-8' })
-      const svgUrl = URL.createObjectURL(svgBlob)
-
-      try {
-        const img = new Image()
-        await new Promise((resolve, reject) => {
-          img.onload = resolve
-          img.onerror = reject
-          img.src = svgUrl
-        })
-
-        const w = img.naturalWidth || 800
-        const h = img.naturalHeight || 600
-        const c = document.createElement('canvas')
-        c.width = w * 2
-        c.height = h * 2
-        const ctx = c.getContext('2d')
-        ctx.fillStyle = '#ffffff'
-        ctx.fillRect(0, 0, c.width, c.height)
-        ctx.drawImage(img, 0, 0, c.width, c.height)
-
-        const replacement = document.createElement('img')
-        replacement.src = c.toDataURL('image/png')
-        replacement.width = w
-        replacement.height = h
-        replacement.style.cssText = 'max-width:100%;height:auto;display:block;margin:16px 0;'
-
-        await replacement.decode().catch(() => {})
-
-        pre.replaceWith(replacement)
-      } finally {
-        URL.revokeObjectURL(svgUrl)
-      }
+      const replacement = await svgToPdfImage(cleanSvg)
+      pre.replaceWith(replacement)
     } catch (err) {
       console.warn(`[PDF] mermaid block ${counter} failed:`, err)
       document.querySelector(`#d${id}`)?.remove()
@@ -261,6 +280,37 @@ async function renderMermaidForPdf(container) {
     er: { useMaxWidth: false },
     pie: { useMaxWidth: false },
   })
+}
+
+// Pre-render ```archimate code blocks to raster images for PDF capture.
+// Reuses the same SVG the chat builds (via renderArchimateSpecToSvg) and the
+// same rasterisation path as mermaid. Needs the project/session context to
+// fetch the .archimate model; without it the raw code block is left intact.
+async function renderArchimateForPdf(container, repoContext) {
+  const codeBlocks = container.querySelectorAll('pre > code.language-archimate')
+  if (codeBlocks.length === 0) return
+  if (!repoContext?.id) {
+    console.warn('[PDF] archimate blocks present but no project context — left as raw code')
+    return
+  }
+
+  const { renderArchimateSpecToSvg } = await import('../components/archimate/archimateRender')
+
+  let counter = 0
+  for (const codeEl of codeBlocks) {
+    const pre = codeEl.parentElement
+    const code = codeEl.textContent.trim()
+    if (!code) continue
+    counter++
+    try {
+      const { svg } = await renderArchimateSpecToSvg(code, repoContext)
+      const replacement = await svgToPdfImage(svg)
+      pre.replaceWith(replacement)
+    } catch (err) {
+      console.warn(`[PDF] archimate block ${counter} failed:`, err)
+      // leave the raw code block in place
+    }
+  }
 }
 
 export function buildChatTranscript(sessionData) {
@@ -358,7 +408,7 @@ export function buildChatTranscript(sessionData) {
   return lines.join('\n')
 }
 
-export async function downloadContentAsPdf(markdownContent, path) {
+export async function downloadContentAsPdf(markdownContent, path, repoContext = null) {
   const [{ marked }, { default: DOMPurify }] = await Promise.all([
     import('marked'),
     import('dompurify'),
@@ -393,6 +443,7 @@ export async function downloadContentAsPdf(markdownContent, path) {
   document.body.appendChild(container)
   try {
     await renderMermaidForPdf(container)
+    await renderArchimateForPdf(container, repoContext)
     await downloadElementAsPdf(container.firstElementChild, path)
   } finally {
     document.body.removeChild(container)

--- a/frontend/src/utils/downloadDesign.js
+++ b/frontend/src/utils/downloadDesign.js
@@ -121,6 +121,31 @@ async function downloadElementAsPdf(element, path) {
 // Replace each one with a native SVG <text> so labels survive rasterisation.
 // Uses regex on the raw SVG string to avoid DOMParser/XMLSerializer round-trip
 // which can corrupt namespaces and break the image load.
+
+function wordWrap(text, maxWidth, fontSize) {
+  const avgCharWidth = fontSize * 0.6
+  const maxChars = Math.max(1, Math.floor(maxWidth / avgCharWidth))
+  const words = text.split(/\s+/)
+  const lines = []
+  let cur = ''
+  for (const word of words) {
+    if (!cur) {
+      cur = word
+    } else if ((cur + ' ' + word).length <= maxChars) {
+      cur += ' ' + word
+    } else {
+      lines.push(cur)
+      cur = word
+    }
+  }
+  if (cur) lines.push(cur)
+  return lines.length ? lines : [text]
+}
+
+function escapeXml(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
 function foreignObjectsToText(svgString) {
   return svgString.replace(
     /<foreignObject([^>]*)>([\s\S]*?)<\/foreignObject>/gi,
@@ -136,9 +161,18 @@ function foreignObjectsToText(svgString) {
       const y = parseFloat((attrs.match(/\by="([^"]+)"/) || [])[1]) || 0
       const fontSize = parseFloat((content.match(/font-size:\s*([\d.]+)/i) || [])[1]) || 14
 
-      const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      const cx = x + w / 2
+      const pad = 8
+      const lines = wordWrap(text, Math.max(w - pad * 2, fontSize * 2), fontSize)
+      const lineH = fontSize * 1.35
+      const totalH = lines.length * lineH
+      const baseY = y + (h - totalH) / 2 + fontSize * 0.9
 
-      return `<text x="${x + w / 2}" y="${y + h / 2}" text-anchor="middle" dominant-baseline="central" font-family="'trebuchet ms', verdana, arial, sans-serif" font-size="${fontSize}" fill="#333">${escaped}</text>`
+      const tspans = lines
+        .map((line, i) => `<tspan x="${cx}" y="${baseY + i * lineH}">${escapeXml(line)}</tspan>`)
+        .join('')
+
+      return `<text text-anchor="middle" font-family="'trebuchet ms', verdana, arial, sans-serif" font-size="${fontSize}" fill="#333">${tspans}</text>`
     },
   )
 }

--- a/testing/tools/td-pdf-export-archimate-mermaid-paused.yaml
+++ b/testing/tools/td-pdf-export-archimate-mermaid-paused.yaml
@@ -1,0 +1,696 @@
+## Seeded session for validating the PDF export of a Technical Design.
+##
+## Drives the full design flow deterministically (no LLM) and stops on the
+## architect's TD approval gate with EVERYTHING in place:
+##   - docs/functional-design.md      (BA, approved — contains a mermaid flowchart)
+##   - docs/technical-research.md      (architect, approved)
+##   - docs/architecture.archimate     (architect, approved — the ArchiMate model)
+##   - docs/technical-design.md        (architect, approval PENDING) with BOTH
+##       mermaid diagrams (sequence + state) AND the embedded ArchiMate view.
+##
+## Purpose: let a tester verify the PDF download end-to-end.
+##   1. Run td-pdf-export-archimate-mermaid-paused from the evaluations page -> green.
+##   2. Log in as the session owner (admin). Open the session "overlast-meldportaal-pdf".
+##   3. The FD approval card (approved) -> download the FD as PDF: its mermaid
+##      flowchart renders with shapes + labels and fills the page width.
+##   4. The TD approval card (pending) -> download the TD as PDF: the two mermaid
+##      diagrams render at page width AND the ArchiMate view renders (no longer a
+##      raw ```archimate code block).
+##
+## Deterministic (no LLM up to the gate). Embed view id matches the injected
+## architecture.archimate: id-22c5ae408afc4068aa82d09d65c58df2.
+
+tool-test:
+  name: td-pdf-export-archimate-mermaid-paused
+  description: "FD + research + ArchiMate plate + TD (with mermaid AND archimate) injected, paused on the TD approval gate — for validating the PDF export of FD and TD"
+  tags: [archimate, mermaid, pdf, td-approval, paused, manual-followup]
+  session_status: paused
+
+  chain:
+    # --- Router ---
+    - agent: router
+      tool: builtin:set_intent
+      arguments:
+        intent: create_project
+        project_name: overlast-meldportaal-pdf
+        description: "Burger-portaal voor het melden van overlast aan het waterschap; meldingen landen in het zaaksysteem (DSP) en het juiste behandelteam wordt genotificeerd."
+      assert:
+        result:
+          - not_empty
+
+    - agent: router
+      tool: builtin:done
+      arguments:
+        summary: "Agent router: Classified as create_project for overlast-meldportaal-pdf"
+
+    # --- Planner: BA first ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: business_analyst
+            prompt: "Gather requirements and create the functional design for the overlast-meldportaal"
+          - agent_id: planner
+            prompt: "Re-evaluate after business analyst completes"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: Planned business_analyst to gather requirements and create the functional design"
+
+    # --- Business Analyst writes the FD (pre-approved; contains a mermaid flowchart) ---
+    - agent: business_analyst
+      tool: coding:make_design
+      approval:
+        status: approved
+      arguments:
+        path: docs/functional-design.md
+        content: |
+          # Functioneel Ontwerp — Burger Overlast-meldportaal
+
+          > Platform standards applied: [docs/platform-functional-standards.md](./platform-functional-standards.md) rev `2026-04-20`.
+
+          > **Disclaimer:** Dit document is gegenereerd met behulp van AI. Controleer de inhoud zorgvuldig voor gebruik. / This document was generated with the help of AI. Please review the content carefully before use.
+
+          ## 1. Current vs Desired Situation
+
+          | Aspect | Current Situation | Desired Situation |
+          |--------|-------------------|-------------------|
+          | Meldkanaal | Telefoon, e-mail, social media verspreid over afdelingen | Eén digitaal portaal voor alle overlast-meldingen |
+          | Registratie | Handmatig per afdeling, geen centraal overzicht | Automatisch in zaaksysteem (DSP) bij indienen |
+          | Notificatie | Hangt af van wie de melding ontvangt | Automatisch naar het juiste behandelteam binnen seconden |
+          | Status voor burger | Geen terugkoppeling tenzij burger zelf belt | Burger volgt status via meldingsnummer + e-maillink |
+          | Trendrapportage | Niet mogelijk — meldingen niet gestructureerd | Dashboard per type, locatie, doorlooptijd |
+          | Bereikbaarheid | Alleen kantooruren effectief | 24/7 indienen, behandeling kantooruren |
+
+          ## 2. Problem Summary
+
+          - **Who is affected:** Burgers in het beheergebied van het waterschap (overlastmelders) en de behandelteams die meldingen oppakken.
+          - **Problem:** Meldingen komen via verspreide kanalen binnen, raken zoek of komen vertraagd bij het juiste team. Burgers krijgen geen statusterugkoppeling.
+          - **Why it matters:** Vertraagde behandeling leidt tot escalaties, herhaalmeldingen en imagoschade. Het waterschap kan niet rapporteren op trends en kan dus niet proactief beleid maken.
+          - **What success looks like:** Elke melding belandt binnen 1 minuut bij het juiste team, burger kan status volgen zonder te bellen, zaakcoördinator heeft realtime overzicht.
+
+          ## 3. Functional Requirements
+
+          | ID | Source | Requirement | Verification Method |
+          |----|--------|-------------|---------------------|
+          | FR-01 | BA | The system shall enable a citizen to submit an overlast report with location, type, description and optional photo. | Functional test |
+          | FR-02 | BA | The system shall return a meldingsnummer so the citizen can track status without an account. | Functional test |
+          | FR-03 | BA | The system shall send an e-maillink (if e-mail provided) so the citizen can return to the status page. | Integration test |
+          | FR-04 | BA | The system shall automatically register every report as a zaak in the DSP with the matching zaaktype. | Integration test |
+          | FR-05 | BA | The system shall notify the responsible behandelteam within 60 seconds of submission. | Integration test |
+          | FR-06 | BA | The system shall mirror status updates from the DSP to the citizen status page within 60 seconds. | Integration test |
+          | FR-07 | BA | The system shall expose a coordinator dashboard with meldingen filtered by type, location and doorlooptijd. | Functional test |
+
+          ## 4. Business Rules & Logic
+
+          | Rule ID | Description | Condition | Outcome |
+          |---------|-------------|-----------|---------|
+          | BR-01 | Mapping melding-type → zaaktype | Type matches a DSP zaaktype | Auto-register with matched zaaktype |
+          | BR-02 | Onbekend melding-type | No DSP zaaktype matches | Register with default "overlast-overig" |
+          | BR-03 | Pseudonimiseer e-mail bij sluiten | Zaak status becomes "afgesloten" | Replace e-mail with hash after 7 days |
+          | BR-04 | Duplicaat-detectie | New melding within 500m + 4h + same type | Link to existing zaak |
+          | BR-05 | Notificatie-routing | Zaaktype assigned to a behandelteam | Notify that team; fallback to algemene meldkamer |
+
+          ## 5. User Journeys
+
+          **Journey A — Burger dient melding in**
+          1. Burger opent portaal-URL in browser
+          2. Systeem toont kaart van beheergebied
+          3. Burger zet pin op overlast-locatie
+          4. Systeem resolved adres via PDOK en toont in formulier
+          5. Burger kiest type, schrijft beschrijving, voegt foto toe, vult optioneel e-mail in
+          6. Burger drukt op "Verstuur"
+          7. Systeem registreert zaak in DSP, krijgt zaaknummer terug
+          8. Systeem toont meldingsnummer + link naar status-pagina
+
+          **Journey B — Behandelteam handelt af**
+          1. Team ontvangt notificatie met zaaknummer + samenvatting
+          2. Teamlid behandelt de zaak in het zaaksysteem
+          3. Status verschijnt binnen 60s op burger's status-pagina
+
+          ## 6. Integration Points
+
+          | System/Service | Interaction Type | Purpose |
+          |----------------|------------------|---------|
+          | Zaaksysteem (DSP) | REST (ZGW-API) | Zaakregistratie, statusupdates, zaaktype-lookup |
+          | Notificatieservice | REST | E-mail + push naar behandelteams |
+          | PDOK BAG/BGT | REST | Adres-resolutie bij coördinaten |
+          | Object-opslag (S3-compatibel) | S3 API | Foto's bij meldingen |
+          | Waterschap-SSO (Keycloak) | OIDC | Authenticatie van behandelteam + coördinator |
+
+          ## 7. Non-Functional Requirements
+
+          | ID | Source | Requirement | Verification Method |
+          |----|--------|-------------|---------------------|
+          | NFR-01 | BA | 95% van indien-acties wordt binnen 2 seconden verwerkt. | Performance test |
+          | NFR-02 | BA | Beschikbaarheid 99.5% tijdens kantooruren. | SLA-monitoring |
+          | NFR-03 | BA | Actuele zaakstatus binnen 60s na update in DSP. | Integration test |
+          | NFR-04 | BA | Foto-upload max 10 MB, JPEG/PNG/HEIC, auto-herschalen naar max 1920px. | Functional test |
+
+          ## 8. Security & Compliance Requirements
+
+          - **Personal Data Involved:** Ja — e-mailadres (optioneel) en locatie van de melder.
+          - **Authentication Required:** Burger: nee (meldingsnummer + e-maillink). Team/coördinator: ja, via Keycloak (OIDC).
+          - **Failure Preference:** Stop completely — bij falen van de DSP-koppeling wordt de melding NIET geregistreerd.
+          - **Data Retention:** E-mailadres wordt 7 dagen na sluiten van de zaak gepseudonimiseerd.
+
+          ## 9. Process Flow Diagram
+
+          ```mermaid
+          flowchart TD
+              start(["Burger opent portaal"]) --> form["Locatie + type + beschrijving + foto"]
+              form --> submit{"Submit"}
+              submit --> resolve["PDOK adres-resolutie"]
+              resolve --> dup{"Duplicaat binnen 500m + 4h?"}
+              dup -->|"Ja"| link["Koppel aan bestaande zaak"]
+              dup -->|"Nee"| zaak["Registreer zaak in DSP"]
+              link --> num["Toon meldingsnummer"]
+              zaak --> num
+              num --> notify["Notificeer behandelteam"]
+              notify --> finish(["Bevestiging + e-maillink"])
+          ```
+
+          ## 10. Out of Scope
+
+          - Mobiele app (alleen responsive web).
+          - Beheer-UI voor zaaktype-mapping (config-bestand volstaat in v1).
+          - Push-notificaties naar de burger (alleen e-mail + status-pagina).
+
+    - agent: business_analyst
+      tool: builtin:done
+      arguments:
+        summary: "Agent business_analyst: DESIGN_APPROVED for overlast-meldportaal-pdf — 7 FRs, 4 NFRs, 5 BRs, AVG-pseudonimisatie, integration met DSP/PDOK/notificatie/S3."
+
+    # --- Planner re-evaluates after BA → plans architect ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: architect
+            prompt: "Review the functional design and create the technical research + design with an ArchiMate plate"
+          - agent_id: planner
+            prompt: "Re-evaluate after architect completes"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: BA approved design, planned architect to create the technical research + design with ArchiMate plate"
+
+    # --- Architect prep work (mocked — fast replay) ---
+    - agent: architect
+      tool: coding:read_file
+      mock: true
+      mock_result: "[FD loaded — see docs/functional-design.md in workspace]"
+      arguments:
+        path: docs/functional-design.md
+
+    - agent: architect
+      tool: builtin:invoke_skill
+      mock: true
+      mock_result: "[architecture-principles skill loaded]"
+      arguments:
+        skill_name: architecture-principles
+
+    # --- Architect writes the research doc (pre-approved) ---
+    - agent: architect
+      tool: coding:make_design
+      approval:
+        status: approved
+      arguments:
+        path: docs/technical-research.md
+        content: |
+          # Technisch Onderzoek — Burger Overlast-meldportaal
+
+          > **Disclaimer:** Dit document is gegenereerd met behulp van AI. Controleer de inhoud zorgvuldig voor gebruik.
+
+          ## Inleiding
+
+          ### Onderwerp
+          Het Burger Overlast-meldportaal stelt burgers in staat overlast te melden (locatie, type, beschrijving, optionele foto). Elke melding wordt automatisch een zaak in het zaaksysteem (DSP) via de ZGW-API's, het juiste behandelteam wordt genotificeerd, en de burger volgt de status via een meldingsnummer.
+
+          ### Onderzoeksvraag
+          Welke architecturale benadering levert een overlast-meldportaal dat (1) meldingen binnen 60 seconden bij het juiste behandelteam krijgt, (2) burger-statusinformatie binnen 60 seconden update, (3) de DSP-integratie via ZGW-API's correct realiseert, en (4) herbruikbaar is als Druppie-modules voor toekomstige waterschapsprojecten?
+
+          ### Uitgangspunten
+          - **Platform-standaarden:** conform `docs/platform-technical-standards.md` rev 2026-04-20 (React + FastAPI + Postgres, Docker Compose, Druppie SDK).
+          - **NORA/WILMA:** WILMA-referentiecomponenten (Zaakbeheercomponent, Notificatierouteringcomponent) zijn geïdentificeerd.
+          - **PII:** e-mailadres en locatie zijn persoonsgegevens; pseudonimisatie binnen 7 dagen na zaaksluiting is een keiharde eis.
+          - **Stop-completely bij falen:** als de DSP-koppeling faalt wordt de melding NIET geregistreerd (geen best-effort).
+
+          ## Overwogen Benaderingen
+
+          ### Benadering A — Synchrone monolithische applicatie
+          - **Beschrijving:** Eén FastAPI-applicatie met Postgres die bij indienen synchroon PDOK, DSP, object-opslag en de notificatieservice aanroept. Status via polling van de DSP.
+          - **Voordelen:** lage complexiteit, minimale infrastructuur.
+          - **Nadelen:** integraties zitten in projectcode (niet herbruikbaar); één falende upstream blokkeert de hele flow; polling belast de DSP onnodig.
+          - **Geschikt voor:** kleine pilots zonder hergebruik-eis.
+
+          ### Benadering B — Modulair met MCP-modules voor integraties
+          - **Beschrijving:** De kern-applicatie (FastAPI + React + Postgres) is het portaal. Externe koppelingen worden Druppie MCP-modules: `module-dsp-zgw`, `module-notificatie`, `module-pdok-geo`. Status via polling (60s) van de DSP.
+          - **Voordelen:** modules herbruikbaar over waterschapsprojecten; duidelijke verantwoordelijkheden; sluit aan op platform-principes (standaard voor maatwerk, gestandaardiseerde interfaces).
+          - **Nadelen:** meer componenten dan A; extra containers (standaard Druppie-patroon).
+          - **Geschikt voor:** productie-waardige oplossing met hergebruik-ambitie.
+
+          ### Benadering C — Event-driven met message broker
+          - **Beschrijving:** Als B, maar koppelingen asynchroon via een message broker (queue) met retry en dead-letter.
+          - **Voordelen:** veerkrachtig bij tijdelijke uitval; ontkoppeld.
+          - **Nadelen:** hoogste operationele complexiteit; broker is een extra platform-component die nu niet standaard is; botst met de stop-completely-eis (async maakt directe foutterugkoppeling lastig).
+          - **Geschikt voor:** hoog-volume scenario's met losse koppeling.
+
+          ## Conclusie & Aanbeveling
+
+          **Aanbevolen: Benadering B (modulair met MCP-modules + polling).** Deze balanceert herbruikbaarheid, complexiteit en operationele kosten, sluit aan op de platform-principes en realiseert de stop-completely-eis (synchrone DSP-call met directe foutterugkoppeling). Benadering A schiet tekort op herbruikbaarheid; C voegt complexiteit toe die de huidige volumes en de stop-completely-eis niet rechtvaardigen.
+
+    # --- Inject the finished ArchiMate model (architect IS allowed make_design;
+    #     it writes verbatim, Mermaid-validating only — the XML has none) ---
+    - agent: architect
+      tool: coding:make_design
+      approval:
+        status: approved
+      arguments:
+        path: docs/architecture.archimate
+        content: |
+          <?xml version='1.0' encoding='UTF-8'?>
+          <model xmlns="http://www.opengroup.org/xsd/archimate/3.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" identifier="id-9739e69f96004fa996b7d281dfeb51a5" xsi:schemaLocation="http://www.opengroup.org/xsd/archimate/3.0/ http://www.opengroup.org/xsd/archimate/3.1/archimate3_Diagram.xsd">
+            <name xml:lang="en">Project Architecture</name>
+            <propertyDefinitions>
+              <propertyDefinition identifier="propid-6343eae0" type="string">
+                <name>wilma-source</name>
+              </propertyDefinition>
+              <propertyDefinition identifier="propid-bd4fead3" type="string">
+                <name>stereotype</name>
+              </propertyDefinition>
+            </propertyDefinitions>
+            <elements>
+              <element identifier="id-e7779c171938138a86d29c590254be00" xsi:type="ApplicationComponent">
+                <name xml:lang="en">Zaakbeheercomponent</name>
+                <documentation xml:lang="en">Component voor het afhandelen van zaken van alle typen.</documentation>
+                <properties>
+                  <property propertyDefinitionRef="propid-6343eae0">
+                    <value xml:lang="en">true</value>
+                  </property>
+                </properties>
+              </element>
+              <element identifier="id-a3e9717e6059ca136296087f8cc1f339" xsi:type="ApplicationComponent">
+                <name xml:lang="en">Notificatierouteringcomponent</name>
+                <documentation xml:lang="en">Component voor ontvangen van notificaties van bronsystemen en het routeren daarvan naar geabonneerde afnemers.</documentation>
+                <properties>
+                  <property propertyDefinitionRef="propid-6343eae0">
+                    <value xml:lang="en">true</value>
+                  </property>
+                </properties>
+              </element>
+              <element identifier="id-96681c537c793f1270126059256c7402" xsi:type="ApplicationService">
+                <name xml:lang="en">PDOK - Publieke Dienstverlening op Kaart</name>
+                <documentation xml:lang="en">Publieke Dienstverlening Op de Kaart (PDOK) ontsluit digitale geo-informatie van de overheid. Dit ontsluiten gebeurt via een centrale voorziening: het PDOK Loket. De data is beschikbaar als data services of als downloadbare bestanden.</documentation>
+                <properties>
+                  <property propertyDefinitionRef="propid-6343eae0">
+                    <value xml:lang="en">true</value>
+                  </property>
+                </properties>
+              </element>
+              <element identifier="id-cbca84bac0214fbfa4bfb6a3a6d19543" xsi:type="BusinessActor">
+                <name xml:lang="en">Burger</name>
+                <documentation xml:lang="en">De melder van overlast. Heeft geen account; communiceert via meldingsnummer en e-maillink.</documentation>
+              </element>
+              <element identifier="id-1d1d14671ce4404cbe6f456027b7ac61" xsi:type="BusinessRole">
+                <name xml:lang="en">Behandelteam</name>
+                <documentation xml:lang="en">Het team dat de overlast-melding inhoudelijk behandelt. Authenticeert via waterschap-SSO (Keycloak). Ziet alleen zaken van het eigen zaaktype.</documentation>
+              </element>
+              <element identifier="id-74ebff51737147c6b4d8ca4e0ebaec15" xsi:type="BusinessRole">
+                <name xml:lang="en">Zaakcoördinator</name>
+                <documentation xml:lang="en">De zaakcoördinator die meldingen monitort, filtert en rapporteert. Authenticeert via waterschap-SSO (Keycloak). Heeft inzage in alle meldingen binnen het waterschap.</documentation>
+              </element>
+              <element identifier="id-912acaf271294e3fa965de8fb1144ad8" xsi:type="BusinessProcess">
+                <name xml:lang="en">Overlast melden</name>
+                <documentation xml:lang="en">Het proces van het indienen van een overlast-melding door een burger, inclusief locatie, type, beschrijving en optioneel foto en e-mailadres.</documentation>
+              </element>
+              <element identifier="id-47f55957db464b97a6aed7ed0490b173" xsi:type="BusinessProcess">
+                <name xml:lang="en">Meldingsstatus volgen</name>
+                <documentation xml:lang="en">Het proces van het volgen van de status van een ingediende overlast-melding via het meldingsnummer.</documentation>
+              </element>
+              <element identifier="id-c30979c81b64444a9f568a39df5a3c35" xsi:type="BusinessProcess">
+                <name xml:lang="en">Meldingen rapporteren</name>
+                <documentation xml:lang="en">Het proces van het monitoren, filteren en rapporteren van overlast-meldingen voor bestuursrapportage.</documentation>
+              </element>
+              <element identifier="id-704e4abd5b434af7b54c69e7393a864e" xsi:type="BusinessObject">
+                <name xml:lang="en">Overlastmelding</name>
+                <documentation xml:lang="en">Een overlast-melding zoals ingediend door een burger: locatie, type, beschrijving, optionele foto, optioneel e-mailadres en meldingsnummer.</documentation>
+              </element>
+              <element identifier="id-51c6b9e9b2704b32b921931efb686b61" xsi:type="ApplicationComponent">
+                <name xml:lang="en">Overlast-meldportaal</name>
+                <documentation xml:lang="en">Het Burger Overlast-meldportaal: een webapplicatie voor het indienen, volgen en rapporteren van overlast-meldingen. Gebouwd als Druppie-project met React frontend en FastAPI backend.</documentation>
+                <properties>
+                  <property propertyDefinitionRef="propid-bd4fead3">
+                    <value xml:lang="en">Applicatie</value>
+                  </property>
+                </properties>
+              </element>
+              <element identifier="id-c2f1972b46c643128810ec4d50794b95" xsi:type="ApplicationComponent">
+                <name xml:lang="en">module-dsp-zgw</name>
+                <documentation xml:lang="en">Druppie MCP-module voor koppeling met het zaaksysteem (DSP) via de ZGW API's. Biedt tools voor zaakregistratie, status-ophaling en document-koppeling.</documentation>
+                <properties>
+                  <property propertyDefinitionRef="propid-bd4fead3">
+                    <value xml:lang="en">Applicatie</value>
+                  </property>
+                </properties>
+              </element>
+              <element identifier="id-33b9639463b94a8eb3353553854cb2ae" xsi:type="ApplicationComponent">
+                <name xml:lang="en">module-notificatie</name>
+                <documentation xml:lang="en">Druppie MCP-module voor het versturen van notificaties (e-mail en push) via de Notificatieservice.</documentation>
+                <properties>
+                  <property propertyDefinitionRef="propid-bd4fead3">
+                    <value xml:lang="en">Applicatie</value>
+                  </property>
+                </properties>
+              </element>
+              <element identifier="id-f101727d982244c8b747cb638f58b486" xsi:type="ApplicationComponent">
+                <name xml:lang="en">module-pdok-geo</name>
+                <documentation xml:lang="en">Druppie MCP-module voor geolocatie-functionaliteit via PDOK (BAG/BGT). Biedt reverse/forward geocoding.</documentation>
+                <properties>
+                  <property propertyDefinitionRef="propid-bd4fead3">
+                    <value xml:lang="en">Applicatie</value>
+                  </property>
+                </properties>
+              </element>
+              <element identifier="id-55df85f438854f559a125e05792a0475" xsi:type="DataObject">
+                <name xml:lang="en">Meldportaal Data</name>
+                <documentation xml:lang="en">De data-objecten van het overlast-meldportaal: melding, statushistorie, zaaktype-mapping, team-routing, configuratie. Opgeslagen in Postgres.</documentation>
+              </element>
+              <element identifier="id-45c30976b62e4c67930e62b073c06c09" xsi:type="TechnologyService">
+                <name xml:lang="en">Object-opslag (S3)</name>
+                <documentation xml:lang="en">S3-compatibele objectopslag voor het opslaan van foto's bij overlast-meldingen.</documentation>
+              </element>
+              <element identifier="id-318ea20dc92f4e46be3cbc0d92e4ed75" xsi:type="SystemSoftware">
+                <name xml:lang="en">PostgreSQL</name>
+                <documentation xml:lang="en">PostgreSQL database voor het overlast-meldportaal. Bevat meldingen, statushistorie, configuratie en zaaktype-mapping.</documentation>
+              </element>
+              <element identifier="id-6acba7100f614f999f73104ee1708b5a" xsi:type="Grouping">
+                <name xml:lang="en">Beveiligingsdomein - niet-vertrouwd</name>
+                <documentation xml:lang="en">Het niet-vertrouwd domein: het publieke deel van het overlast-meldportaal dat bereikbaar is zonder authenticatie (burger-interface, status-pagina).</documentation>
+                <properties>
+                  <property propertyDefinitionRef="propid-bd4fead3">
+                    <value xml:lang="en">Beveiligingsdomein</value>
+                  </property>
+                </properties>
+              </element>
+              <element identifier="id-f86b8f8546484e71aeb07ce9c5d6c9a4" xsi:type="Grouping">
+                <name xml:lang="en">Beveiligingsdomein - vertrouwd</name>
+                <documentation xml:lang="en">Het vertrouwd domein: het interne deel van het overlast-meldportaal dat bereikbaar is alleen met waterschap-SSO authenticatie (dashboard, behandelteam-interface).</documentation>
+                <properties>
+                  <property propertyDefinitionRef="propid-bd4fead3">
+                    <value xml:lang="en">Beveiligingsdomein</value>
+                  </property>
+                </properties>
+              </element>
+              <element identifier="id-cad707283bd8430ebc19ceba99dbe018" xsi:type="DataObject">
+                <name xml:lang="en">Meldingsnummer</name>
+                <documentation xml:lang="en">Schaalbare, niet-guessable meldingsnummer ter identificatie van een melding door de burger.</documentation>
+              </element>
+            </elements>
+            <relationships>
+              <relationship identifier="id-829437efaca2466d9d7b89c3dd26556c" source="id-cbca84bac0214fbfa4bfb6a3a6d19543" target="id-912acaf271294e3fa965de8fb1144ad8" xsi:type="Assignment">
+                <name xml:lang="en">meldt overlast</name>
+              </relationship>
+              <relationship identifier="id-8a05c54c72d943a98afd4855c2b62610" source="id-cbca84bac0214fbfa4bfb6a3a6d19543" target="id-47f55957db464b97a6aed7ed0490b173" xsi:type="Assignment">
+                <name xml:lang="en">volgt status</name>
+              </relationship>
+              <relationship identifier="id-723ea6906dff47619286ca07cabf68a5" source="id-74ebff51737147c6b4d8ca4e0ebaec15" target="id-c30979c81b64444a9f568a39df5a3c35" xsi:type="Assignment">
+                <name xml:lang="en">rappporteert</name>
+              </relationship>
+              <relationship identifier="id-7b626c8ae5d446e59e02650a29d5ce95" source="id-51c6b9e9b2704b32b921931efb686b61" target="id-912acaf271294e3fa965de8fb1144ad8" xsi:type="Serving">
+                <name xml:lang="en">ondersteunt</name>
+              </relationship>
+              <relationship identifier="id-2fee246d8e2546e09070ac3a1a6c1261" source="id-51c6b9e9b2704b32b921931efb686b61" target="id-47f55957db464b97a6aed7ed0490b173" xsi:type="Serving">
+                <name xml:lang="en">ondersteunt</name>
+              </relationship>
+              <relationship identifier="id-38fab6615e4242abb80cde8a74c5105d" source="id-51c6b9e9b2704b32b921931efb686b61" target="id-c30979c81b64444a9f568a39df5a3c35" xsi:type="Serving">
+                <name xml:lang="en">ondersteunt</name>
+              </relationship>
+              <relationship identifier="id-a96ea33a1f314fe6a64a5115cd74f21e" source="id-c2f1972b46c643128810ec4d50794b95" target="id-51c6b9e9b2704b32b921931efb686b61" xsi:type="Serving">
+                <name xml:lang="en">zaakregistratie en status</name>
+              </relationship>
+              <relationship identifier="id-28da4ae1bb4b40ffa6066c01e8ea078c" source="id-33b9639463b94a8eb3353553854cb2ae" target="id-51c6b9e9b2704b32b921931efb686b61" xsi:type="Serving">
+                <name xml:lang="en">notificaties</name>
+              </relationship>
+              <relationship identifier="id-7e52165d1156403fb2ea3dcf8a669f43" source="id-f101727d982244c8b747cb638f58b486" target="id-51c6b9e9b2704b32b921931efb686b61" xsi:type="Serving">
+                <name xml:lang="en">adres-resolutie</name>
+              </relationship>
+              <relationship identifier="id-5ada052b8b7d439aa4caf49920ab8760" source="id-e7779c171938138a86d29c590254be00" target="id-c2f1972b46c643128810ec4d50794b95" xsi:type="Serving">
+                <name xml:lang="en">ZGW API</name>
+              </relationship>
+              <relationship identifier="id-ddd67acb69044fa3a5694964708ba949" source="id-a3e9717e6059ca136296087f8cc1f339" target="id-33b9639463b94a8eb3353553854cb2ae" xsi:type="Serving">
+                <name xml:lang="en">notificatie-routering</name>
+              </relationship>
+              <relationship identifier="id-76125b2ac6a44ac49f874664d1513184" source="id-96681c537c793f1270126059256c7402" target="id-f101727d982244c8b747cb638f58b486" xsi:type="Serving">
+                <name xml:lang="en">geo-informatie</name>
+              </relationship>
+              <relationship identifier="id-fed38820a637441eb04b4ee26f5bec26" source="id-51c6b9e9b2704b32b921931efb686b61" target="id-55df85f438854f559a125e05792a0475" xsi:type="Access" accessType="ReadWrite">
+                <name xml:lang="en">leest/schrijft meldingsdata</name>
+              </relationship>
+              <relationship identifier="id-ec17e080c1a741c3801bc2c2965070d1" source="id-318ea20dc92f4e46be3cbc0d92e4ed75" target="id-55df85f438854f559a125e05792a0475" xsi:type="Serving">
+                <name xml:lang="en">host data</name>
+              </relationship>
+              <relationship identifier="id-5acc8eef5e994093bc3bdaffc7fdc746" source="id-912acaf271294e3fa965de8fb1144ad8" target="id-704e4abd5b434af7b54c69e7393a864e" xsi:type="Access" accessType="Write">
+                <name xml:lang="en">produceert melding</name>
+              </relationship>
+              <relationship identifier="id-25872e59cbac4029b4b658858622b9da" source="id-1d1d14671ce4404cbe6f456027b7ac61" target="id-e7779c171938138a86d29c590254be00" xsi:type="Assignment">
+                <name xml:lang="en">behandelt zaken van</name>
+              </relationship>
+              <relationship identifier="id-6ae93492744643c8a6fc57710014c798" source="id-51c6b9e9b2704b32b921931efb686b61" target="id-1d1d14671ce4404cbe6f456027b7ac61" xsi:type="Serving">
+                <name xml:lang="en">ondersteunt via SSO</name>
+              </relationship>
+              <relationship identifier="id-048b0eb687b1445dbcf7dbc412a7e9f3" source="id-51c6b9e9b2704b32b921931efb686b61" target="id-74ebff51737147c6b4d8ca4e0ebaec15" xsi:type="Serving">
+                <name xml:lang="en">ondersteunt via SSO</name>
+              </relationship>
+              <relationship identifier="id-cfbf3526b3584d8293ddc79ce6c752af" source="id-45c30976b62e4c67930e62b073c06c09" target="id-51c6b9e9b2704b32b921931efb686b61" xsi:type="Serving">
+                <name xml:lang="en">foto-opslag</name>
+              </relationship>
+            </relationships>
+            <views>
+              <diagrams>
+                <view identifier="id-22c5ae408afc4068aa82d09d65c58df2" xsi:type="Diagram">
+                  <name xml:lang="en">Overlast-meldportaal - Application Cooperation</name>
+                  <documentation xml:lang="en">Application Cooperation view: toont de samenwerking tussen het Overlast-meldportaal en de externe services (DSP, Notificatieservice, PDOK) via Druppie-modules, inclusief technologische infrastructuur (Postgres, S3).</documentation>
+                  <node identifier="id-59c9b14b7f1c48d29fa19518f90fd033" elementRef="id-96681c537c793f1270126059256c7402" xsi:type="Element" x="1514" y="455" w="304" h="55"></node>
+                  <node identifier="id-41f0ea5ecc624e158d281596f9bb3abe" elementRef="id-6acba7100f614f999f73104ee1708b5a" xsi:type="Element" x="1481" y="310" w="269" h="55"></node>
+                  <node identifier="id-33e8578b2f264334863eaf17df633f5b" elementRef="id-f86b8f8546484e71aeb07ce9c5d6c9a4" xsi:type="Element" x="1187" y="310" w="234" h="55"></node>
+                  <node identifier="id-56b58bdd9572416594195e0bd95f2fea" elementRef="id-a3e9717e6059ca136296087f8cc1f339" xsi:type="Element" x="1227" y="455" w="227" h="55"></node>
+                  <node identifier="id-9d37ea3bc30b4d1abe2cbd4d500f542f" elementRef="id-47f55957db464b97a6aed7ed0490b173" xsi:type="Element" x="421" y="165" w="171" h="55"></node>
+                  <node identifier="id-878dfca692354778959d63702ce33632" elementRef="id-c30979c81b64444a9f568a39df5a3c35" xsi:type="Element" x="852" y="165" w="171" h="55"></node>
+                  <node identifier="id-a4e968c086a24efe94ff3019394b2e7a" elementRef="id-51c6b9e9b2704b32b921931efb686b61" xsi:type="Element" x="910" y="745" w="164" h="55"></node>
+                  <node identifier="id-f81eb21cdce344709d8218a89a523d2d" elementRef="id-e7779c171938138a86d29c590254be00" xsi:type="Element" x="1010" y="455" w="157" h="55"></node>
+                  <node identifier="id-01439d89a3474a4681d23570e9bfea1a" elementRef="id-33b9639463b94a8eb3353553854cb2ae" xsi:type="Element" x="1265" y="600" w="150" h="55"></node>
+                  <node identifier="id-d1ce338f5e88456dbe24990033583b37" elementRef="id-45c30976b62e4c67930e62b073c06c09" xsi:type="Element" x="815" y="1035" w="150" h="55"></node>
+                  <node identifier="id-1fd862bbd5014d1f963737d9658aa977" elementRef="id-cbca84bac0214fbfa4bfb6a3a6d19543" xsi:type="Element" x="220" y="165" w="140" h="55"></node>
+                  <node identifier="id-dc8fe44b60b9452f8619ab2106cd290d" elementRef="id-c2f1972b46c643128810ec4d50794b95" xsi:type="Element" x="1018" y="600" w="140" h="55"></node>
+                  <node identifier="id-063cf90c4efc4190bfcbcb4ea1458004" elementRef="id-f101727d982244c8b747cb638f58b486" xsi:type="Element" x="1596" y="600" w="140" h="55"></node>
+                  <node identifier="id-a385266d2ff94cda948e36d8ea226f89" elementRef="id-55df85f438854f559a125e05792a0475" xsi:type="Element" x="1025" y="890" w="140" h="55"></node>
+                  <node identifier="id-56bd3f18482a4c2bb98b3bbb49c16917" elementRef="id-318ea20dc92f4e46be3cbc0d92e4ed75" xsi:type="Element" x="1025" y="1035" w="140" h="55"></node>
+                  <node identifier="id-a7f02f2f3dc444bcbc93e2d135bd5830" elementRef="id-1d1d14671ce4404cbe6f456027b7ac61" xsi:type="Element" x="1398" y="165" w="140" h="55"></node>
+                  <node identifier="id-0e16948069ec4cf6bc22a35a2dc5e25d" elementRef="id-74ebff51737147c6b4d8ca4e0ebaec15" xsi:type="Element" x="20" y="165" w="140" h="55"></node>
+                  <node identifier="id-6c4a3320520b4cc8b45163a3552c67e2" elementRef="id-912acaf271294e3fa965de8fb1144ad8" xsi:type="Element" x="486" y="20" w="140" h="55"></node>
+                  <node identifier="id-e4a915173c324ed4866e2f834115c2eb" elementRef="id-704e4abd5b434af7b54c69e7393a864e" xsi:type="Element" x="652" y="165" w="140" h="55"></node>
+                  <connection identifier="id-f460882b5f924418804771184ef69d5d" relationshipRef="id-7b626c8ae5d446e59e02650a29d5ce95" xsi:type="Relationship" source="id-a4e968c086a24efe94ff3019394b2e7a" target="id-6c4a3320520b4cc8b45163a3552c67e2">
+                    <bendpoint x="947" y="745"></bendpoint>
+                    <bendpoint x="947" y="685"></bendpoint>
+                    <bendpoint x="390" y="685"></bendpoint>
+                    <bendpoint x="390" y="85"></bendpoint>
+                    <bendpoint x="533" y="85"></bendpoint>
+                    <bendpoint x="533" y="75"></bendpoint>
+                  </connection>
+                  <connection identifier="id-6e934ca8e482479fb9f4e48682aa7a6f" relationshipRef="id-2fee246d8e2546e09070ac3a1a6c1261" xsi:type="Relationship" source="id-a4e968c086a24efe94ff3019394b2e7a" target="id-9d37ea3bc30b4d1abe2cbd4d500f542f">
+                    <bendpoint x="965" y="745"></bendpoint>
+                    <bendpoint x="965" y="675"></bendpoint>
+                    <bendpoint x="507" y="675"></bendpoint>
+                    <bendpoint x="507" y="220"></bendpoint>
+                  </connection>
+                  <connection identifier="id-62927e77a2f9480c8ead7eaaa8f88198" relationshipRef="id-38fab6615e4242abb80cde8a74c5105d" xsi:type="Relationship" source="id-a4e968c086a24efe94ff3019394b2e7a" target="id-878dfca692354778959d63702ce33632">
+                    <bendpoint x="983" y="745"></bendpoint>
+                    <bendpoint x="983" y="665"></bendpoint>
+                    <bendpoint x="938" y="665"></bendpoint>
+                    <bendpoint x="938" y="220"></bendpoint>
+                  </connection>
+                  <connection identifier="id-25a08ccc3ded488bba615ef990fa71b3" relationshipRef="id-a96ea33a1f314fe6a64a5115cd74f21e" xsi:type="Relationship" source="id-dc8fe44b60b9452f8619ab2106cd290d" target="id-a4e968c086a24efe94ff3019394b2e7a">
+                    <bendpoint x="1088" y="655"></bendpoint>
+                    <bendpoint x="1088" y="665"></bendpoint>
+                    <bendpoint x="1001" y="665"></bendpoint>
+                    <bendpoint x="1001" y="745"></bendpoint>
+                  </connection>
+                  <connection identifier="id-cdc3fe07365041d79f1e509448444ede" relationshipRef="id-28da4ae1bb4b40ffa6066c01e8ea078c" xsi:type="Relationship" source="id-01439d89a3474a4681d23570e9bfea1a" target="id-a4e968c086a24efe94ff3019394b2e7a">
+                    <bendpoint x="1340" y="655"></bendpoint>
+                    <bendpoint x="1340" y="675"></bendpoint>
+                    <bendpoint x="1020" y="675"></bendpoint>
+                    <bendpoint x="1020" y="745"></bendpoint>
+                  </connection>
+                  <connection identifier="id-074afc60b3c348578a8357ef05ded1ba" relationshipRef="id-7e52165d1156403fb2ea3dcf8a669f43" xsi:type="Relationship" source="id-063cf90c4efc4190bfcbcb4ea1458004" target="id-a4e968c086a24efe94ff3019394b2e7a">
+                    <bendpoint x="1666" y="655"></bendpoint>
+                    <bendpoint x="1666" y="685"></bendpoint>
+                    <bendpoint x="1038" y="685"></bendpoint>
+                    <bendpoint x="1038" y="745"></bendpoint>
+                  </connection>
+                  <connection identifier="id-fed3e9fc7fd74a76b62057e88b4954d4" relationshipRef="id-5ada052b8b7d439aa4caf49920ab8760" xsi:type="Relationship" source="id-f81eb21cdce344709d8218a89a523d2d" target="id-dc8fe44b60b9452f8619ab2106cd290d">
+                    <bendpoint x="1088" y="510"></bendpoint>
+                    <bendpoint x="1088" y="600"></bendpoint>
+                  </connection>
+                  <connection identifier="id-54443f3396884fbbadde6949cf7770d3" relationshipRef="id-ddd67acb69044fa3a5694964708ba949" xsi:type="Relationship" source="id-56b58bdd9572416594195e0bd95f2fea" target="id-01439d89a3474a4681d23570e9bfea1a">
+                    <bendpoint x="1340" y="510"></bendpoint>
+                    <bendpoint x="1340" y="600"></bendpoint>
+                  </connection>
+                  <connection identifier="id-a5b583d7bb724e1594c650816212be86" relationshipRef="id-76125b2ac6a44ac49f874664d1513184" xsi:type="Relationship" source="id-59c9b14b7f1c48d29fa19518f90fd033" target="id-063cf90c4efc4190bfcbcb4ea1458004">
+                    <bendpoint x="1666" y="510"></bendpoint>
+                    <bendpoint x="1666" y="600"></bendpoint>
+                  </connection>
+                  <connection identifier="id-a711d017831c4103a393e0912b22bce0" relationshipRef="id-fed38820a637441eb04b4ee26f5bec26" xsi:type="Relationship" source="id-a4e968c086a24efe94ff3019394b2e7a" target="id-a385266d2ff94cda948e36d8ea226f89">
+                    <bendpoint x="1020" y="800"></bendpoint>
+                    <bendpoint x="1020" y="810"></bendpoint>
+                    <bendpoint x="1095" y="810"></bendpoint>
+                    <bendpoint x="1095" y="890"></bendpoint>
+                  </connection>
+                  <connection identifier="id-600c3c483faf4924b9ab47c789d338ab" relationshipRef="id-ec17e080c1a741c3801bc2c2965070d1" xsi:type="Relationship" source="id-56bd3f18482a4c2bb98b3bbb49c16917" target="id-a385266d2ff94cda948e36d8ea226f89">
+                    <bendpoint x="1095" y="1035"></bendpoint>
+                    <bendpoint x="1095" y="945"></bendpoint>
+                  </connection>
+                  <connection identifier="id-86edd547088a4d749aa540c06cbfcac3" relationshipRef="id-5acc8eef5e994093bc3bdaffc7fdc746" xsi:type="Relationship" source="id-6c4a3320520b4cc8b45163a3552c67e2" target="id-e4a915173c324ed4866e2f834115c2eb">
+                    <bendpoint x="579" y="75"></bendpoint>
+                    <bendpoint x="579" y="85"></bendpoint>
+                    <bendpoint x="722" y="85"></bendpoint>
+                    <bendpoint x="722" y="165"></bendpoint>
+                  </connection>
+                  <connection identifier="id-207b050eed8f460d99d5dad5cc9a96fd" relationshipRef="id-6ae93492744643c8a6fc57710014c798" xsi:type="Relationship" source="id-a4e968c086a24efe94ff3019394b2e7a" target="id-a7f02f2f3dc444bcbc93e2d135bd5830">
+                    <bendpoint x="1056" y="745"></bendpoint>
+                    <bendpoint x="1056" y="695"></bendpoint>
+                    <bendpoint x="1848" y="695"></bendpoint>
+                    <bendpoint x="1848" y="230"></bendpoint>
+                    <bendpoint x="1491" y="230"></bendpoint>
+                    <bendpoint x="1491" y="220"></bendpoint>
+                  </connection>
+                  <connection identifier="id-9bf04b9ce4aa4a4faea9677ab0cac311" relationshipRef="id-048b0eb687b1445dbcf7dbc412a7e9f3" xsi:type="Relationship" source="id-a4e968c086a24efe94ff3019394b2e7a" target="id-0e16948069ec4cf6bc22a35a2dc5e25d">
+                    <bendpoint x="928" y="745"></bendpoint>
+                    <bendpoint x="928" y="695"></bendpoint>
+                    <bendpoint x="90" y="695"></bendpoint>
+                    <bendpoint x="90" y="220"></bendpoint>
+                  </connection>
+                  <connection identifier="id-562c2c274e7543f2b00758d33cbdaeb7" relationshipRef="id-25872e59cbac4029b4b658858622b9da" xsi:type="Relationship" source="id-a7f02f2f3dc444bcbc93e2d135bd5830" target="id-f81eb21cdce344709d8218a89a523d2d">
+                    <bendpoint x="1445" y="220"></bendpoint>
+                    <bendpoint x="1445" y="230"></bendpoint>
+                    <bendpoint x="1088" y="230"></bendpoint>
+                    <bendpoint x="1088" y="455"></bendpoint>
+                  </connection>
+                  <connection identifier="id-b285be44b9ef4269b870a20b03c77cf2" relationshipRef="id-cfbf3526b3584d8293ddc79ce6c752af" xsi:type="Relationship" source="id-d1ce338f5e88456dbe24990033583b37" target="id-a4e968c086a24efe94ff3019394b2e7a">
+                    <bendpoint x="890" y="1035"></bendpoint>
+                    <bendpoint x="890" y="810"></bendpoint>
+                    <bendpoint x="965" y="810"></bendpoint>
+                    <bendpoint x="965" y="800"></bendpoint>
+                  </connection>
+                </view>
+              </diagrams>
+            </views>
+          </model>
+
+    # --- Architect writes the TD referencing the plate + mermaid — approval gate PENDING ---
+    - agent: architect
+      tool: coding:make_design
+      approval:
+        status: pending
+      arguments:
+        path: docs/technical-design.md
+        content: |
+          # Technical Design — Burger Overlast-meldportaal
+
+          > Platform standards: conforms to [docs/platform-technical-standards.md](./platform-technical-standards.md) rev 2026-04-20.
+
+          > **Disclaimer:** Dit document is gegenereerd met behulp van AI. Controleer de inhoud zorgvuldig voor gebruik. / This document was generated with the help of AI. Please review the content carefully before use.
+
+          ## Introduction
+
+          ### Subject
+          Burger Overlast-meldportaal: een digitaal portaal waarmee burgers overlast melden. Elke melding wordt automatisch een zaak in het zaaksysteem (DSP) via de ZGW-API, het verantwoordelijke behandelteam wordt genotificeerd, en de burger volgt de status via een meldingsnummer.
+
+          ### Problem Summary
+          Meldingen komen nu versnipperd binnen (telefoon, e-mail, social media), raken zoek of komen vertraagd bij het juiste team. Burgers krijgen geen statusterugkoppeling en het waterschap kan niet rapporteren op trends.
+
+          ## Solution
+
+          ### Applied Principles (per NORA layer)
+          - **Organization:** elke melding wordt een zaak in het bestaande DSP (zaakgericht werken).
+          - **Information:** PDOK is de authentieke bron voor adresgegevens; het DSP is de authentieke bron voor zaakstatus.
+          - **Application:** een project-applicatie (React + FastAPI) consumeert drie Druppie-modules (DSP/ZGW, notificatie, PDOK-geo). Foto-opslag via S3.
+          - **Security & Privacy:** burger zonder account (niet-guessable meldingsnummer); behandelteam/coördinator via Keycloak-SSO; PII gepseudonimiseerd; fail-stop bij DSP-fout.
+
+          ### Requirements
+
+          | ID | Source | Requirement | Verification |
+          |----|--------|-------------|--------------|
+          | FR-01 | BA | Burger dient melding in met locatie, type, beschrijving, optionele foto. | Functional test |
+          | FR-04 | BA | Elke melding wordt automatisch als zaak in het DSP geregistreerd. | Integration test |
+          | FR-05 | BA | Behandelteam ontvangt binnen 60s een notificatie. | Integration test |
+          | FR-06 | BA | Statusupdates uit het DSP zijn binnen 60s zichtbaar voor de burger. | Integration test |
+          | TR-02 | AR | Duplicaatdetectie binnen 500m + 4h + zelfde type via spatial index. | Unit test |
+          | TR-03 | AR | E-mail gepseudonimiseerd (SHA-256) 7 dagen na zaaksluiting. | Integration test |
+
+          ### Architectural Solution
+          De project-applicatie bevat de domeinlogica (duplicaatdetectie, zaaktype-mapping, team-routing, pseudonimisering, foto-herschaling) en orkestreert de drie modules. Achtergrond-taken: DSP-status-poller (60s) en pseudonimiserings-taak (dagelijks).
+
+          #### Visualisatie — Melding Indienen Flow
+
+          ```mermaid
+          sequenceDiagram
+              actor Burger
+              participant Portaal as Overlast-meldportaal
+              participant PDOK as PDOK
+              participant DSP as Zaaksysteem DSP
+              participant Notif as Notificatieservice
+              Burger->>Portaal: Dien melding in
+              Portaal->>PDOK: Resolve adres
+              PDOK-->>Portaal: Adresgegevens
+              Portaal->>DSP: Registreer zaak via ZGW
+              DSP-->>Portaal: Zaaknummer
+              Portaal->>Notif: Notificeer behandelteam
+              Notif-->>Portaal: Bevestiging
+              Portaal-->>Burger: Meldingsnummer en e-maillink
+          ```
+
+          #### Visualisatie — Zaakstatus Lifecycle
+
+          ```mermaid
+          stateDiagram-v2
+              [*] --> Ingediend
+              Ingediend --> InBehandeling: opgepakt door team
+              InBehandeling --> Afgehandeld: opgelost
+              InBehandeling --> Afgewezen: geen overlast
+              Afgehandeld --> [*]
+              Afgewezen --> [*]
+          ```
+
+          #### Visualisatie — Application Cooperation (ArchiMate)
+
+          ```archimate
+          view-id: id-22c5ae408afc4068aa82d09d65c58df2
+          file: docs/architecture.archimate
+          ```
+
+          **Legenda:** business (geel) — Burger, Behandelteam, Zaakcoördinator + bedrijfsprocessen; application (blauw) — Overlast-meldportaal + de drie modules + WILMA-referenties; technology (groen) — PostgreSQL, Object-opslag S3.
+
+          ### Integration Points
+
+          | Extern systeem | Categorie | Beslissing | Module |
+          |----------------|-----------|------------|--------|
+          | Zaaksysteem (DSP) | organizational | NEW | module-dsp-zgw |
+          | Notificatieservice | organizational | NEW | module-notificatie |
+          | PDOK BAG/BGT | other | NEW | module-pdok-geo |
+          | Object-opslag (S3) | other | PROJECT-SPECIFIC | n.v.t. |
+          | Waterschap-SSO (Keycloak) | organizational | REUSE | platform auth |
+
+          ### Security & Compliance
+
+          | Aspect | Maatregel |
+          |--------|-----------|
+          | Data Protection | Fail-stop bij DSP-fout — melding niet geregistreerd als DSP onbeschikbaar is. |
+          | PII handling | E-mail na 7 dagen zaaksluiting vervangen door SHA-256 hash. |
+          | Access Control | Burger: geen auth (niet-guessable meldingsnummer); team/coördinator: SSO + rol-filter. |
+          | Compliance | AVG (taak algemeen belang); BIO-baseline voor publieke webapps. |
+
+  verify:
+    - gitea_repo_exists: true


### PR DESCRIPTION
## Summary

- Mermaid diagrams in functional design PDFs were either not rendering at all or rendering without text labels
- **Root cause**: browsers skip `<foreignObject>` content when rendering SVG as `<img>` (security sandbox). Mermaid puts all text labels inside `<foreignObject>` by default. The old code also used `btoa()` encoding which broke on Dutch/Unicode content, and didn't await image decoding before html2canvas captured the container.
- **Fix**: after mermaid renders the SVG, a regex-based pass replaces each `<foreignObject>` with a native SVG `<text>` element — extracting the label text, font size, and bounding box. Text is word-wrapped into `<tspan>` lines to stay within node bounds. SVG is loaded via same-origin Blob URL instead of base64 to avoid encoding issues, and `img.decode()` guarantees pixels are ready before capture.

## Test plan

- [x] Open a chat session that has a functional design with a mermaid process flow diagram
- [x] Click the PDF download button on the approval card / file preview
- [x] Verify the diagram renders with shapes **and** text labels inside the nodes
- [x] Verify longer labels wrap within their boxes (no text overflow)
- [x] Verify the interactive mermaid diagram in the chat still works normally after downloading


🤖 Generated with [Claude Code](https://claude.com/claude-code)