### PR TITLE
feat(tests): add cancel button for running test batches

### DIFF
--- a/druppie/api/routes/evaluations_tests.py
+++ b/druppie/api/routes/evaluations_tests.py
@@ -23,6 +23,7 @@ logger = structlog.get_logger()
 router = APIRouter()
 
 _running_lock = threading.Lock()
+_cancel_events: dict[str, threading.Event] = {}
 
 
 class RunTestsRequest(BaseModel):
@@ -130,6 +131,9 @@ async def run_tests(
     finally:
         db_check.close()
 
+    cancel_event = threading.Event()
+    _cancel_events[run_id] = cancel_event
+
     test_name = body.test_name
     test_names = body.test_names
     tag = body.tag
@@ -180,6 +184,8 @@ async def run_tests(
             logger.error("tests_run_fatal", run_id=run_id, error=str(e), exc_info=True)
             _update_batch(status="error", current_test=None,
                           message=str(e), completed_at=datetime.now(timezone.utc))
+        finally:
+            _cancel_events.pop(run_id, None)
 
     def _run_inner(run_id, test_name, test_names, tag, run_all,
                    execute, judge, input_values):
@@ -279,6 +285,8 @@ async def run_tests(
             )
 
         def _run_single_test(name, test_def):
+            if cancel_event.is_set():
+                return []
             with _running_lock:
                 _add_db = SessionLocal()
                 try:
@@ -326,6 +334,8 @@ async def run_tests(
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = {}
             for name, test_def in tests_to_run:
+                if cancel_event.is_set():
+                    break
                 future = pool.submit(_run_single_test, name, test_def)
                 futures[future] = name
 
@@ -345,13 +355,18 @@ async def run_tests(
                 finally:
                     completed_count += 1
                     _sync_running_tests()
+                if cancel_event.is_set():
+                    for f in futures:
+                        f.cancel()
+                    break
 
-        passed = sum(1 for r in all_results if r.status == "passed")
-        _update_batch(
-            status="completed", current_test=None,
-            message=f"{passed}/{len(all_results)} passed",
-            completed_at=datetime.now(timezone.utc),
-        )
+        if not cancel_event.is_set():
+            passed = sum(1 for r in all_results if r.status == "passed")
+            _update_batch(
+                status="completed", current_test=None,
+                message=f"{passed}/{len(all_results)} passed",
+                completed_at=datetime.now(timezone.utc),
+            )
         _clr_db = SessionLocal()
         try:
             EvaluationRepository(_clr_db).clear_running_tests(run_id)
@@ -431,6 +446,40 @@ async def get_active_run(user: dict = Depends(require_admin)):
         }
     finally:
         db.close()
+
+
+@router.post("/evaluations/cancel-run/{run_id}")
+async def cancel_run(
+    run_id: str,
+    user: dict = Depends(require_admin),
+):
+    """Cancel a running test batch."""
+    from druppie.db.database import SessionLocal
+    from druppie.repositories.evaluation_repository import EvaluationRepository
+
+    event = _cancel_events.get(run_id)
+    if not event:
+        return JSONResponse(
+            status_code=404,
+            content={"error": "No active run found or run already finished"},
+        )
+    event.set()
+
+    db = SessionLocal()
+    try:
+        repo = EvaluationRepository(db)
+        repo.update_batch_run(
+            run_id, status="cancelled", current_test=None,
+            message="Cancelled by user",
+            completed_at=datetime.now(timezone.utc),
+        )
+        repo.clear_running_tests(run_id)
+        db.commit()
+    finally:
+        db.close()
+
+    logger.info("test_run_cancelled", run_id=run_id, user_id=user.get("sub"))
+    return {"success": True, "message": "Run cancelled"}
 
 
 @router.get("/evaluations/test-runs")

--- a/frontend/src/pages/Evaluations.jsx
+++ b/frontend/src/pages/Evaluations.jsx
@@ -24,6 +24,7 @@ import {
   getActiveRun,
   deleteTestUsers,
   runTests,
+  cancelTestRun,
 } from '../services/api'
 
 import { TestSelectorModal, RunProgress, UnitTestsSection } from './evaluations/TestRunner'
@@ -61,6 +62,7 @@ export default function Evaluations() {
   const [judgeEnabled, setJudgeEnabled] = useState(true)
   const [deletingUsers, setDeletingUsers] = useState(false)
   const [runProgress, setRunProgress] = useState(null)
+  const [currentRunId, setCurrentRunId] = useState(null)
 
   // Effective selected count for display (respects both the mode filter and the
   // search query when selectAll, so the count matches what actually runs)
@@ -100,6 +102,7 @@ export default function Evaluations() {
             total_tests: activeRun.total_tests || 0,
           })
           pollRunStatus(activeRun.run_id)
+          setCurrentRunId(activeRun.run_id)
         }
       } catch (err) {
         setTestsError(err.message)
@@ -109,6 +112,19 @@ export default function Evaluations() {
     }
     fetch()
   }, [])
