### PR TITLE
feat: Azure DevOps MCP — backlog access with create/update (HITL approval)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,6 +181,22 @@ SANDBOX_MODEL=
 
 # Important: OBO tokens are NEVER cached or stored - fetched fresh per request
 
+# =============================================================================
+# AZURE DEVOPS MCP (read-only backlog, ONE project only)
+# =============================================================================
+# Agents can read backlog / work items from a SINGLE Azure DevOps project.
+# Isolation is enforced two ways:
+#   1. Grant the service principal read-only access to ONLY this one project in
+#      Azure DevOps (it must have no access to other projects).
+#   2. The MCP server is hard-scoped to AZURE_DEVOPS_PROJECT and exposes no
+#      project picker / list_projects tool.
+# AZURE_DEVOPS_ORG_URL=https://dev.azure.com/<org>
+# AZURE_DEVOPS_PROJECT=<the-one-allowed-project>
+# AZURE_DEVOPS_TENANT_ID=
+# AZURE_DEVOPS_CLIENT_ID=
+# AZURE_DEVOPS_CLIENT_SECRET=
+# MCP_AZUREDEVOPS_PORT=9012
+
 # Sandbox runtime: "docker" (default, cross-platform) or "kata" (VM isolation, Linux + KVM only)
 # See docs/KATA_CONTAINERS.md for Kata setup instructions
 SANDBOX_RUNTIME=docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -415,6 +415,31 @@ services:
       retries: 5
       start_period: 10s
 
+  module-azuredevops:
+    build:
+      context: ./druppie/mcp-servers
+      dockerfile: module-azuredevops/Dockerfile
+    container_name: druppie-module-azuredevops
+    profiles: [infra, dev, prod]
+    environment:
+      MCP_PORT: "9012"
+      # Read-only access is hard-scoped to this single project (see module).
+      AZURE_DEVOPS_ORG_URL: ${AZURE_DEVOPS_ORG_URL:-}
+      AZURE_DEVOPS_PROJECT: ${AZURE_DEVOPS_PROJECT:-}
+      AZURE_DEVOPS_TENANT_ID: ${AZURE_DEVOPS_TENANT_ID:-}
+      AZURE_DEVOPS_CLIENT_ID: ${AZURE_DEVOPS_CLIENT_ID:-}
+      AZURE_DEVOPS_CLIENT_SECRET: ${AZURE_DEVOPS_CLIENT_SECRET:-}
+    ports:
+      - "${MCP_AZUREDEVOPS_PORT:-9012}:9012"
+    networks:
+      - druppie-new-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9012/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   # ===========================================================================
   # SANDBOX INFRASTRUCTURE (background-agents)
   # ===========================================================================

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -18,7 +18,7 @@ Because all actions are tool calls, every action can be logged, inspected, and g
 
 ## Agent Pipeline
 
-Thirteen agents are defined. Twelve are functional; one is a stub.
+Fourteen agents are defined. Thirteen are functional; one is a stub.
 
 ### Functional Agents
 
@@ -36,6 +36,7 @@ Thirteen agents are defined. Twelve are functional; one is a stub.
 | **Update Core Builder** | Implements Druppie core changes | Delegates coding to a dual-repo sandbox via `execute_coding_task` with the `druppie-core-builder` sandbox agent. The sandbox clones Druppie's GitHub repo into `/workspace/druppie-core/` and the project repo (with FD/TD) into `/workspace/project-<name>/`. Creates a PR targeting `colab-dev` on GitHub. The `done()` tool requires approval from a user with the `developer` role — the reviewer merges the PR on GitHub before approving. Max 100 iterations. |
 | **Developer** | Writes and modifies code | Implements features in git-managed workspaces. Handles branch creation, file writes, commits, pull requests, and merges. Can delegate to sandbox agents via `execute_coding_task`. For `create_project`, works on main; for `update_project`, works on feature branches. Max 100 iterations. |
 | **Deployer** | Builds and deploys via Docker | Clones from git, builds Docker images, runs containers with auto-assigned ports (9100-9199). Verifies health via container logs. For preview deploys, asks the user for feedback before finalizing. Max 100 iterations. |
+| **Product Owner** | Answers backlog questions | Reads the backlog / work items (user stories, bugs, tasks, epics) of the configured Azure DevOps project via the read-only `azuredevops` MCP and answers the user in chat. Read-only, single project — cannot create/edit work items or see any other project. General chat only. Max 50 iterations. |
 | **Reviewer** | Code review | Reviews code for quality, security, and best practices. |
 | **Tester** | Testing | Writes and runs tests to validate implementations. |
 | **Summarizer** | Creates completion messages | Reads all previous agent summaries and produces a concise, user-friendly message. Always the final step. Max 5 iterations. |

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -205,7 +205,7 @@ druppie/
 `module-azuredevops` (port 9012) gives agents **read-only** access to the backlog /
 work items of **exactly one** Azure DevOps project. It authenticates to Azure DevOps
 with an **Entra ID service principal** (`ClientSecretCredential`, resource scope
-`499b84ac-1321-427f-aa17-267ca6975798/.default`); tokens are fetched on demand and
+`{scope_id}/.default`); tokens are fetched on demand and
 never written to disk. Configuration is via env vars: `AZURE_DEVOPS_ORG_URL`,
 `AZURE_DEVOPS_PROJECT`, `AZURE_DEVOPS_TENANT_ID`, `AZURE_DEVOPS_CLIENT_ID`,
 `AZURE_DEVOPS_CLIENT_SECRET` (the server fails fast at startup if any are missing).

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -20,6 +20,7 @@ Druppie is a full-stack platform composed of the following services:
 | MCP File Search | Python / FastMCP | 9004 | Local file search within datasets |
 | MCP Web | Python / FastMCP | 9005 | Web browsing, URL fetching, web search |
 | MCP ArchiMate | Python / FastMCP | 9006 | ArchiMate model operations (list, read, search, export) |
+| MCP Azure DevOps | Python / FastMCP | 9012 | Read-only backlog / work items for a single Azure DevOps project |
 | Sandbox Control Plane | Node.js | 8787 | Sandbox session/event management, coordinates sandbox lifecycle |
 | Sandbox Manager | Node.js | 8000 | Creates/manages sandbox Docker containers, enforces resource limits |
 | Sandbox Image Builder | Docker | — | One-shot build producing `open-inspect-sandbox:latest` image |
@@ -191,7 +192,36 @@ druppie/
     module-web/          # Port 9005 — web browsing/search
     module-archimate/    # Port 9006 — ArchiMate model ops
     module-registry/     # Port 9007 — platform catalog/discovery
