### PR TITLE
fix(chat): auto-resize HITL answer textarea for long answers

### DIFF
--- a/frontend/src/components/chat/HITLQuestionMessage.jsx
+++ b/frontend/src/components/chat/HITLQuestionMessage.jsx
@@ -29,12 +29,24 @@ const HITLQuestionMessage = ({ question, onSubmitAnswer, isAnswering, answered =
   const [freeText, setFreeText] = useState('')
   const [showFreeText, setShowFreeText] = useState(false)
   const freeTextRef = useRef(null)
+  const plainTextRef = useRef(null)
+
+  const autoResize = (ref) => {
+    const el = ref?.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = Math.min(el.scrollHeight, 200) + 'px'
+  }
 
   useEffect(() => {
     if (showFreeText && freeTextRef.current) {
       freeTextRef.current.focus()
     }
   }, [showFreeText])
+
+  useEffect(() => {
+    autoResize(hasOptions ? freeTextRef : plainTextRef)
+  }, [freeText, hasOptions])
 
   const handleToggleChoice = (index) => {
     setSelectedIndices((prev) => {
@@ -147,7 +159,7 @@ const HITLQuestionMessage = ({ question, onSubmitAnswer, isAnswering, answered =
                     placeholder="Type your answer..."
                     rows={2}
                     disabled={isAnswering}
-                    className="flex-1 resize-none bg-transparent outline-none text-sm leading-6 min-w-0"
+                    className="flex-1 resize-y bg-transparent outline-none text-sm leading-6 min-w-0 max-h-[200px]"
                   />
                 </div>
               </div>
@@ -175,6 +187,7 @@ const HITLQuestionMessage = ({ question, onSubmitAnswer, isAnswering, answered =
           <div className="mt-2">
             <div className="flex items-end gap-2 border border-gray-200 rounded-lg px-3 py-2 bg-white focus-within:border-gray-300 transition-colors">
               <textarea
+                ref={plainTextRef}
                 value={freeText}
                 onChange={(e) => setFreeText(e.target.value)}
                 onKeyDown={(e) => {
@@ -186,7 +199,7 @@ const HITLQuestionMessage = ({ question, onSubmitAnswer, isAnswering, answered =
                 placeholder="Type your answer..."
                 rows={2}
                 disabled={isAnswering}
-                className="flex-1 resize-none bg-transparent outline-none text-sm leading-6 min-w-0"
+                className="flex-1 resize-y bg-transparent outline-none text-sm leading-6 min-w-0 max-h-[200px]"
               />
               <button
                 onClick={handleSubmit}


### PR DESCRIPTION
## Summary
- HITL answer textareas now **auto-grow** as the user types, up to 200px
- Users can also **manually drag-resize** the textarea vertically
- Applies to both the free-text answer input and the "custom other" input on multiple-choice questions

Partially addresses #239 (punt 1: uitklapbaar tekstvak). Punt 2 (speciale tekens / dubbele punt) kon niet worden gereproduceerd in de frontend code — alle `onKeyDown` handlers checken alleen op Enter. Dit is waarschijnlijk een OS/toetsenbord-instelling.

> **Note:** Issue #239 must be closed manually after merging — auto-close is not enabled on this repo.

## Test plan
- [x] Start a chat session and trigger a HITL question from an agent (e.g. ask the BA a question)
- [x] Type a long multi-line answer — verify the textarea grows automatically as you type
- [x] Verify it stops growing at ~200px and scrolls beyond that
- [x] Verify you can manually drag the bottom-right resize handle to make it taller
- [x] Verify pressing Enter (without Shift) still submits the answer
- [x] Verify Shift+Enter still inserts a newline
- [x] Test a multiple-choice question with "Add a custom answer" — verify the custom textarea also auto-resizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)