+
+  useEffect(() => {
+    if (!isRunning) setCurrentRunId(null)
+  }, [isRunning])
+
+  const handleCancel = async () => {
+    if (!currentRunId) return
+    try {
+      await cancelTestRun(currentRunId)
+    } catch (err) {
+      alert('Failed to cancel: ' + err.message)
+    }
+  }
 
   const handleRun = async () => {
     if (isRunning) return
@@ -147,6 +163,7 @@ export default function Evaluations() {
 
       const response = await runTests(options)
       const { run_id } = response
+      setCurrentRunId(run_id)
       pollRunStatus(run_id)
     } catch (err) {
       setIsRunning(false)
@@ -285,7 +302,7 @@ export default function Evaluations() {
 
           {/* Running progress */}
           {isRunning && (
-            <RunProgress runMessage={runMessage} runProgress={runProgress} />
+            <RunProgress runMessage={runMessage} runProgress={runProgress} onCancel={handleCancel} />
           )}
 
           {/* ============ SECTION 2: Test Results (grouped by batch) ============ */}

--- a/frontend/src/pages/evaluations/TestRunner.jsx
+++ b/frontend/src/pages/evaluations/TestRunner.jsx
@@ -5,7 +5,7 @@
  * and the run controls / progress bar shown on the main list view.
  */
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import {
   FlaskConical,
   Loader2,
@@ -395,7 +395,7 @@ export const TestSelectorModal = ({
 
 // ---- Running Progress Display ----
 
-export const RunProgress = ({ runMessage, runProgress }) => {
+export const RunProgress = ({ runMessage, runProgress, onCancel }) => {
   return (
     <div className="bg-blue-50 border border-blue-200 rounded-lg overflow-hidden">
       <div className="flex items-center gap-3 px-4 py-3">
@@ -413,6 +413,15 @@ export const RunProgress = ({ runMessage, runProgress }) => {
             </div>
           )}
         </div>
+        {onCancel && (
+          <button
+            onClick={onCancel}
+            className="flex items-center gap-1 px-3 py-1.5 text-sm text-red-600 bg-red-50 hover:bg-red-100 border border-red-200 rounded-lg transition-colors shrink-0"
+          >
+            <X className="w-3.5 h-3.5" />
+            Cancel
+          </button>
+        )}
       </div>
       {/* Completed tests so far */}
       {runProgress && runProgress.completed_tests.length > 0 && (

--- a/frontend/src/pages/evaluations/useTestPolling.js
+++ b/frontend/src/pages/evaluations/useTestPolling.js
@@ -64,6 +64,15 @@ export default function useTestPolling({
           setRunProgress(null)
           setRunResult({ error: true, message: status.message })
           setRefreshKey((k) => k + 1)
+        } else if (status.status === 'cancelled') {
+          clearInterval(id)
+          intervalRef.current = null
+          activeRunRef.current = null
+          setIsRunning(false)
+          setRunMessage(null)
+          setRunProgress(null)
+          setRunResult({ cancelled: true, message: status.message || 'Test run was cancelled' })
+          setRefreshKey((k) => k + 1)
         } else if (status.status === 'not_found') {
           // Backend might have restarted — wait a few polls before giving up
           notFoundCount++

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -363,6 +363,9 @@ export const runTests = (options = {}) =>
 export const getRunStatus = (runId) =>
   request(`/api/evaluations/run-status/${runId}`)
 
+export const cancelTestRun = (runId) =>
+  request(`/api/evaluations/cancel-run/${runId}`, { method: 'POST' })
+
 export const getTestBatches = (page = 1, limit = 10, tag = null) => {
   const params = new URLSearchParams({ page, limit })
   if (tag) params.append('tag', tag)


### PR DESCRIPTION
## Summary
- Adds a `POST /evaluations/cancel-run/{run_id}` backend endpoint that signals cancellation via `threading.Event` and updates the batch status to "cancelled"
- Adds a red **Cancel** button in the `RunProgress` component so users can stop a running test batch
- Frontend polling now recognizes "cancelled" as a terminal status and stops cleanly

Fixes #242

## Test plan
- [x] Start a test batch (select multiple tests so it takes a while)
- [x] Verify the Cancel button appears in the blue progress bar
- [x] Click Cancel — progress should stop, the batch should show as "cancelled" in the results list
- [x] Start a new run after cancelling — confirm it works normally and completes
- [x] Refresh the page while tests are running — verify the Cancel button reappears (active-run restore)
- [x] Try cancelling after tests already finished — should get a 404 / no-op (no UI error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)