+    module-azuredevops/  # Port 9012 — read-only Azure DevOps backlog (single project)
+      MODULE.yaml
+      server.py
+      v1/tools.py        # 3 read-only @mcp.tool()s — no project picker
+      v1/module.py       # backlog ops, hard-scoped to AZURE_DEVOPS_PROJECT
+      v1/client.py       # async ADO REST client, service-principal auth
 ```
+
+### Azure DevOps backlog MCP (single-project isolation)
+
+`module-azuredevops` (port 9012) gives agents **read-only** access to the backlog /
+work items of **exactly one** Azure DevOps project. It authenticates to Azure DevOps
+with an **Entra ID service principal** (`ClientSecretCredential`, resource scope
+`499b84ac-1321-427f-aa17-267ca6975798/.default`); tokens are fetched on demand and
+never written to disk. Configuration is via env vars: `AZURE_DEVOPS_ORG_URL`,
+`AZURE_DEVOPS_PROJECT`, `AZURE_DEVOPS_TENANT_ID`, `AZURE_DEVOPS_CLIENT_ID`,
+`AZURE_DEVOPS_CLIENT_SECRET` (the server fails fast at startup if any are missing).
+
+Project isolation is enforced in two independent layers:
+
+1. **Azure-side (the real boundary):** grant the service principal read-only access to
+   only the one project. Any other project returns 403 from Azure itself.
+2. **Server-side allowlist:** every tool is hard-scoped to `AZURE_DEVOPS_PROJECT` — the
+   project is put in the REST path and the WIQL `[System.TeamProject]` clause, is never a
+   tool argument, and there is no `list_projects` tool. So the server cannot be steered
+   at another project even if the credential were over-scoped.
+
+Tools: `list_backlog_items`, `get_work_item`, `search_work_items` (all
+`requires_approval: false`). Consumed by the **Product Owner** agent. Isolation is pinned
+by `druppie/tests/test_azuredevops_isolation.py`.
 
 ---
 

--- a/druppie/agents/definitions/planner.yaml
+++ b/druppie/agents/definitions/planner.yaml
@@ -41,6 +41,7 @@ system_prompt: |
 
   - business_analyst: Gathers functional requirements, creates docs/functional-design.md (always confirms FD with user before finishing, including after revisions)
   - data_analyst: Handles data-related questions, finds relevant datasets, answers data questions, and outlines analysis plans. Does NOT write files or generate code. General chat only.
+  - product_owner: Answers questions about the backlog / work items of the configured Azure DevOps project (read-only). Does NOT write files or generate code. General chat only.
   - architect: Designs system architecture, creates docs/technical-design.md
   - builder_planner: Creates detailed implementation plans (code standards, test strategy, solution approach, change approach). Reads design docs, writes builder_plan.md.
   - test_builder: Generates comprehensive tests (TDD Red Phase). Writes test files, sets up test framework. Does NOT run tests.
@@ -90,6 +91,7 @@ system_prompt: |
      - business_analyst: ALWAYS use when the user describes a problem, pain point, frustration, or challenge they are facing. Also for requirements questions, process questions, stakeholder concerns, functional design questions
      - architect: Architecture questions, technical standards, NORA principles, infrastructure, security/compliance technical details, visualizing processes/workflows
      - data_analyst: Data-related questions, dataset discovery, questions about available data, data analysis approaches, interpreting data, building analysis plans. **Also use for any chart/visualization request** — the data_analyst has `dataaccess_create_chart` for rendering bar/line/pie/scatter charts inline in chat (including when the user provides the data values directly in their message). Use when the question is specifically about data, datasets, or visualizing values — rather than about processes/requirements (business_analyst) or architecture/standards (architect).
+     - product_owner: Questions about the backlog, work items, user stories, bugs, tasks, epics, or their states/details in the configured Azure DevOps project (e.g. "what's on the backlog?", "which stories are open?", "show me bug 1234"). Read-only, single project.
      - If the question is truly generic or does not clearly fit any agent, use the summarizer directly
      (1 step plan) and include the answer in the summarizer prompt. This is the only case where
      general_chat uses 1 step (no planner re-evaluation), since the summarizer terminates the workflow.

--- a/druppie/agents/definitions/product_owner.yaml
+++ b/druppie/agents/definitions/product_owner.yaml
@@ -164,9 +164,9 @@ system_prompt: |
            person, board column counts, completion %.
         3. Optionally call list_backlog_items with board_column filters for detail.
         Present the sprint summary with effort stats and board layout.
-     b. **Person questions** ("what is Nuno working on?", "who has the most work?"):
+     b. **Person questions** ("what is Jane working on?", "who has the most work?"):
         Use get_sprint_summary() for the per-person breakdown, or
-        list_backlog_items(assigned_to="Nuno", iteration=...) for their items.
+        list_backlog_items(assigned_to="Jane", iteration=...) for their items.
      c. **Specific item** ("tell me about item 1234") → get_work_item(1234).
         This shows parent Feature, child Tasks, and progress.
      d. **Feature questions** ("what PBIs are under Feature X?") → get_work_item

--- a/druppie/agents/definitions/product_owner.yaml
+++ b/druppie/agents/definitions/product_owner.yaml
@@ -1,0 +1,182 @@
+id: product_owner
+name: Product Owner Agent
+description: Answers questions about the backlog and work items of the configured Azure DevOps project (read-only, single project). Does NOT write files or generate code.
+category: execution
+
+system_prompt: |
+  ############################################################################
+  # CRITICAL: YOU MUST USE TOOL CALLS - TEXT OUTPUT DOES NOTHING!            #
+  ############################################################################
+
+  You communicate with the user ONLY via hitl_ask_question and
+  hitl_ask_multiple_choice_question tool calls.
+
+  WRONG: Outputting text as a response (this does NOTHING — the user never sees it)
+  RIGHT: Calling hitl_ask_question or hitl_ask_multiple_choice_question to talk to the user
+
+  After finishing your work, call done() to complete.
+  ############################################################################
+
+  =============================================================================
+  COMPLETION (CRITICAL — READ THIS FIRST!)
+  =============================================================================
+  When calling done(), your summary MUST include what you found and communicated.
+  Previous agent summaries are auto-prepended by the system. You only provide
+  YOUR OWN "Agent product_owner:" line.
+
+  ### STATUS: CHAT_COMPLETE
+  Use when the conversation is finished and the user's backlog question has been
+  answered.
+
+  CORRECT:
+    Call done with summary: "Agent product_owner: CHAT_COMPLETE. [summary of what was found and communicated]."
+
+  ### STATUS: CHAT_ROUTE_AGENT
+  Use when the user's question is better suited to a different agent's expertise.
+  Recognize when a question falls outside your domain and route promptly rather
+  than attempting to answer it yourself.
+
+  **Available agents and their specializations:**
+  - **business_analyst** (agent_id: "business_analyst"): Requirements elicitation,
+    problem analysis, root cause analysis, stakeholder concerns, functional design.
+  - **architect** (agent_id: "architect"): Architecture questions, technical
+    standards, infrastructure decisions, system design patterns, technology choices.
+  - **data_analyst** (agent_id: "data_analyst"): Data-related questions, dataset
+    discovery, interpreting data, charts/visualizations.
+  - **summarizer** (agent_id: "summarizer"): Generic questions that don't fit any
+    specialist agent.
+
+  CORRECT:
+    Call done with summary: "Agent product_owner: CHAT_ROUTE_AGENT. Suggested agent: [agent_id]. Context: [what the user is asking and why this agent is better suited]. User question: [the user's question to pass along]."
+
+  ### STATUS: CHAT_ROUTE_CREATE_PROJECT
+  Use when the user expresses intent to build something new based on the backlog
+  discussion. Confirm with the user via hitl_ask_multiple_choice_question first
+  (e.g., "Yes, start a new project" / "No, continue chatting").
+
+  CORRECT:
+    Call done with summary: "Agent product_owner: CHAT_ROUTE_CREATE_PROJECT. Project: [brief project description]. The user confirmed they want to create a project."
+
+  ### STATUS: CHAT_ROUTE_UPDATE_PROJECT
+  Use when the user wants to modify an existing project based on the backlog
+  discussion. Confirm with the user via hitl_ask_multiple_choice_question first.
+
+  CORRECT:
+    Call done with summary: "Agent product_owner: CHAT_ROUTE_UPDATE_PROJECT. Project ID: [project_id if known]. The user confirmed they want to update an existing project. Change requested: [brief description]."
+
+  WRONG:
+    Calling done with summary "Task completed"  <- NEVER DO THIS
+
+  =============================================================================
+
+  # Product Owner
+
+  ## Purpose
+
+  You answer questions about the **backlog and work items** of the team's Azure
+  DevOps project. You read work items (user stories, bugs, tasks, epics), surface
+  what is planned and in what state, and help the user understand the backlog.
+
+  You have read-only access to exactly ONE Azure DevOps project — the one the
+  platform is configured for. You cannot see, list, or query any other project.
+
+  ## Tools (azuredevops MCP — all read-only)
+
+  - azuredevops_list_backlog_items(work_item_type=None, state=None, limit=100) —
+    List work items in the configured project, newest-changed first. Optionally
+    filter by work_item_type ("User Story", "Bug", "Task", "Epic", ...) and/or
+    state ("New", "Active", "Closed", ...).
+  - azuredevops_get_work_item(item_id) — Full detail for one work item: title,
+    type, state, description, assignee, tags, timestamps.
+  - azuredevops_search_work_items(text, limit=50) — Find work items whose title or
+    description contains the given text.
+
+  Every result includes the `project` it came from — always the single configured
+  project. There is intentionally no tool to choose or list projects.
+
+  =============================================================================
+  OPERATIONAL FLOW
+  =============================================================================
+
+  1. **Understand the question.** If it is vague ("what's going on?"), ask one
+     clarifying question (which work item type, state, or topic).
+  2. **Query the backlog.**
+     - "What's on the backlog?" / "open stories?" → azuredevops_list_backlog_items
+       (filter by state/type as appropriate).
+     - "Tell me about item 1234" → azuredevops_get_work_item(1234).
+     - "Anything about login?" → azuredevops_search_work_items("login").
+  3. **Present the answer** via hitl_ask_question. For lists, show id, title, type,
+     and state in a compact, readable form. For a single item, include the key
+     fields and (briefly) the description. Keep raw dumps out — summarize.
+  4. **Complete** with done() using the appropriate CHAT_* status.
+
+  When a tool returns `{"success": false, "error": ...}`, do not retry blindly.
+  Tell the user plainly what failed (e.g. the item id does not exist in this
+  project, or the backlog source is unreachable) and ask how to proceed.
+
+  =============================================================================
+  RULES & GUARDRAILS
+  =============================================================================
+
+  ### This Agent DOES:
+  - Read and summarize backlog / work items from the configured project
+  - Filter and search work items by type, state, or text
+  - Cite work item ids and states when answering
+  - Route to other agents when questions are outside its domain
+
+  ### This Agent DOES NOT:
+  - Create, edit, or close work items (no write tools exist)
+  - Access any Azure DevOps project other than the configured one
+  - Write code, files, or documents
+  - Make architecture or requirements decisions
+
+  =============================================================================
+  INTERACTION GUIDELINES
+  =============================================================================
+
+  - **Exactly ONE question at a time** — each tool call contains exactly one question.
+  - **Offer defaults** — if the user is unsure, suggest a sensible default.
+  - **Keep it short** — 1-3 sentences per question; front-load the core ask.
+  - **Cite the backlog** — reference specific work item ids and states.
+  - Match the user's language when talking to them.
+
+skills: []
+
+system_prompts:
+  - tool_only_communication
+  - summary_relay
+  - done_tool_format
+  - workspace_state
+
+extra_builtin_tools: []
+excluded_builtin_tools: []
+
+mcps:
+  azuredevops:
+    - list_backlog_items
+    - get_work_item
+    - search_work_items
+
+approval_overrides: {}
+
+allowed_next_agents: []
+
+completion_preconditions: []
+
+required_summary_status:
+  one_of:
+    - "CHAT_COMPLETE"
+    - "CHAT_ROUTE_AGENT"
+    - "CHAT_ROUTE_CREATE_PROJECT"
+    - "CHAT_ROUTE_UPDATE_PROJECT"
+  error_message: >
+    PRECONDITION FAILED: Your done() summary MUST contain one of the required
+    status keywords: CHAT_COMPLETE, CHAT_ROUTE_AGENT, CHAT_ROUTE_CREATE_PROJECT,
+    or CHAT_ROUTE_UPDATE_PROJECT. These are mandatory protocol keywords that must
+    appear exactly as written (in English, uppercase). Review your completion
+    instructions and call done() again with the correct status in your summary.
+
+llm_profile: cheap
+temperature: 0.2
+max_tokens: 100000
+max_iterations: 50

--- a/druppie/agents/definitions/product_owner.yaml
+++ b/druppie/agents/definitions/product_owner.yaml
@@ -82,32 +82,91 @@ system_prompt: |
 
   ## Tools (azuredevops MCP — all read-only)
 
-  - azuredevops_list_backlog_items(work_item_type=None, state=None, limit=100) —
-    List work items in the configured project, newest-changed first. Optionally
-    filter by work_item_type ("User Story", "Bug", "Task", "Epic", ...) and/or
-    state ("New", "Active", "Closed", ...).
-  - azuredevops_get_work_item(item_id) — Full detail for one work item: title,
-    type, state, description, assignee, tags, timestamps.
-  - azuredevops_search_work_items(text, limit=50) — Find work items whose title or
-    description contains the given text.
+  - azuredevops_get_current_sprint() — Returns the current sprint and all sprints
+    with date ranges. Use the sprint path as the `iteration` filter.
+  - azuredevops_get_sprint_summary(iteration) — Aggregated sprint stats: effort by
+    person, board column distribution, completion %, item counts by type/state.
+    Use this for sprint overview questions — it's one call instead of many.
+  - azuredevops_list_backlog_items(work_item_type, state, board_column, iteration,
+    assigned_to, limit) — List work items with optional filters. All filters are
+    optional; combine them as needed.
+  - azuredevops_get_work_item(item_id) — Full detail for one work item INCLUDING
+    its parent (e.g. the Feature above a PBI) and children (e.g. Tasks under a
+    PBI) with a children_summary showing progress (done/total/completion_pct).
+  - azuredevops_search_work_items(text, limit) — Find work items by text.
 
-  Every result includes the `project` it came from — always the single configured
-  project. There is intentionally no tool to choose or list projects.
+  ## Work Item Hierarchy
+
+  The hierarchy is: **Epic → Feature → Product Backlog Item (PBI) → Task**
+
+  - **Features** span multiple sprints and describe high-level goals/themes.
+  - **Product Backlog Items (PBIs)** are the main unit on the board. They contain
+    implementation details and are what the team tracks in the sprint board view.
+    PBIs have an **effort** field (story points).
+  - **Tasks** are children of PBIs and track granular progress within a PBI.
+    Progress is measured by task state (Done vs To Do/In Progress), not hours.
+
+  When showing a PBI, use get_work_item() to see its parent Feature (context) and
+  child Tasks (progress). When showing a Feature, its children are the PBIs.
+
+  ## State vs Board Column (IMPORTANT!)
+
+  Each work item has TWO position indicators:
+    - **state** — the workflow state (e.g. "Approved", "New", "Committed", "Done")
+    - **board_column** — the lane on the board (e.g. "In Progress", "In Review",
+      "Ready", "Done", "Draft")
+
+  These can DIFFER. A PBI can have state="Approved" but board_column="In Progress",
+  meaning it IS being worked on. The board_column reflects the actual board view.
+  When the user asks about "current work" or "in progress", use board_column.
+
+  ## Sprints / Iterations
+
+  Work items belong to sprints via iteration path (e.g. "AI-platform\Sprint 11").
+  ALWAYS call get_current_sprint() first to find the current sprint, then scope
+  queries with the iteration filter. Without it you get ALL sprints → wrong counts.
+
+  ## Effort Tracking
+
+  PBIs have an **effort** field (story points). Use get_sprint_summary() to see:
+  - Total effort planned vs completed in the sprint
+  - Effort breakdown per team member
+  - Completion percentage
+  - Board column distribution
+
+  States: New, Approved, Committed, In Progress, To Do, Review, Done, Removed
+  Board columns: New, In Progress, In Review, Ready, Done, Draft
+
+  IMPORTANT: Do NOT use "Active" or "Closed" as filters — they don't exist here.
 
   =============================================================================
   OPERATIONAL FLOW
   =============================================================================
 
-  1. **Understand the question.** If it is vague ("what's going on?"), ask one
-     clarifying question (which work item type, state, or topic).
+  1. **Understand the question.** If it is vague ("what's going on?"), do NOT ask
+     for clarification — give a sprint overview (step 2a).
   2. **Query the backlog.**
-     - "What's on the backlog?" / "open stories?" → azuredevops_list_backlog_items
-       (filter by state/type as appropriate).
-     - "Tell me about item 1234" → azuredevops_get_work_item(1234).
-     - "Anything about login?" → azuredevops_search_work_items("login").
+     a. **Overview / sprint questions** ("sprint status?", "what are we working on?",
+        "how's the sprint going?", "what's on the backlog?"):
+        1. Call get_current_sprint() to get the sprint path.
+        2. Call get_sprint_summary(iteration) for the aggregate view: effort per
+           person, board column counts, completion %.
+        3. Optionally call list_backlog_items with board_column filters for detail.
+        Present the sprint summary with effort stats and board layout.
+     b. **Person questions** ("what is Nuno working on?", "who has the most work?"):
+        Use get_sprint_summary() for the per-person breakdown, or
+        list_backlog_items(assigned_to="Nuno", iteration=...) for their items.
+     c. **Specific item** ("tell me about item 1234") → get_work_item(1234).
+        This shows parent Feature, child Tasks, and progress.
+     d. **Feature questions** ("what PBIs are under Feature X?") → get_work_item
+        on the Feature to see its children (the PBIs).
+     e. **Topic search** ("anything about login?") → search_work_items("login").
+     f. **"What's in progress?"** → use board_column="In Progress" (NOT state).
+        Always scope to the current sprint.
   3. **Present the answer** via hitl_ask_question. For lists, show id, title, type,
-     and state in a compact, readable form. For a single item, include the key
-     fields and (briefly) the description. Keep raw dumps out — summarize.
+     and state in a compact, readable form. Group by state when showing multiple
+     states. For a single item, include the key fields and (briefly) the description.
+     Keep raw dumps out — summarize.
   4. **Complete** with done() using the appropriate CHAT_* status.
 
   When a tool returns `{"success": false, "error": ...}`, do not retry blindly.
@@ -120,7 +179,9 @@ system_prompt: |
 
   ### This Agent DOES:
   - Read and summarize backlog / work items from the configured project
-  - Filter and search work items by type, state, or text
+  - Filter and search work items by type, state, board column, sprint, or assignee
+  - Show sprint progress: effort per person, completion %, board column breakdown
+  - Navigate the hierarchy: Feature → PBI → Task with progress tracking
   - Cite work item ids and states when answering
   - Route to other agents when questions are outside its domain
 
@@ -153,6 +214,8 @@ excluded_builtin_tools: []
 
 mcps:
   azuredevops:
+    - get_current_sprint
+    - get_sprint_summary
     - list_backlog_items
     - get_work_item
     - search_work_items

--- a/druppie/agents/definitions/product_owner.yaml
+++ b/druppie/agents/definitions/product_owner.yaml
@@ -1,6 +1,6 @@
 id: product_owner
 name: Product Owner Agent
-description: Answers questions about the backlog and work items of the configured Azure DevOps project (read-only, single project). Does NOT write files or generate code.
+description: Answers questions about the backlog and work items of the configured Azure DevOps project. Can create and update work items with human approval. Does NOT write files or generate code.
 category: execution
 
 system_prompt: |
@@ -80,8 +80,9 @@ system_prompt: |
   You have read-only access to exactly ONE Azure DevOps project — the one the
   platform is configured for. You cannot see, list, or query any other project.
 
-  ## Tools (azuredevops MCP — all read-only)
+  ## Tools (azuredevops MCP)
 
+  ### Read tools
   - azuredevops_get_current_sprint() — Returns the current sprint and all sprints
     with date ranges. Use the sprint path as the `iteration` filter.
   - azuredevops_get_sprint_summary(iteration) — Aggregated sprint stats: effort by
@@ -94,6 +95,16 @@ system_prompt: |
     its parent (e.g. the Feature above a PBI) and children (e.g. Tasks under a
     PBI) with a children_summary showing progress (done/total/completion_pct).
   - azuredevops_search_work_items(text, limit) — Find work items by text.
+
+  ### Write tools (require human approval)
+  - azuredevops_create_work_item(work_item_type, title, description, state,
+    assigned_to, iteration, area_path, effort, tags, parent_id) — Create a new
+    work item. The user will see all fields and must approve before it executes.
+    Valid types: Epic, Feature, Product Backlog Item, Task, Bug.
+  - azuredevops_update_work_item(item_id, title, description, state, assigned_to,
+    iteration, area_path, effort, tags, parent_id) — Update an existing work item.
+    Only set fields you want to change — omitted fields stay the same. The user
+    must approve before it executes.
 
   ## Work Item Hierarchy
 
@@ -167,7 +178,14 @@ system_prompt: |
      and state in a compact, readable form. Group by state when showing multiple
      states. For a single item, include the key fields and (briefly) the description.
      Keep raw dumps out — summarize.
-  4. **Complete** with done() using the appropriate CHAT_* status.
+  4. **Create/update work items** (when the user requests it).
+     a. Gather the necessary information through the conversation.
+     b. ALWAYS use get_work_item() first when updating, to see current values.
+     c. Call create_work_item or update_work_item with the fields.
+     d. The user will be asked to approve before the operation executes.
+     e. Report the result (created/updated item id, title, state) to the user.
+     f. Do NOT batch-create many items without the user explicitly requesting it.
+  5. **Complete** with done() using the appropriate CHAT_* status.
 
   When a tool returns `{"success": false, "error": ...}`, do not retry blindly.
   Tell the user plainly what failed (e.g. the item id does not exist in this
@@ -182,11 +200,13 @@ system_prompt: |
   - Filter and search work items by type, state, board column, sprint, or assignee
   - Show sprint progress: effort per person, completion %, board column breakdown
   - Navigate the hierarchy: Feature → PBI → Task with progress tracking
+  - Create new work items (with human approval)
+  - Update existing work items (with human approval)
   - Cite work item ids and states when answering
   - Route to other agents when questions are outside its domain
 
   ### This Agent DOES NOT:
-  - Create, edit, or close work items (no write tools exist)
+  - Create or update work items WITHOUT human approval (all writes require approval)
   - Access any Azure DevOps project other than the configured one
   - Write code, files, or documents
   - Make architecture or requirements decisions
@@ -219,8 +239,16 @@ mcps:
     - list_backlog_items
     - get_work_item
     - search_work_items
+    - create_work_item
+    - update_work_item
 
-approval_overrides: {}
+approval_overrides:
+  "azuredevops:create_work_item":
+    requires_approval: true
+    required_role: session_owner
+  "azuredevops:update_work_item":
+    requires_approval: true
+    required_role: session_owner
 
 allowed_next_agents: []
 

--- a/druppie/core/mcp_config.yaml
+++ b/druppie/core/mcp_config.yaml
@@ -316,3 +316,16 @@ mcps:
 
       - name: create_chart_from_source
         requires_approval: false
+
+  # Read-only Azure DevOps backlog for ONE configured project (AZURE_DEVOPS_PROJECT).
+  # No write tools and no cross-project access — the project is fixed server-side.
+  azuredevops:
+    url: ${MCP_AZUREDEVOPS_URL:-http://module-azuredevops:9012}
+    type: module
+    tools:
+      - name: list_backlog_items
+        requires_approval: false
+      - name: get_work_item
+        requires_approval: false
+      - name: search_work_items
+        requires_approval: false

--- a/druppie/core/mcp_config.yaml
+++ b/druppie/core/mcp_config.yaml
@@ -317,8 +317,9 @@ mcps:
       - name: create_chart_from_source
         requires_approval: false
 
-  # Read-only Azure DevOps backlog for ONE configured project (AZURE_DEVOPS_PROJECT).
-  # No write tools and no cross-project access — the project is fixed server-side.
+  # Azure DevOps backlog for ONE configured project (AZURE_DEVOPS_PROJECT).
+  # No cross-project access — the project is fixed server-side.
+  # Write tools require session_owner approval (the user who started the chat).
   azuredevops:
     url: ${MCP_AZUREDEVOPS_URL:-http://module-azuredevops:9012}
     type: module
@@ -329,3 +330,13 @@ mcps:
         requires_approval: false
       - name: search_work_items
         requires_approval: false
+      - name: get_current_sprint
+        requires_approval: false
+      - name: get_sprint_summary
+        requires_approval: false
+      - name: create_work_item
+        requires_approval: true
+        required_role: session_owner
+      - name: update_work_item
+        requires_approval: true
+        required_role: session_owner

--- a/druppie/llm/litellm_provider.py
+++ b/druppie/llm/litellm_provider.py
@@ -200,7 +200,7 @@ PROVIDER_CONFIGS = {
         "default_base_url": "https://api.deepseek.com/v1",
     },
     "azure_foundry": {
-        "prefix": "azure",  # LiteLLM native Azure routing (deployment-based URLs)
+        "prefix": "azure",  # Overridden at runtime for Claude models → "anthropic"
         "default_model": "GPT-5-MINI",
         "api_key_env": "FOUNDRY_API_KEY",
         "model_env": "FOUNDRY_MODEL",
@@ -208,8 +208,10 @@ PROVIDER_CONFIGS = {
         "default_base_url": "https://druppie-resource.openai.azure.com",
         "use_max_completion_tokens": True,
         "default_temperature": 1.0,
-        "force_temperature": True,  # GPT-5-MINI only supports temperature=1.0
+        "force_temperature": True,
         "api_version": "2024-12-01-preview",
+        "anthropic_base_url_env": "FOUNDRY_ANTHROPIC_URL",
+        "anthropic_default_base_url": "https://druppie-resource.services.ai.azure.com/anthropic",
     },
     "ollama": {
         "prefix": "openai",  # Ollama is OpenAI-compatible
@@ -300,8 +302,24 @@ class ChatLiteLLM(BaseLLM):
         # Azure API version (required for azure/ prefix)
         self._api_version = config.get("api_version")
 
+        # Azure Foundry: Claude models use Anthropic Messages API, not OpenAI
+        is_claude = self._model.lower().startswith("claude")
+        if provider == "azure_foundry" and is_claude:
+            prefix = "anthropic"
+            anthropic_url = (
+                os.getenv(config.get("anthropic_base_url_env", ""), "")
+                or config.get("anthropic_default_base_url", "")
+            )
+            if anthropic_url:
+                self.api_base = anthropic_url.rstrip("/")
+                if not self.api_base.endswith("/anthropic"):
+                    self.api_base += "/anthropic"
+            self._api_version = None
+            self._use_max_completion_tokens = False
+        else:
+            prefix = config["prefix"]
+
         # LiteLLM model format (e.g., "openai/glm-4.7" for custom endpoints)
-        prefix = config["prefix"]
         if prefix and not self._model.startswith(f"{prefix}/"):
             self._litellm_model = f"{prefix}/{self._model}"
         else:

--- a/druppie/llm/litellm_provider.py
+++ b/druppie/llm/litellm_provider.py
@@ -200,16 +200,16 @@ PROVIDER_CONFIGS = {
         "default_base_url": "https://api.deepseek.com/v1",
     },
     "azure_foundry": {
-        "prefix": "openai",  # OpenAI-compatible API
+        "prefix": "azure",  # LiteLLM native Azure routing (deployment-based URLs)
         "default_model": "GPT-5-MINI",
         "api_key_env": "FOUNDRY_API_KEY",
         "model_env": "FOUNDRY_MODEL",
         "base_url_env": "FOUNDRY_API_URL",
-        "default_base_url": "https://druppie.cognitiveservices.azure.com/openai/v1",
+        "default_base_url": "https://druppie-resource.openai.azure.com",
         "use_max_completion_tokens": True,
         "default_temperature": 1.0,
         "force_temperature": True,  # GPT-5-MINI only supports temperature=1.0
-        "auth_type": "bearer",  # Use Bearer token instead of api-key header
+        "api_version": "2024-12-01-preview",
     },
     "ollama": {
         "prefix": "openai",  # Ollama is OpenAI-compatible
@@ -291,11 +291,14 @@ class ChatLiteLLM(BaseLLM):
         if not self._ssl_verify and LITELLM_AVAILABLE:
             litellm.ssl_verify = False
 
-        # Bearer token auth (e.g. Azure Foundry) — send key as Authorization header
+        # Bearer token auth — send key as Authorization header
         self._auth_type = config.get("auth_type", "api_key")
         self._extra_headers: dict[str, str] = {}
         if self._auth_type == "bearer" and self.api_key:
             self._extra_headers["Authorization"] = f"Bearer {self.api_key}"
+
+        # Azure API version (required for azure/ prefix)
+        self._api_version = config.get("api_version")
 
         # LiteLLM model format (e.g., "openai/glm-4.7" for custom endpoints)
         prefix = config["prefix"]
@@ -372,6 +375,9 @@ class ChatLiteLLM(BaseLLM):
 
         if self.api_base:
             kwargs["api_base"] = self.api_base
+
+        if self._api_version:
+            kwargs["api_version"] = self._api_version
 
         if not self._ssl_verify:
             kwargs["ssl_verify"] = False

--- a/druppie/mcp-servers/module-azuredevops/Dockerfile
+++ b/druppie/mcp-servers/module-azuredevops/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY module-azuredevops/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY module_router.py .
+COPY module-azuredevops/ .
+
+ENV PYTHONUNBUFFERED=1
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:9012/health || exit 1
+
+CMD ["python", "server.py"]

--- a/druppie/mcp-servers/module-azuredevops/MODULE.yaml
+++ b/druppie/mcp-servers/module-azuredevops/MODULE.yaml
@@ -1,0 +1,4 @@
+id: azuredevops
+latest_version: "1.0.0"
+versions:
+  - "1.0.0"

--- a/druppie/mcp-servers/module-azuredevops/module_router.py
+++ b/druppie/mcp-servers/module-azuredevops/module_router.py
@@ -1,0 +1,101 @@
+"""Shared version router factory for MCP module servers.
+
+Every module server has the same structure: read MODULE.yaml, mount versioned
+MCP apps, expose /health, and wire the FastMCP lifespan. This factory
+eliminates the duplication.
+
+Usage in a module's server.py:
+
+    from module_router import create_module_app
+    app = create_module_app("coding", default_port=9001)
+    # That's it — `app` is a Starlette application ready for uvicorn.
+"""
+
+import logging
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import yaml
+import uvicorn
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Mount, Route
+
+
+def create_module_app(
+    module_name: str,
+    default_port: int,
+    *,
+    module_dir: Path | None = None,
+) -> Starlette:
+    """Create a versioned Starlette app for an MCP module.
+
+    Args:
+        module_name: Human-readable name for logging (e.g. "coding").
+        default_port: Fallback port when MCP_PORT env var is unset.
+        module_dir: Root directory of the module. Defaults to caller's directory
+                    (works when server.py and MODULE.yaml are siblings).
+
+    Returns:
+        A fully configured Starlette application.
+    """
+    if module_dir is None:
+        # Resolve relative to the calling server.py — but since this is
+        # imported as a copied file in /app, use CWD which is /app.
+        module_dir = Path.cwd()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    logger = logging.getLogger(f"{module_name}-mcp")
+
+    # Read MODULE.yaml
+    manifest_path = module_dir / "MODULE.yaml"
+    with open(manifest_path) as f:
+        manifest = yaml.safe_load(f)
+
+    latest_version = manifest["latest_version"]
+    major_latest = latest_version.split(".")[0]
+
+    # Import version-specific MCP app (v1/tools.py must define `mcp`)
+    from v1.tools import mcp as v1_mcp
+
+    version_apps = {
+        "1": v1_mcp.http_app(),
+    }
+
+    async def health(request):
+        return JSONResponse({
+            "status": "healthy",
+            "module_id": manifest["id"],
+            "latest_version": latest_version,
+            "active_versions": manifest["versions"],
+        })
+
+    # Build routes
+    routes = [
+        Route("/health", health, methods=["GET"]),
+    ]
+    for major, app in version_apps.items():
+        routes.append(Mount(f"/v{major}", app=app))
+
+    # /mcp → latest version
+    routes.append(Mount("/", app=version_apps[major_latest]))
+
+    @asynccontextmanager
+    async def lifespan(app):
+        async with version_apps[major_latest].router.lifespan_context(
+            version_apps[major_latest]
+        ):
+            yield
+
+    return Starlette(routes=routes, lifespan=lifespan)
+
+
+def run_module(module_name: str, default_port: int) -> None:
+    """Create and run a module server (convenience for __main__ blocks)."""
+    app = create_module_app(module_name, default_port)
+    port = int(os.getenv("MCP_PORT", str(default_port)))
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")

--- a/druppie/mcp-servers/module-azuredevops/requirements.txt
+++ b/druppie/mcp-servers/module-azuredevops/requirements.txt
@@ -1,0 +1,6 @@
+fastmcp>=0.1.0
+httpx>=0.25.0
+uvicorn>=0.24.0
+pyyaml>=6.0.0
+azure-identity>=1.15.0
+aiohttp>=3.9.0

--- a/druppie/mcp-servers/module-azuredevops/server.py
+++ b/druppie/mcp-servers/module-azuredevops/server.py
@@ -1,0 +1,16 @@
+"""Azure DevOps MCP Server — Version Router.
+
+Read-only access to backlog / work items of a SINGLE, server-configured Azure
+DevOps project. The project is fixed via the AZURE_DEVOPS_PROJECT env var and is
+never taken from a tool argument, so agents cannot read any other project.
+"""
+
+import os
+import uvicorn
+from module_router import create_module_app
+
+app = create_module_app("azuredevops", default_port=9012)
+
+if __name__ == "__main__":
+    port = int(os.getenv("MCP_PORT", "9012"))
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")

--- a/druppie/mcp-servers/module-azuredevops/v1/client.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/client.py
@@ -1,0 +1,114 @@
+"""Thin async Azure DevOps REST client (read-only, single project).
+
+Authenticates with an Entra ID service principal (client credentials) and talks
+to the Azure DevOps REST API. Every call is hard-scoped to ONE project that is
+read from configuration — there is no method that accepts a caller-chosen
+project, so the client cannot be steered at a different project.
+
+Access tokens are requested fresh from azure-identity on demand (the credential
+caches in memory and refreshes near expiry) and are NEVER written to disk.
+"""
+
+import logging
+
+import httpx
+from azure.identity.aio import ClientSecretCredential
+
+logger = logging.getLogger("azuredevops-mcp")
+
+# Fixed resource ID for the Azure DevOps API. The ".default" scope yields a token
+# carrying whatever permissions the service principal was granted in Azure DevOps.
+AZURE_DEVOPS_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default"
+
+API_VERSION = "7.0"
+
+
+class AzureDevOpsClient:
+    """Read-only client bound to a single Azure DevOps project."""
+
+    def __init__(
+        self,
+        org_url: str,
+        project: str,
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+    ) -> None:
+        # The project is stored once here and injected into every request path /
+        # WIQL query below. It is intentionally not a method parameter anywhere.
+        self._org_url = org_url.rstrip("/")
+        self._project = project
+        self._credential = ClientSecretCredential(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
+    @property
+    def project(self) -> str:
+        return self._project
+
+    async def _auth_header(self) -> dict[str, str]:
+        token = await self._credential.get_token(AZURE_DEVOPS_SCOPE)
+        return {"Authorization": f"Bearer {token.token}"}
+
+    async def _post(self, path: str, json_body: dict) -> dict:
+        headers = await self._auth_header()
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{self._org_url}/{path}",
+                params={"api-version": API_VERSION},
+                json=json_body,
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def _get(self, path: str, params: dict | None = None) -> dict:
+        headers = await self._auth_header()
+        query = {"api-version": API_VERSION, **(params or {})}
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(
+                f"{self._org_url}/{path}",
+                params=query,
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def query_wiql(self, wiql: str, top: int) -> list[int]:
+        """Run a WIQL query scoped to the configured project, return work-item ids."""
+        # Project goes in the URL path so the query can only ever hit this project.
+        result = await self._post(
+            f"{self._project}/_apis/wit/wiql",
+            {"query": wiql},
+        )
+        work_items = result.get("workItems", [])
+        return [wi["id"] for wi in work_items[:top]]
+
+    async def get_work_items(
+        self, ids: list[int], fields: list[str] | None = None
+    ) -> list[dict]:
+        """Batch-fetch work items by id, scoped to the configured project."""
+        if not ids:
+            return []
+        body: dict = {"ids": ids}
+        if fields:
+            body["fields"] = fields
+        result = await self._post(
+            f"{self._project}/_apis/wit/workitemsbatch",
+            body,
+        )
+        return result.get("value", [])
+
+    async def get_work_item(self, item_id: int) -> dict:
+        """Fetch a single work item by id, scoped to the configured project."""
+        # Routing through the project path means an id belonging to another
+        # project returns 404, never another project's data.
+        return await self._get(
+            f"{self._project}/_apis/wit/workitems/{item_id}",
+            {"$expand": "fields"},
+        )
+
+    async def close(self) -> None:
+        await self._credential.close()

--- a/druppie/mcp-servers/module-azuredevops/v1/client.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/client.py
@@ -110,5 +110,12 @@ class AzureDevOpsClient:
             {"$expand": "fields"},
         )
 
+    async def get_team_iterations(self) -> list[dict]:
+        """Fetch all iterations (sprints) for the default team."""
+        result = await self._get(
+            f"{self._project}/_apis/work/teamsettings/iterations",
+        )
+        return result.get("value", [])
+
     async def close(self) -> None:
         await self._credential.close()

--- a/druppie/mcp-servers/module-azuredevops/v1/client.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/client.py
@@ -16,8 +16,9 @@ from azure.identity.aio import ClientSecretCredential
 
 logger = logging.getLogger("azuredevops-mcp")
 
-# Fixed resource ID for the Azure DevOps API. The ".default" scope yields a token
-# carrying whatever permissions the service principal was granted in Azure DevOps.
+# Microsoft's well-known Application ID for the Azure DevOps REST API — the same
+# across every Azure tenant. The ".default" suffix requests whatever permissions
+# have been assigned to the service principal in Entra ID.
 AZURE_DEVOPS_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default"
 
 API_VERSION = "7.0"

--- a/druppie/mcp-servers/module-azuredevops/v1/client.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/client.py
@@ -1,4 +1,4 @@
-"""Thin async Azure DevOps REST client (read-only, single project).
+"""Thin async Azure DevOps REST client (single project).
 
 Authenticates with an Entra ID service principal (client credentials) and talks
 to the Azure DevOps REST API. Every call is hard-scoped to ONE project that is
@@ -24,7 +24,7 @@ API_VERSION = "7.0"
 
 
 class AzureDevOpsClient:
-    """Read-only client bound to a single Azure DevOps project."""
+    """REST client bound to a single Azure DevOps project."""
 
     def __init__(
         self,
@@ -47,6 +47,10 @@ class AzureDevOpsClient:
     @property
     def project(self) -> str:
         return self._project
+
+    @property
+    def org_url(self) -> str:
+        return self._org_url
 
     async def _auth_header(self) -> dict[str, str]:
         token = await self._credential.get_token(AZURE_DEVOPS_SCOPE)
@@ -71,6 +75,36 @@ class AzureDevOpsClient:
             resp = await client.get(
                 f"{self._org_url}/{path}",
                 params=query,
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def _patch(self, path: str, operations: list[dict]) -> dict:
+        import json as _json
+
+        headers = await self._auth_header()
+        headers["Content-Type"] = "application/json-patch+json"
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.patch(
+                f"{self._org_url}/{path}",
+                params={"api-version": API_VERSION},
+                content=_json.dumps(operations),
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def _post_patch(self, path: str, operations: list[dict]) -> dict:
+        import json as _json
+
+        headers = await self._auth_header()
+        headers["Content-Type"] = "application/json-patch+json"
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{self._org_url}/{path}",
+                params={"api-version": API_VERSION},
+                content=_json.dumps(operations),
                 headers=headers,
             )
             resp.raise_for_status()
@@ -116,6 +150,24 @@ class AzureDevOpsClient:
             f"{self._project}/_apis/work/teamsettings/iterations",
         )
         return result.get("value", [])
+
+    async def create_work_item(
+        self, work_item_type: str, operations: list[dict]
+    ) -> dict:
+        """Create a work item in the configured project."""
+        return await self._post_patch(
+            f"{self._project}/_apis/wit/workitems/${work_item_type}",
+            operations,
+        )
+
+    async def update_work_item(
+        self, item_id: int, operations: list[dict]
+    ) -> dict:
+        """Update a work item in the configured project."""
+        return await self._patch(
+            f"{self._project}/_apis/wit/workitems/{item_id}",
+            operations,
+        )
 
     async def close(self) -> None:
         await self._credential.close()

--- a/druppie/mcp-servers/module-azuredevops/v1/client.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/client.py
@@ -107,7 +107,7 @@ class AzureDevOpsClient:
         # project returns 404, never another project's data.
         return await self._get(
             f"{self._project}/_apis/wit/workitems/{item_id}",
-            {"$expand": "fields"},
+            {"$expand": "all"},
         )
 
     async def get_team_iterations(self) -> list[dict]:

--- a/druppie/mcp-servers/module-azuredevops/v1/module.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/module.py
@@ -1,0 +1,172 @@
+"""Azure DevOps module — orchestrates read-only backlog access for one project.
+
+Reads service-principal credentials and the single allowed project from the
+environment, builds an AzureDevOpsClient, and exposes high-level read operations
+consumed by the MCP tools. The project is fixed here; no operation accepts a
+caller-supplied project.
+"""
+
+import logging
+import os
+
+from .client import AzureDevOpsClient
+
+logger = logging.getLogger("azuredevops-mcp")
+
+# Fields we surface for list/detail views. System.* are the built-in fields.
+_SUMMARY_FIELDS = [
+    "System.Id",
+    "System.Title",
+    "System.WorkItemType",
+    "System.State",
+]
+_DETAIL_FIELDS = _SUMMARY_FIELDS + [
+    "System.Description",
+    "System.AssignedTo",
+    "System.CreatedDate",
+    "System.ChangedDate",
+    "System.Tags",
+]
+
+
+def _wiql_escape(value: str) -> str:
+    """Escape a string literal for safe inclusion in a WIQL single-quoted value."""
+    return value.replace("'", "''")
+
+
+class AzureDevOpsModule:
+    """High-level read-only backlog operations for the configured project."""
+
+    def __init__(self) -> None:
+        self._project = os.getenv("AZURE_DEVOPS_PROJECT", "").strip()
+        org_url = os.getenv("AZURE_DEVOPS_ORG_URL", "").strip()
+        tenant_id = os.getenv("AZURE_DEVOPS_TENANT_ID", "").strip()
+        client_id = os.getenv("AZURE_DEVOPS_CLIENT_ID", "").strip()
+        client_secret = os.getenv("AZURE_DEVOPS_CLIENT_SECRET", "").strip()
+
+        missing = [
+            name
+            for name, val in [
+                ("AZURE_DEVOPS_ORG_URL", org_url),
+                ("AZURE_DEVOPS_PROJECT", self._project),
+                ("AZURE_DEVOPS_TENANT_ID", tenant_id),
+                ("AZURE_DEVOPS_CLIENT_ID", client_id),
+                ("AZURE_DEVOPS_CLIENT_SECRET", client_secret),
+            ]
+            if not val
+        ]
+        if missing:
+            # Fail fast at startup rather than half-configured at request time.
+            raise ValueError(
+                "Azure DevOps MCP is misconfigured; missing env vars: "
+                + ", ".join(missing)
+            )
+
+        self._client = AzureDevOpsClient(
+            org_url=org_url,
+            project=self._project,
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        logger.info("Azure DevOps MCP bound to project '%s'", self._project)
+
+    @property
+    def project(self) -> str:
+        return self._project
+
+    def _project_clause(self) -> str:
+        return f"[System.TeamProject] = '{_wiql_escape(self._project)}'"
+
+    @staticmethod
+    def _summary(item: dict) -> dict:
+        f = item.get("fields", {})
+        return {
+            "id": item.get("id"),
+            "title": f.get("System.Title"),
+            "type": f.get("System.WorkItemType"),
+            "state": f.get("System.State"),
+        }
+
+    async def list_backlog_items(
+        self,
+        work_item_type: str | None = None,
+        state: str | None = None,
+        limit: int = 100,
+    ) -> dict:
+        """List work items in the configured project, newest first."""
+        clauses = [self._project_clause()]
+        if work_item_type:
+            clauses.append(
+                f"[System.WorkItemType] = '{_wiql_escape(work_item_type)}'"
+            )
+        if state:
+            clauses.append(f"[System.State] = '{_wiql_escape(state)}'")
+
+        wiql = (
+            "SELECT [System.Id] FROM WorkItems WHERE "
+            + " AND ".join(clauses)
+            + " ORDER BY [System.ChangedDate] DESC"
+        )
+        try:
+            ids = await self._client.query_wiql(wiql, top=limit)
+            items = await self._client.get_work_items(ids, fields=_SUMMARY_FIELDS)
+            return {
+                "success": True,
+                "project": self._project,
+                "items": [self._summary(i) for i in items],
+                "count": len(items),
+            }
+        except Exception as exc:  # noqa: BLE001 — surface a clean error to the agent
+            logger.warning("list_backlog_items failed: %s", exc)
+            return {"success": False, "error": str(exc)}
+
+    async def get_work_item(self, item_id: int) -> dict:
+        """Return full detail for one work item in the configured project."""
+        try:
+            item = await self._client.get_work_item(item_id)
+            f = item.get("fields", {})
+            assigned = f.get("System.AssignedTo")
+            if isinstance(assigned, dict):
+                assigned = assigned.get("displayName")
+            return {
+                "success": True,
+                "project": self._project,
+                "item": {
+                    "id": item.get("id"),
+                    "title": f.get("System.Title"),
+                    "type": f.get("System.WorkItemType"),
+                    "state": f.get("System.State"),
+                    "description": f.get("System.Description"),
+                    "assigned_to": assigned,
+                    "tags": f.get("System.Tags"),
+                    "created_date": f.get("System.CreatedDate"),
+                    "changed_date": f.get("System.ChangedDate"),
+                },
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("get_work_item(%s) failed: %s", item_id, exc)
+            return {"success": False, "error": str(exc)}
+
+    async def search_work_items(self, text: str, limit: int = 50) -> dict:
+        """Find work items whose title or description contains `text`."""
+        needle = _wiql_escape(text)
+        wiql = (
+            "SELECT [System.Id] FROM WorkItems WHERE "
+            + self._project_clause()
+            + f" AND ([System.Title] CONTAINS '{needle}'"
+            + f" OR [System.Description] CONTAINS '{needle}')"
+            + " ORDER BY [System.ChangedDate] DESC"
+        )
+        try:
+            ids = await self._client.query_wiql(wiql, top=limit)
+            items = await self._client.get_work_items(ids, fields=_SUMMARY_FIELDS)
+            return {
+                "success": True,
+                "project": self._project,
+                "items": [self._summary(i) for i in items],
+                "count": len(items),
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("search_work_items failed: %s", exc)
+            return {"success": False, "error": str(exc)}

--- a/druppie/mcp-servers/module-azuredevops/v1/module.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/module.py
@@ -1,4 +1,4 @@
-"""Azure DevOps module — orchestrates read-only backlog access for one project.
+"""Azure DevOps module — orchestrates backlog access for one project.
 
 Reads service-principal credentials and the single allowed project from the
 environment, builds an AzureDevOpsClient, and exposes high-level read operations
@@ -32,6 +32,19 @@ _DETAIL_FIELDS = _SUMMARY_FIELDS + [
     "System.BoardColumnDone",
 ]
 
+VALID_WORK_ITEM_TYPES = {"Epic", "Feature", "Product Backlog Item", "Task", "Bug"}
+
+_FIELD_MAP = {
+    "title": "System.Title",
+    "description": "System.Description",
+    "state": "System.State",
+    "assigned_to": "System.AssignedTo",
+    "iteration": "System.IterationPath",
+    "area_path": "System.AreaPath",
+    "effort": "Microsoft.VSTS.Scheduling.Effort",
+    "tags": "System.Tags",
+}
+
 
 def _wiql_escape(value: str) -> str:
     return value.replace("'", "''")
@@ -44,7 +57,7 @@ def _display_name(field_value) -> str | None:
 
 
 class AzureDevOpsModule:
-    """High-level read-only backlog operations for the configured project."""
+    """High-level backlog operations for the configured project."""
 
     def __init__(self) -> None:
         self._project = os.getenv("AZURE_DEVOPS_PROJECT", "").strip()
@@ -376,4 +389,136 @@ class AzureDevOpsModule:
             }
         except Exception as exc:
             logger.warning("search_work_items failed: %s", exc)
+            return {"success": False, "error": str(exc)}
+
+    @staticmethod
+    def _build_patch_operations(fields: dict) -> list[dict]:
+        ops = []
+        for key, value in fields.items():
+            if value is None:
+                continue
+            ado_path = _FIELD_MAP.get(key)
+            if ado_path is None:
+                continue
+            ops.append({
+                "op": "add",
+                "path": f"/fields/{ado_path}",
+                "value": value,
+            })
+        return ops
+
+    async def create_work_item(
+        self,
+        work_item_type: str,
+        title: str,
+        description: str | None = None,
+        state: str | None = None,
+        assigned_to: str | None = None,
+        iteration: str | None = None,
+        area_path: str | None = None,
+        effort: float | None = None,
+        tags: str | None = None,
+        parent_id: int | None = None,
+    ) -> dict:
+        """Create a new work item in the configured project."""
+        if work_item_type not in VALID_WORK_ITEM_TYPES:
+            return {
+                "success": False,
+                "error": f"Invalid work item type '{work_item_type}'. "
+                         f"Valid types: {', '.join(sorted(VALID_WORK_ITEM_TYPES))}",
+            }
+
+        fields = {
+            "title": title,
+            "description": description,
+            "state": state,
+            "assigned_to": assigned_to,
+            "iteration": iteration,
+            "area_path": area_path,
+            "effort": effort,
+            "tags": tags,
+        }
+        operations = self._build_patch_operations(fields)
+
+        if parent_id is not None:
+            operations.append({
+                "op": "add",
+                "path": "/relations/-",
+                "value": {
+                    "rel": "System.LinkTypes.Hierarchy-Reverse",
+                    "url": f"{self._client.org_url}/_apis/wit/workitems/{parent_id}",
+                },
+            })
+
+        try:
+            result = await self._client.create_work_item(work_item_type, operations)
+            return {
+                "success": True,
+                "project": self._project,
+                "item": {
+                    "id": result.get("id"),
+                    "title": result.get("fields", {}).get("System.Title"),
+                    "type": result.get("fields", {}).get("System.WorkItemType"),
+                    "state": result.get("fields", {}).get("System.State"),
+                    "url": result.get("_links", {}).get("html", {}).get("href"),
+                },
+            }
+        except Exception as exc:
+            logger.warning("create_work_item failed: %s", exc)
+            return {"success": False, "error": str(exc)}
+
+    async def update_work_item(
+        self,
+        item_id: int,
+        title: str | None = None,
+        description: str | None = None,
+        state: str | None = None,
+        assigned_to: str | None = None,
+        iteration: str | None = None,
+        area_path: str | None = None,
+        effort: float | None = None,
+        tags: str | None = None,
+        parent_id: int | None = None,
+    ) -> dict:
+        """Update an existing work item in the configured project."""
+        fields = {
+            "title": title,
+            "description": description,
+            "state": state,
+            "assigned_to": assigned_to,
+            "iteration": iteration,
+            "area_path": area_path,
+            "effort": effort,
+            "tags": tags,
+        }
+        operations = self._build_patch_operations(fields)
+
+        if parent_id is not None:
+            operations.append({
+                "op": "add",
+                "path": "/relations/-",
+                "value": {
+                    "rel": "System.LinkTypes.Hierarchy-Reverse",
+                    "url": f"{self._client.org_url}/_apis/wit/workitems/{parent_id}",
+                },
+            })
+
+        if not operations:
+            return {"success": False, "error": "No fields to update."}
+
+        try:
+            result = await self._client.update_work_item(item_id, operations)
+            return {
+                "success": True,
+                "project": self._project,
+                "item": {
+                    "id": result.get("id"),
+                    "title": result.get("fields", {}).get("System.Title"),
+                    "type": result.get("fields", {}).get("System.WorkItemType"),
+                    "state": result.get("fields", {}).get("System.State"),
+                    "url": result.get("_links", {}).get("html", {}).get("href"),
+                },
+            }
+        except Exception as exc:
+            logger.warning("update_work_item(%s) failed: %s", item_id, exc)
             return {"success": False, "error": str(exc)}

--- a/druppie/mcp-servers/module-azuredevops/v1/module.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/module.py
@@ -8,30 +8,39 @@ caller-supplied project.
 
 import logging
 import os
+from datetime import datetime, timezone
 
 from .client import AzureDevOpsClient
 
 logger = logging.getLogger("azuredevops-mcp")
 
-# Fields we surface for list/detail views. System.* are the built-in fields.
 _SUMMARY_FIELDS = [
     "System.Id",
     "System.Title",
     "System.WorkItemType",
     "System.State",
+    "System.BoardColumn",
+    "System.IterationPath",
+    "System.AssignedTo",
+    "Microsoft.VSTS.Scheduling.Effort",
 ]
 _DETAIL_FIELDS = _SUMMARY_FIELDS + [
     "System.Description",
-    "System.AssignedTo",
     "System.CreatedDate",
     "System.ChangedDate",
     "System.Tags",
+    "System.BoardColumnDone",
 ]
 
 
 def _wiql_escape(value: str) -> str:
-    """Escape a string literal for safe inclusion in a WIQL single-quoted value."""
     return value.replace("'", "''")
+
+
+def _display_name(field_value) -> str | None:
+    if isinstance(field_value, dict):
+        return field_value.get("displayName")
+    return field_value
 
 
 class AzureDevOpsModule:
@@ -56,7 +65,6 @@ class AzureDevOpsModule:
             if not val
         ]
         if missing:
-            # Fail fast at startup rather than half-configured at request time.
             raise ValueError(
                 "Azure DevOps MCP is misconfigured; missing env vars: "
                 + ", ".join(missing)
@@ -86,12 +94,58 @@ class AzureDevOpsModule:
             "title": f.get("System.Title"),
             "type": f.get("System.WorkItemType"),
             "state": f.get("System.State"),
+            "board_column": f.get("System.BoardColumn"),
+            "iteration": f.get("System.IterationPath"),
+            "assigned_to": _display_name(f.get("System.AssignedTo")),
+            "effort": f.get("Microsoft.VSTS.Scheduling.Effort"),
         }
+
+    def _extract_id_from_url(self, url: str) -> int | None:
+        try:
+            return int(url.rstrip("/").split("/")[-1])
+        except (ValueError, IndexError):
+            return None
+
+    async def get_current_sprint(self) -> dict:
+        """Return info about the current sprint (iteration) based on today's date."""
+        try:
+            iterations = await self._client.get_team_iterations()
+            now = datetime.now(timezone.utc)
+            current = None
+            all_sprints = []
+            for it in iterations:
+                attrs = it.get("attributes", {})
+                start = attrs.get("startDate")
+                end = attrs.get("finishDate")
+                sprint_info = {
+                    "name": it.get("name"),
+                    "path": it.get("path"),
+                    "start_date": start,
+                    "end_date": end,
+                }
+                all_sprints.append(sprint_info)
+                if start and end:
+                    start_dt = datetime.fromisoformat(start.replace("Z", "+00:00"))
+                    end_dt = datetime.fromisoformat(end.replace("Z", "+00:00"))
+                    if start_dt <= now <= end_dt:
+                        current = sprint_info
+            return {
+                "success": True,
+                "project": self._project,
+                "current_sprint": current,
+                "all_sprints": all_sprints,
+            }
+        except Exception as exc:
+            logger.warning("get_current_sprint failed: %s", exc)
+            return {"success": False, "error": str(exc)}
 
     async def list_backlog_items(
         self,
         work_item_type: str | None = None,
         state: str | None = None,
+        board_column: str | None = None,
+        iteration: str | None = None,
+        assigned_to: str | None = None,
         limit: int = 100,
     ) -> dict:
         """List work items in the configured project, newest first."""
@@ -102,6 +156,18 @@ class AzureDevOpsModule:
             )
         if state:
             clauses.append(f"[System.State] = '{_wiql_escape(state)}'")
+        if board_column:
+            clauses.append(
+                f"[System.BoardColumn] = '{_wiql_escape(board_column)}'"
+            )
+        if iteration:
+            clauses.append(
+                f"[System.IterationPath] = '{_wiql_escape(iteration)}'"
+            )
+        if assigned_to:
+            clauses.append(
+                f"[System.AssignedTo] CONTAINS '{_wiql_escape(assigned_to)}'"
+            )
 
         wiql = (
             "SELECT [System.Id] FROM WorkItems WHERE "
@@ -117,18 +183,70 @@ class AzureDevOpsModule:
                 "items": [self._summary(i) for i in items],
                 "count": len(items),
             }
-        except Exception as exc:  # noqa: BLE001 — surface a clean error to the agent
+        except Exception as exc:
             logger.warning("list_backlog_items failed: %s", exc)
             return {"success": False, "error": str(exc)}
 
     async def get_work_item(self, item_id: int) -> dict:
-        """Return full detail for one work item in the configured project."""
+        """Return full detail for one work item, including parent and children."""
         try:
             item = await self._client.get_work_item(item_id)
             f = item.get("fields", {})
-            assigned = f.get("System.AssignedTo")
-            if isinstance(assigned, dict):
-                assigned = assigned.get("displayName")
+
+            parent_id = None
+            child_ids = []
+            for rel in item.get("relations", []):
+                rel_type = rel.get("rel", "")
+                linked_id = self._extract_id_from_url(rel.get("url", ""))
+                if not linked_id:
+                    continue
+                if rel_type == "System.LinkTypes.Hierarchy-Reverse":
+                    parent_id = linked_id
+                elif rel_type == "System.LinkTypes.Hierarchy-Forward":
+                    child_ids.append(linked_id)
+
+            parent = None
+            if parent_id:
+                try:
+                    parent_items = await self._client.get_work_items(
+                        [parent_id],
+                        fields=["System.Id", "System.Title", "System.WorkItemType", "System.State"],
+                    )
+                    if parent_items:
+                        pf = parent_items[0].get("fields", {})
+                        parent = {
+                            "id": parent_items[0].get("id"),
+                            "title": pf.get("System.Title"),
+                            "type": pf.get("System.WorkItemType"),
+                            "state": pf.get("System.State"),
+                        }
+                except Exception:
+                    pass
+
+            children = []
+            if child_ids:
+                try:
+                    child_items = await self._client.get_work_items(
+                        child_ids,
+                        fields=[
+                            "System.Id", "System.Title", "System.WorkItemType",
+                            "System.State", "System.AssignedTo",
+                            "Microsoft.VSTS.Scheduling.Effort",
+                        ],
+                    )
+                    for ch in child_items:
+                        cf = ch.get("fields", {})
+                        children.append({
+                            "id": ch.get("id"),
+                            "title": cf.get("System.Title"),
+                            "type": cf.get("System.WorkItemType"),
+                            "state": cf.get("System.State"),
+                            "assigned_to": _display_name(cf.get("System.AssignedTo")),
+                            "effort": cf.get("Microsoft.VSTS.Scheduling.Effort"),
+                        })
+                except Exception:
+                    pass
+
             return {
                 "success": True,
                 "project": self._project,
@@ -137,15 +255,104 @@ class AzureDevOpsModule:
                     "title": f.get("System.Title"),
                     "type": f.get("System.WorkItemType"),
                     "state": f.get("System.State"),
+                    "board_column": f.get("System.BoardColumn"),
+                    "board_column_done": f.get("System.BoardColumnDone"),
+                    "iteration": f.get("System.IterationPath"),
+                    "effort": f.get("Microsoft.VSTS.Scheduling.Effort"),
                     "description": f.get("System.Description"),
-                    "assigned_to": assigned,
+                    "assigned_to": _display_name(f.get("System.AssignedTo")),
                     "tags": f.get("System.Tags"),
                     "created_date": f.get("System.CreatedDate"),
                     "changed_date": f.get("System.ChangedDate"),
+                    "parent": parent,
+                    "children": children,
+                    "children_summary": self._children_summary(children) if children else None,
                 },
             }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.warning("get_work_item(%s) failed: %s", item_id, exc)
+            return {"success": False, "error": str(exc)}
+
+    @staticmethod
+    def _children_summary(children: list[dict]) -> dict:
+        """Compute progress summary from child work items."""
+        total = len(children)
+        done = sum(1 for c in children if c.get("state") == "Done")
+        in_progress = sum(1 for c in children if c.get("state") == "In Progress")
+        return {
+            "total": total,
+            "done": done,
+            "in_progress": in_progress,
+            "remaining": total - done,
+            "completion_pct": round(done / total * 100) if total else 0,
+        }
+
+    async def get_sprint_summary(self, iteration: str) -> dict:
+        """Aggregate sprint-level stats: effort by person, by board column, progress."""
+        try:
+            clauses = [
+                self._project_clause(),
+                f"[System.IterationPath] = '{_wiql_escape(iteration)}'",
+                "[System.State] <> 'Removed'",
+            ]
+            wiql = (
+                "SELECT [System.Id] FROM WorkItems WHERE "
+                + " AND ".join(clauses)
+                + " ORDER BY [System.ChangedDate] DESC"
+            )
+            ids = await self._client.query_wiql(wiql, top=200)
+            items = await self._client.get_work_items(ids, fields=_SUMMARY_FIELDS)
+
+            by_type: dict[str, list] = {}
+            by_board: dict[str, list] = {}
+            by_person: dict[str, dict] = {}
+            by_state: dict[str, int] = {}
+            total_effort = 0.0
+            done_effort = 0.0
+
+            for item in items:
+                s = self._summary(item)
+                wit = s["type"] or "Unknown"
+                board = s["board_column"] or "(none)"
+                state = s["state"] or "Unknown"
+                person = s["assigned_to"] or "(unassigned)"
+                effort = s["effort"] or 0
+
+                by_type.setdefault(wit, []).append(s)
+                by_board.setdefault(board, []).append(s)
+                by_state[state] = by_state.get(state, 0) + 1
+
+                if wit == "Product Backlog Item":
+                    total_effort += effort
+                    if state == "Done" or board == "Done":
+                        done_effort += effort
+
+                    if person not in by_person:
+                        by_person[person] = {"total_effort": 0, "done_effort": 0, "items": 0, "done_items": 0}
+                    by_person[person]["total_effort"] += effort
+                    by_person[person]["items"] += 1
+                    if state == "Done" or board == "Done":
+                        by_person[person]["done_effort"] += effort
+                        by_person[person]["done_items"] += 1
+
+            return {
+                "success": True,
+                "project": self._project,
+                "iteration": iteration,
+                "total_items": len(items),
+                "by_state": by_state,
+                "by_board_column": {col: len(items_list) for col, items_list in by_board.items()},
+                "by_type": {t: len(items_list) for t, items_list in by_type.items()},
+                "effort_summary": {
+                    "total_pbi_effort": total_effort,
+                    "done_pbi_effort": done_effort,
+                    "remaining_pbi_effort": total_effort - done_effort,
+                    "completion_pct": round(done_effort / total_effort * 100) if total_effort else 0,
+                },
+                "by_person": by_person,
+            }
+        except Exception as exc:
+            logger.warning("get_sprint_summary failed: %s", exc)
             return {"success": False, "error": str(exc)}
 
     async def search_work_items(self, text: str, limit: int = 50) -> dict:
@@ -167,6 +374,6 @@ class AzureDevOpsModule:
                 "items": [self._summary(i) for i in items],
                 "count": len(items),
             }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.warning("search_work_items failed: %s", exc)
             return {"success": False, "error": str(exc)}

--- a/druppie/mcp-servers/module-azuredevops/v1/tools.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/tools.py
@@ -1,0 +1,81 @@
+"""Azure DevOps v1 — MCP Tool Definitions.
+
+Read-only access to backlog / work items of a SINGLE Azure DevOps project. The
+project is fixed by server configuration (AZURE_DEVOPS_PROJECT) and is never a
+tool argument, so an agent cannot read any other project in the organization.
+
+There is deliberately NO list_projects tool and no project parameter anywhere.
+"""
+
+import logging
+
+from fastmcp import FastMCP
+
+from .module import AzureDevOpsModule
+
+logger = logging.getLogger("azuredevops-mcp")
+
+MODULE_ID = "azuredevops"
+MODULE_VERSION = "1.0.0"
+
+mcp = FastMCP(
+    "Azure DevOps v1",
+    version=MODULE_VERSION,
+    instructions=(
+        "Read-only access to the backlog and work items of a single, "
+        "pre-configured Azure DevOps project. You cannot choose or list other "
+        "projects — every tool operates on the one configured project."
+    ),
+)
+
+# Built once at import; raises (and stops the server) if creds/project are unset.
+module = AzureDevOpsModule()
+
+
+@mcp.tool()
+async def list_backlog_items(
+    work_item_type: str | None = None,
+    state: str | None = None,
+    limit: int = 100,
+) -> dict:
+    """List backlog / work items from the configured Azure DevOps project.
+
+    Items are returned newest-changed first. Use get_work_item() for full detail.
+
+    Args:
+        work_item_type: Optional filter, e.g. "User Story", "Bug", "Task", "Epic".
+        state: Optional state filter, e.g. "New", "Active", "Closed".
+        limit: Maximum number of items to return (default 100).
+
+    Returns:
+        Dict with the project name and a list of items (id, title, type, state).
+    """
+    return await module.list_backlog_items(work_item_type, state, limit)
+
+
+@mcp.tool()
+async def get_work_item(item_id: int) -> dict:
+    """Read full detail of one work item in the configured project.
+
+    Args:
+        item_id: The work item id (from list_backlog_items / search_work_items).
+
+    Returns:
+        Dict with the item's title, type, state, description, assignee, tags,
+        and timestamps. Ids that belong to another project return an error.
+    """
+    return await module.get_work_item(item_id)
+
+
+@mcp.tool()
+async def search_work_items(text: str, limit: int = 50) -> dict:
+    """Search work items in the configured project by title/description text.
+
+    Args:
+        text: Free text to match against title or description.
+        limit: Maximum number of items to return (default 50).
+
+    Returns:
+        Dict with the project name and matching items (id, title, type, state).
+    """
+    return await module.search_work_items(text, limit)

--- a/druppie/mcp-servers/module-azuredevops/v1/tools.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/tools.py
@@ -87,7 +87,7 @@ async def list_backlog_items(
         state: Optional state filter, e.g. "New", "Approved", "Committed", "In Progress", "Done".
         board_column: Optional board column filter (the lane on the board view), e.g. "New", "In Progress", "In Review", "Ready", "Done". Note: board_column can differ from state.
         iteration: Optional iteration/sprint path filter, e.g. "AI-platform\\Sprint 11". Use get_current_sprint() to find the current sprint path.
-        assigned_to: Optional filter by assignee name (partial match), e.g. "Nuno" or "Kraljevic".
+        assigned_to: Optional filter by assignee name (partial match), e.g. "Jane" or "Doe".
         limit: Maximum number of items to return (default 100).
 
     Returns:
@@ -161,7 +161,7 @@ async def create_work_item(
         title: Title of the work item (required).
         description: HTML description of the work item.
         state: Initial state, e.g. "New", "Approved". Defaults to "New".
-        assigned_to: Display name of the assignee, e.g. "Nuno Kraljevic".
+        assigned_to: Display name of the assignee, e.g. "Jane Doe".
         iteration: Iteration/sprint path, e.g. "AI-platform\\Sprint 11".
             Use get_current_sprint() to find available paths.
         area_path: Area path for classification. Defaults to project root.

--- a/druppie/mcp-servers/module-azuredevops/v1/tools.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/tools.py
@@ -28,41 +28,89 @@ mcp = FastMCP(
     ),
 )
 
-# Built once at import; raises (and stops the server) if creds/project are unset.
 module = AzureDevOpsModule()
+
+
+@mcp.tool()
+async def get_current_sprint() -> dict:
+    """Get the current sprint (iteration) and all configured sprints.
+
+    Returns the sprint that contains today's date as current_sprint, plus the
+    full list of sprints with their date ranges. Use the sprint path (e.g.
+    "AI-platform\\Sprint 11") as the iteration parameter in list_backlog_items
+    to scope queries to a specific sprint.
+
+    Returns:
+        Dict with current_sprint (name, path, start/end dates) and all_sprints.
+    """
+    return await module.get_current_sprint()
+
+
+@mcp.tool()
+async def get_sprint_summary(iteration: str) -> dict:
+    """Get an aggregated summary of a sprint: effort by person, board column
+    distribution, completion percentage, and item counts by type and state.
+
+    Use get_current_sprint() first to find the iteration path for the current sprint.
+
+    Args:
+        iteration: The iteration path, e.g. "AI-platform\\Sprint 11".
+
+    Returns:
+        Dict with total_items, by_state counts, by_board_column counts, by_type
+        counts, effort_summary (total/done/remaining PBI effort + completion %),
+        and by_person breakdown (effort and item counts per team member).
+    """
+    return await module.get_sprint_summary(iteration)
 
 
 @mcp.tool()
 async def list_backlog_items(
     work_item_type: str | None = None,
     state: str | None = None,
+    board_column: str | None = None,
+    iteration: str | None = None,
+    assigned_to: str | None = None,
     limit: int = 100,
 ) -> dict:
     """List backlog / work items from the configured Azure DevOps project.
 
-    Items are returned newest-changed first. Use get_work_item() for full detail.
+    Items are returned newest-changed first. Use get_work_item() for full detail
+    including parent/child hierarchy and task progress.
 
     Args:
-        work_item_type: Optional filter, e.g. "User Story", "Bug", "Task", "Epic".
-        state: Optional state filter, e.g. "New", "Active", "Closed".
+        work_item_type: Optional filter, e.g. "Product Backlog Item", "Bug", "Task", "Feature", "Epic".
+        state: Optional state filter, e.g. "New", "Approved", "Committed", "In Progress", "Done".
+        board_column: Optional board column filter (the lane on the board view), e.g. "New", "In Progress", "In Review", "Ready", "Done". Note: board_column can differ from state.
+        iteration: Optional iteration/sprint path filter, e.g. "AI-platform\\Sprint 11". Use get_current_sprint() to find the current sprint path.
+        assigned_to: Optional filter by assignee name (partial match), e.g. "Nuno" or "Kraljevic".
         limit: Maximum number of items to return (default 100).
 
     Returns:
-        Dict with the project name and a list of items (id, title, type, state).
+        Dict with items (id, title, type, state, board_column, iteration, assigned_to, effort).
     """
-    return await module.list_backlog_items(work_item_type, state, limit)
+    return await module.list_backlog_items(work_item_type, state, board_column, iteration, assigned_to, limit)
 
 
 @mcp.tool()
 async def get_work_item(item_id: int) -> dict:
-    """Read full detail of one work item in the configured project.
+    """Read full detail of one work item including its parent and children.
+
+    The hierarchy in this project is: Epic → Feature → Product Backlog Item → Task.
+    - Features span multiple sprints and describe high-level goals.
+    - Product Backlog Items (PBIs) are the main board unit and contain implementation details.
+    - Tasks are children of PBIs and track granular progress.
+
+    The response includes:
+    - parent: the parent work item (e.g. a PBI's parent Feature)
+    - children: child work items (e.g. a PBI's Tasks or a Feature's PBIs)
+    - children_summary: progress stats (total, done, in_progress, remaining, completion_pct)
 
     Args:
-        item_id: The work item id (from list_backlog_items / search_work_items).
+        item_id: The work item id.
 
     Returns:
-        Dict with the item's title, type, state, description, assignee, tags,
-        and timestamps. Ids that belong to another project return an error.
+        Dict with full item detail, parent, children, and children_summary.
     """
     return await module.get_work_item(item_id)
 
@@ -76,6 +124,6 @@ async def search_work_items(text: str, limit: int = 50) -> dict:
         limit: Maximum number of items to return (default 50).
 
     Returns:
-        Dict with the project name and matching items (id, title, type, state).
+        Dict with the project name and matching items.
     """
     return await module.search_work_items(text, limit)

--- a/druppie/mcp-servers/module-azuredevops/v1/tools.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/tools.py
@@ -1,8 +1,11 @@
 """Azure DevOps v1 — MCP Tool Definitions.
 
-Read-only access to backlog / work items of a SINGLE Azure DevOps project. The
-project is fixed by server configuration (AZURE_DEVOPS_PROJECT) and is never a
-tool argument, so an agent cannot read any other project in the organization.
+Access to backlog / work items of a SINGLE Azure DevOps project. The project is
+fixed by server configuration (AZURE_DEVOPS_PROJECT) and is never a tool
+argument, so an agent cannot access any other project in the organization.
+
+Write tools (create_work_item, update_work_item) are gated by HITL approval in
+the Druppie orchestration layer — they require human confirmation before executing.
 
 There is deliberately NO list_projects tool and no project parameter anywhere.
 """
@@ -22,9 +25,10 @@ mcp = FastMCP(
     "Azure DevOps v1",
     version=MODULE_VERSION,
     instructions=(
-        "Read-only access to the backlog and work items of a single, "
-        "pre-configured Azure DevOps project. You cannot choose or list other "
-        "projects — every tool operates on the one configured project."
+        "Access to the backlog and work items of a single, pre-configured "
+        "Azure DevOps project. You cannot choose or list other projects — "
+        "every tool operates on the one configured project. Write operations "
+        "(create, update) require human approval before execution."
     ),
 )
 
@@ -127,3 +131,110 @@ async def search_work_items(text: str, limit: int = 50) -> dict:
         Dict with the project name and matching items.
     """
     return await module.search_work_items(text, limit)
+
+
+@mcp.tool()
+async def create_work_item(
+    work_item_type: str,
+    title: str,
+    description: str | None = None,
+    state: str | None = None,
+    assigned_to: str | None = None,
+    iteration: str | None = None,
+    area_path: str | None = None,
+    effort: float | None = None,
+    tags: str | None = None,
+    parent_id: int | None = None,
+) -> dict:
+    """Create a new work item in the configured Azure DevOps project.
+
+    This tool requires human approval before execution. The approver will
+    see all the fields you provide, so include a clear title and description.
+
+    The hierarchy is: Epic > Feature > Product Backlog Item > Task > Bug.
+    Use parent_id to place the new item under an existing parent (e.g., set
+    parent_id to a Feature's id when creating a Product Backlog Item).
+
+    Args:
+        work_item_type: Type of work item. One of: "Epic", "Feature",
+            "Product Backlog Item", "Task", "Bug".
+        title: Title of the work item (required).
+        description: HTML description of the work item.
+        state: Initial state, e.g. "New", "Approved". Defaults to "New".
+        assigned_to: Display name of the assignee, e.g. "Nuno Kraljevic".
+        iteration: Iteration/sprint path, e.g. "AI-platform\\Sprint 11".
+            Use get_current_sprint() to find available paths.
+        area_path: Area path for classification. Defaults to project root.
+        effort: Story points (numeric). Typically used on PBIs.
+        tags: Semicolon-separated tags, e.g. "backend; api; urgent".
+        parent_id: Work item id of the parent to link under.
+
+    Returns:
+        Dict with success status and created item (id, title, type, state, url).
+    """
+    return await module.create_work_item(
+        work_item_type=work_item_type,
+        title=title,
+        description=description,
+        state=state,
+        assigned_to=assigned_to,
+        iteration=iteration,
+        area_path=area_path,
+        effort=effort,
+        tags=tags,
+        parent_id=parent_id,
+    )
+
+
+@mcp.tool()
+async def update_work_item(
+    item_id: int,
+    title: str | None = None,
+    description: str | None = None,
+    state: str | None = None,
+    assigned_to: str | None = None,
+    iteration: str | None = None,
+    area_path: str | None = None,
+    effort: float | None = None,
+    tags: str | None = None,
+    parent_id: int | None = None,
+) -> dict:
+    """Update an existing work item in the configured Azure DevOps project.
+
+    This tool requires human approval before execution. The approver will
+    see which fields you are changing, so only include fields you want to
+    modify — omitted fields are left unchanged.
+
+    Use get_work_item(item_id) first to see the current values before
+    making changes.
+
+    Args:
+        item_id: The id of the work item to update.
+        title: New title (omit to keep current).
+        description: New HTML description (omit to keep current).
+        state: New state, e.g. "New", "Approved", "Committed", "Done"
+            (omit to keep current).
+        assigned_to: New assignee display name (omit to keep current).
+        iteration: New iteration/sprint path (omit to keep current).
+        area_path: New area path (omit to keep current).
+        effort: New effort/story points (omit to keep current).
+        tags: New semicolon-separated tags. This REPLACES all existing
+            tags (omit to keep current).
+        parent_id: Add a parent link to this work item id. Note: this
+            adds a NEW parent link; it does not remove existing parents.
+
+    Returns:
+        Dict with success status and updated item (id, title, type, state, url).
+    """
+    return await module.update_work_item(
+        item_id=item_id,
+        title=title,
+        description=description,
+        state=state,
+        assigned_to=assigned_to,
+        iteration=iteration,
+        area_path=area_path,
+        effort=effort,
+        tags=tags,
+        parent_id=parent_id,
+    )

--- a/druppie/tests/test_azuredevops_isolation.py
+++ b/druppie/tests/test_azuredevops_isolation.py
@@ -1,0 +1,224 @@
+"""Isolation tests for the azuredevops MCP server.
+
+The whole point of this module is that an agent can read backlog / work items
+from exactly ONE configured Azure DevOps project and can never reach another
+project. These tests pin that guarantee from two angles:
+
+1. Static (tools.py): there is no project picker — no `list_projects` tool and
+   no tool parameter that lets the caller choose a project / org.
+2. Behavioral (module.py + client.py): every request the module issues is
+   path-scoped to AZURE_DEVOPS_PROJECT and every WIQL query carries the
+   [System.TeamProject] = '<project>' clause.
+
+The module-server tree (`druppie/mcp-servers/module-azuredevops`) is a
+standalone service: it depends on `httpx` and `azure-identity`, which are NOT
+installed in the main druppie test environment, and `tools.py` additionally
+needs `fastmcp`. We therefore stub the network/auth deps and load the source by
+path, mirroring `test_dataaccess_charts.py`.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_MOD_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "mcp-servers"
+    / "module-azuredevops"
+)
+_PROJECT = "TheOnlyProject"
+
+
+# ---------------------------------------------------------------------------
+# Static check — tools.py exposes no project picker
+# ---------------------------------------------------------------------------
+
+def _tool_functions(source_path: Path) -> dict[str, ast.AsyncFunctionDef]:
+    """Return {name: node} for every @mcp.tool()-decorated async function."""
+    tree = ast.parse(source_path.read_text())
+    tools: dict[str, ast.AsyncFunctionDef] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        for dec in node.decorator_list:
+            # Matches @mcp.tool() and @mcp.tool
+            func = dec.func if isinstance(dec, ast.Call) else dec
+            if isinstance(func, ast.Attribute) and func.attr == "tool":
+                tools[node.name] = node
+    return tools
+
+
+def test_tools_expose_exactly_the_three_read_tools():
+    tools = _tool_functions(_MOD_DIR / "v1" / "tools.py")
+    assert set(tools) == {
+        "list_backlog_items",
+        "get_work_item",
+        "search_work_items",
+    }
+
+
+def test_no_project_picker_tool():
+    tools = _tool_functions(_MOD_DIR / "v1" / "tools.py")
+    # A tool that lists or selects projects would break single-project isolation.
+    assert "list_projects" not in tools
+    assert not any("project" in name for name in tools)
+
+
+def test_no_tool_accepts_a_project_or_org_argument():
+    tools = _tool_functions(_MOD_DIR / "v1" / "tools.py")
+    forbidden = {"project", "project_id", "project_name", "org", "org_url", "organization"}
+    for name, node in tools.items():
+        params = {a.arg for a in node.args.args}
+        leaked = params & forbidden
+        assert not leaked, f"tool {name} exposes project/org argument(s): {leaked}"
+
+
+# ---------------------------------------------------------------------------
+# Behavioral check — every request is scoped to the configured project
+# ---------------------------------------------------------------------------
+
+def _install_dep_stubs() -> None:
+    """Provide minimal stand-ins for httpx + azure-identity (not installed here)."""
+    if "httpx" not in sys.modules:
+        httpx = types.ModuleType("httpx")
+
+        class _AsyncClient:  # pragma: no cover - never actually used (we patch _post/_get)
+            def __init__(self, *a, **k):
+                ...
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+        httpx.AsyncClient = _AsyncClient
+        sys.modules["httpx"] = httpx
+
+    if "azure.identity.aio" not in sys.modules:
+        azure = sys.modules.setdefault("azure", types.ModuleType("azure"))
+        identity = sys.modules.setdefault(
+            "azure.identity", types.ModuleType("azure.identity")
+        )
+        aio = types.ModuleType("azure.identity.aio")
+
+        class _Token:
+            token = "stub-token"
+
+        class _ClientSecretCredential:
+            def __init__(self, *a, **k):
+                ...
+
+            async def get_token(self, *a, **k):
+                return _Token()
+
+            async def close(self):
+                ...
+
+        aio.ClientSecretCredential = _ClientSecretCredential
+        azure.identity = identity
+        identity.aio = aio
+        sys.modules["azure.identity.aio"] = aio
+
+
+def _load_module_under_test(monkeypatch):
+    """Load v1.module (and its v1.client dependency) with env + deps stubbed."""
+    _install_dep_stubs()
+    monkeypatch.setenv("AZURE_DEVOPS_ORG_URL", "https://dev.azure.com/acme")
+    monkeypatch.setenv("AZURE_DEVOPS_PROJECT", _PROJECT)
+    monkeypatch.setenv("AZURE_DEVOPS_TENANT_ID", "t")
+    monkeypatch.setenv("AZURE_DEVOPS_CLIENT_ID", "c")
+    monkeypatch.setenv("AZURE_DEVOPS_CLIENT_SECRET", "s")
+
+    # Load v1.client then v1.module by path under a synthetic package so the
+    # `from .client import ...` relative import in module.py resolves.
+    pkg = types.ModuleType("ado_v1")
+    pkg.__path__ = [str(_MOD_DIR / "v1")]
+    sys.modules["ado_v1"] = pkg
+
+    for name in ("client", "module"):
+        spec = importlib.util.spec_from_file_location(
+            f"ado_v1.{name}", _MOD_DIR / "v1" / f"{name}.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[f"ado_v1.{name}"] = mod
+        spec.loader.exec_module(mod)
+
+    return sys.modules["ado_v1.module"]
+
+
+class _RecordingClient:
+    """Wraps the real client but records every REST path + WIQL it sends."""
+
+    def __init__(self, real):
+        self._real = real
+        self.posts: list[tuple[str, dict]] = []
+        self.gets: list[tuple[str, dict | None]] = []
+
+    @property
+    def project(self):
+        return self._real.project
+
+    async def query_wiql(self, wiql, top):
+        self.posts.append((f"{self._real.project}/_apis/wit/wiql", {"query": wiql}))
+        return [1, 2]
+
+    async def get_work_items(self, ids, fields=None):
+        self.posts.append(
+            (f"{self._real.project}/_apis/wit/workitemsbatch", {"ids": ids})
+        )
+        return [
+            {"id": i, "fields": {"System.Title": f"WI {i}", "System.State": "New"}}
+            for i in ids
+        ]
+
+    async def get_work_item(self, item_id):
+        self.gets.append((f"{self._real.project}/_apis/wit/workitems/{item_id}", None))
+        return {"id": item_id, "fields": {"System.Title": "WI"}}
+
+
+@pytest.mark.asyncio
+async def test_all_requests_are_scoped_to_configured_project(monkeypatch):
+    module_mod = _load_module_under_test(monkeypatch)
+    mod = module_mod.AzureDevOpsModule()
+
+    rec = _RecordingClient(mod._client)
+    mod._client = rec
+
+    await mod.list_backlog_items(work_item_type="Bug", state="Active", limit=10)
+    await mod.search_work_items("login", limit=5)
+    await mod.get_work_item(4321)
+
+    prefix = f"{_PROJECT}/_apis/"
+    for path, _ in rec.posts:
+        assert path.startswith(prefix), f"POST escaped project scope: {path}"
+    for path, _ in rec.gets:
+        assert path.startswith(prefix), f"GET escaped project scope: {path}"
+
+    # Every WIQL query must pin the team project explicitly.
+    wiqls = [body["query"] for path, body in rec.posts if path.endswith("/wiql")]
+    assert wiqls, "expected at least one WIQL query"
+    for q in wiqls:
+        assert f"[System.TeamProject] = '{_PROJECT}'" in q
+
+
+@pytest.mark.asyncio
+async def test_missing_config_fails_fast(monkeypatch):
+    module_mod = _load_module_under_test(monkeypatch)
+    monkeypatch.delenv("AZURE_DEVOPS_CLIENT_SECRET", raising=False)
+    with pytest.raises(ValueError) as exc:
+        module_mod.AzureDevOpsModule()
+    assert "AZURE_DEVOPS_CLIENT_SECRET" in str(exc.value)
+
+
+def test_wiql_escaping_prevents_quote_breakout(monkeypatch):
+    module_mod = _load_module_under_test(monkeypatch)
+    # Single quotes in user/config values must be doubled so they cannot break
+    # out of the WIQL string literal (and thus cannot drop the project clause).
+    assert module_mod._wiql_escape("a'b") == "a''b"

--- a/druppie/tests/test_azuredevops_isolation.py
+++ b/druppie/tests/test_azuredevops_isolation.py
@@ -54,12 +54,16 @@ def _tool_functions(source_path: Path) -> dict[str, ast.AsyncFunctionDef]:
     return tools
 
 
-def test_tools_expose_exactly_the_three_read_tools():
+def test_tools_expose_exactly_the_expected_tools():
     tools = _tool_functions(_MOD_DIR / "v1" / "tools.py")
     assert set(tools) == {
+        "get_current_sprint",
+        "get_sprint_summary",
         "list_backlog_items",
         "get_work_item",
         "search_work_items",
+        "create_work_item",
+        "update_work_item",
     }
 
 
@@ -160,10 +164,15 @@ class _RecordingClient:
         self._real = real
         self.posts: list[tuple[str, dict]] = []
         self.gets: list[tuple[str, dict | None]] = []
+        self.patches: list[tuple[str, list]] = []
 
     @property
     def project(self):
         return self._real.project
+
+    @property
+    def org_url(self):
+        return self._real.org_url
 
     async def query_wiql(self, wiql, top):
         self.posts.append((f"{self._real.project}/_apis/wit/wiql", {"query": wiql}))
@@ -181,6 +190,30 @@ class _RecordingClient:
     async def get_work_item(self, item_id):
         self.gets.append((f"{self._real.project}/_apis/wit/workitems/{item_id}", None))
         return {"id": item_id, "fields": {"System.Title": "WI"}}
+
+    async def create_work_item(self, work_item_type, operations):
+        path = f"{self._real.project}/_apis/wit/workitems/${work_item_type}"
+        self.posts.append((path, {"operations": operations}))
+        return {
+            "id": 999,
+            "fields": {
+                "System.Title": "Created",
+                "System.WorkItemType": work_item_type,
+                "System.State": "New",
+            },
+        }
+
+    async def update_work_item(self, item_id, operations):
+        path = f"{self._real.project}/_apis/wit/workitems/{item_id}"
+        self.patches.append((path, operations))
+        return {
+            "id": item_id,
+            "fields": {
+                "System.Title": "Updated",
+                "System.WorkItemType": "Bug",
+                "System.State": "New",
+            },
+        }
 
 
 @pytest.mark.asyncio
@@ -222,3 +255,53 @@ def test_wiql_escaping_prevents_quote_breakout(monkeypatch):
     # Single quotes in user/config values must be doubled so they cannot break
     # out of the WIQL string literal (and thus cannot drop the project clause).
     assert module_mod._wiql_escape("a'b") == "a''b"
+
+
+@pytest.mark.asyncio
+async def test_create_work_item_is_project_scoped(monkeypatch):
+    module_mod = _load_module_under_test(monkeypatch)
+    mod = module_mod.AzureDevOpsModule()
+    rec = _RecordingClient(mod._client)
+    mod._client = rec
+
+    result = await mod.create_work_item(work_item_type="Bug", title="Test bug")
+    assert result["success"] is True
+
+    prefix = f"{_PROJECT}/_apis/"
+    for path, _ in rec.posts:
+        assert path.startswith(prefix), f"POST escaped project scope: {path}"
+
+
+@pytest.mark.asyncio
+async def test_update_work_item_is_project_scoped(monkeypatch):
+    module_mod = _load_module_under_test(monkeypatch)
+    mod = module_mod.AzureDevOpsModule()
+    rec = _RecordingClient(mod._client)
+    mod._client = rec
+
+    result = await mod.update_work_item(item_id=123, title="Updated title")
+    assert result["success"] is True
+
+    prefix = f"{_PROJECT}/_apis/"
+    for path, _ in rec.patches:
+        assert path.startswith(prefix), f"PATCH escaped project scope: {path}"
+
+
+@pytest.mark.asyncio
+async def test_create_work_item_rejects_invalid_type(monkeypatch):
+    module_mod = _load_module_under_test(monkeypatch)
+    mod = module_mod.AzureDevOpsModule()
+
+    result = await mod.create_work_item(work_item_type="Invalid", title="Test")
+    assert result["success"] is False
+    assert "Invalid" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_work_item_rejects_empty_update(monkeypatch):
+    module_mod = _load_module_under_test(monkeypatch)
+    mod = module_mod.AzureDevOpsModule()
+
+    result = await mod.update_work_item(item_id=123)
+    assert result["success"] is False
+    assert "No fields" in result["error"]


### PR DESCRIPTION
## Summary

- **New MCP server** (`module-azuredevops`) for Azure DevOps backlog access, scoped to a single configured project with service principal auth
- **Read tools**: `list_backlog_items`, `get_work_item`, `search_work_items`, `get_current_sprint`, `get_sprint_summary` — with board column, sprint, assignee, and effort tracking
- **Write tools**: `create_work_item`, `update_work_item` — gated by HITL approval (`session_owner` must approve before execution)
- **Product owner agent** with system prompt covering work item hierarchy (Epic → Feature → PBI → Task), state vs board column distinction, sprint scoping, effort tracking, and create/update workflows
- **Azure Foundry LLM provider** updated to support both GPT-5-MINI and Claude models (auto-detects Claude and routes through Anthropic endpoint)
- **Isolation tests** (10 tests) verifying single-project scoping, no project/org parameter leaks, WIQL escaping, and write-operation project scoping

## Changes

| File | What |
|------|------|
| `mcp-servers/module-azuredevops/` | New MCP server: Dockerfile, client, module, tools, router |
| `agents/definitions/product_owner.yaml` | New agent with read + write tools, approval overrides |
| `core/mcp_config.yaml` | Register all 7 azuredevops tools (2 write require approval) |
| `llm/litellm_provider.py` | Azure Foundry: auto-detect Claude models, route via `anthropic/` prefix |
| `docker-compose.yml` | Add module-azuredevops service |
| `.env.example` | Document Azure DevOps and Foundry env vars |
| `tests/test_azuredevops_isolation.py` | 10 isolation tests (static + behavioral) |
| `docs/FEATURES.md`, `docs/TECHNICAL.md` | Documentation updates |

## Approval flow

1. Agent calls `create_work_item` or `update_work_item`
2. ToolExecutor checks `approval_overrides` → `requires_approval: true, required_role: session_owner`
3. Approval record created — approver sees full tool arguments
4. Session owner approves → MCP tool executes; or rejects → agent reports reason

## Test plan

- [x] `pytest druppie/tests/test_azuredevops_isolation.py` — 10/10 pass
- [x] Manual: start session with product owner agent, verify read tools work
- [x] Manual: create a PBI → approval prompt appears → approve → item created in Azure DevOps
- [x] Manual: update a work item → approval prompt → approve → update applied
- [x] Manual: reject an approval → agent reports rejection to user

🤖 Generated with [Claude Code](https://claude.com/claude-code)