### PR TITLE
fix: increase approval feedback limit from 1000 to 10000 characters

### DIFF
--- a/druppie/api/routes/approvals.py
+++ b/druppie/api/routes/approvals.py
@@ -46,8 +46,8 @@ class RejectRequest(BaseModel):
     reason: str = Field(
         ...,
         min_length=1,
-        max_length=1000,
-        description="Reason for rejection",
+        max_length=10000,
+        description="Reason for rejection (1-10000 characters)",
     )
 
 

--- a/druppie/api/routes/jobs.py
+++ b/druppie/api/routes/jobs.py
@@ -22,8 +22,8 @@ class RejectJobRequest(BaseModel):
     reason: str = Field(
         ...,
         min_length=1,
-        max_length=1000,
-        description="Reason for rejection",
+        max_length=10000,
+        description="Reason for rejection (1-10000 characters)",
     )
 
 

--- a/frontend/src/components/chat/ApprovalCard.jsx
+++ b/frontend/src/components/chat/ApprovalCard.jsx
@@ -486,14 +486,18 @@ const ApprovalCard = ({ approval, onApprove, onReject, isProcessing, currentUser
               {/* Reject reason input */}
               {showRejectInput && (
                 <div className="mb-3">
-                  <input
-                    type="text"
+                  <textarea
                     value={rejectReason}
                     onChange={(e) => setRejectReason(e.target.value)}
                     placeholder="Enter reason for rejection..."
-                    className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent text-sm"
+                    className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent text-sm resize-y"
+                    rows={3}
+                    maxLength={10000}
                     autoFocus
                   />
+                  <div className="text-xs text-gray-400 text-right mt-1">
+                    {rejectReason.length} / 10,000
+                  </div>
                 </div>
               )}
 

--- a/frontend/src/components/chat/ApprovalCard.jsx
+++ b/frontend/src/components/chat/ApprovalCard.jsx
@@ -494,6 +494,12 @@ const ApprovalCard = ({ approval, onApprove, onReject, isProcessing, currentUser
                     rows={3}
                     maxLength={10000}
                     autoFocus
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && rejectReason.trim() && !isProcessing) {
+                        e.preventDefault()
+                        handleReject()
+                      }
+                    }}
                   />
                   <div className="text-xs text-gray-400 text-right mt-1">
                     {rejectReason.length} / 10,000

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -208,38 +208,41 @@ const InlineApproval = ({ tc, sessionId, sessionUserId }) => {
                     </button>
                   </div>
                 ) : (
-                  <div className="flex items-center gap-1.5">
-                    <input
-                      type="text"
+                  <div className="space-y-1.5">
+                    <textarea
                       value={rejectReason}
                       onChange={(e) => setRejectReason(e.target.value)}
-                      placeholder="Reason..."
+                      placeholder="Reason for rejection..."
                       aria-label="Rejection reason"
-                      className="flex-1 min-w-0 px-2 py-1 text-xs border border-gray-200 rounded-md focus:outline-none focus:ring-1 focus:ring-red-400"
+                      className="w-full px-2 py-1 text-xs border border-gray-200 rounded-md focus:outline-none focus:ring-1 focus:ring-red-400 resize-y"
+                      rows={3}
+                      maxLength={10000}
                       autoFocus
                       onKeyDown={(e) => {
-                        if (e.key === 'Enter' && rejectReason.trim()) {
-                          rejectMut.mutate({ approvalId: tc.approval.id, reason: rejectReason })
-                        }
                         if (e.key === 'Escape') {
                           setRejectMode(false)
                           setRejectReason('')
                         }
                       }}
                     />
-                    <button
-                      onClick={() => rejectMut.mutate({ approvalId: tc.approval.id, reason: rejectReason })}
-                      disabled={isProcessing || !rejectReason.trim()}
-                      className="px-2 py-1 text-xs bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 transition-colors"
-                    >
-                      Reject
-                    </button>
-                    <button
-                      onClick={() => { setRejectMode(false); setRejectReason('') }}
-                      className="px-2 py-1 text-xs text-gray-400 hover:text-gray-600 transition-colors"
-                    >
-                      Cancel
-                    </button>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-gray-400">{rejectReason.length} / 10,000</span>
+                      <div className="flex items-center gap-1.5">
+                        <button
+                          onClick={() => rejectMut.mutate({ approvalId: tc.approval.id, reason: rejectReason })}
+                          disabled={isProcessing || !rejectReason.trim()}
+                          className="px-2 py-1 text-xs bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 transition-colors"
+                        >
+                          Reject
+                        </button>
+                        <button
+                          onClick={() => { setRejectMode(false); setRejectReason('') }}
+                          className="px-2 py-1 text-xs text-gray-400 hover:text-gray-600 transition-colors"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 )
               ) : (

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -223,6 +223,10 @@ const InlineApproval = ({ tc, sessionId, sessionUserId }) => {
                           setRejectMode(false)
                           setRejectReason('')
                         }
+                        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && rejectReason.trim() && !isProcessing) {
+                          e.preventDefault()
+                          rejectMut.mutate({ approvalId: tc.approval.id, reason: rejectReason })
+                        }
                       }}
                     />
                     <div className="flex items-center justify-between">

--- a/frontend/src/components/chat/ToolDecisionCard.jsx
+++ b/frontend/src/components/chat/ToolDecisionCard.jsx
@@ -423,13 +423,17 @@ const ToolDecisionCard = ({
               </div>
             ) : (
               <div className="space-y-2">
-                <input
-                  type="text"
+                <textarea
                   value={rejectReason}
                   onChange={(e) => setRejectReason(e.target.value)}
                   placeholder="Rejection reason (optional)"
-                  className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                  className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm resize-y focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                  rows={3}
+                  maxLength={10000}
                 />
+                <div className="text-xs text-gray-400 text-right">
+                  {rejectReason.length} / 10,000
+                </div>
                 <div className="flex items-center gap-2">
                   <button
                     onClick={handleReject}

--- a/frontend/src/components/chat/ToolDecisionCard.jsx
+++ b/frontend/src/components/chat/ToolDecisionCard.jsx
@@ -430,6 +430,12 @@ const ToolDecisionCard = ({
                   className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm resize-y focus:ring-2 focus:ring-red-500 focus:border-transparent"
                   rows={3}
                   maxLength={10000}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !isProcessing) {
+                      e.preventDefault()
+                      handleReject()
+                    }
+                  }}
                 />
                 <div className="text-xs text-gray-400 text-right">
                   {rejectReason.length} / 10,000

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -304,6 +304,12 @@ const TaskCard = ({ task, onApprove, onReject }) => {
             rows={3}
             maxLength={10000}
             autoFocus
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && rejectReason.trim()) {
+                e.preventDefault()
+                onReject(task.id, rejectReason)
+              }
+            }}
           />
           <div className="flex items-center justify-between">
             <span className="text-xs text-gray-400">{rejectReason.length} / 10,000</span>
@@ -613,6 +619,12 @@ const JobApprovalCard = ({ run, onApprove, onReject }) => {
             rows={3}
             maxLength={10000}
             autoFocus
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && rejectReason.trim()) {
+                e.preventDefault()
+                onReject(run.id, rejectReason)
+              }
+            }}
           />
           <div className="flex items-center justify-between">
             <span className="text-xs text-gray-400">{rejectReason.length} / 10,000</span>

--- a/frontend/src/pages/Tasks.jsx
+++ b/frontend/src/pages/Tasks.jsx
@@ -300,28 +300,32 @@ const TaskCard = ({ task, onApprove, onReject }) => {
             value={rejectReason}
             onChange={(e) => setRejectReason(e.target.value)}
             placeholder="Reason for rejection..."
-            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent text-sm"
-            rows={2}
+            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent text-sm resize-y"
+            rows={3}
+            maxLength={10000}
             autoFocus
           />
-          <div className="flex items-center gap-2 justify-end">
-            <button
-              onClick={() => setShowReject(false)}
-              className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700 rounded-lg"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={() => {
-                if (rejectReason.trim()) {
-                  onReject(task.id, rejectReason)
-                }
-              }}
-              disabled={!rejectReason.trim()}
-              className="px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
-            >
-              Confirm Reject
-            </button>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-gray-400">{rejectReason.length} / 10,000</span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setShowReject(false)}
+                className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700 rounded-lg"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  if (rejectReason.trim()) {
+                    onReject(task.id, rejectReason)
+                  }
+                }}
+                disabled={!rejectReason.trim()}
+                className="px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+              >
+                Confirm Reject
+              </button>
+            </div>
           </div>
         </div>
       )}
@@ -605,28 +609,32 @@ const JobApprovalCard = ({ run, onApprove, onReject }) => {
             value={rejectReason}
             onChange={(e) => setRejectReason(e.target.value)}
             placeholder="Reason for rejection..."
-            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent text-sm"
-            rows={2}
+            className="w-full px-3 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent text-sm resize-y"
+            rows={3}
+            maxLength={10000}
             autoFocus
           />
-          <div className="flex items-center gap-2 justify-end">
-            <button
-              onClick={() => setShowReject(false)}
-              className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700 rounded-lg"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={() => {
-                if (rejectReason.trim()) {
-                  onReject(run.id, rejectReason)
-                }
-              }}
-              disabled={!rejectReason.trim()}
-              className="px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
-            >
-              Confirm Reject
-            </button>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-gray-400">{rejectReason.length} / 10,000</span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setShowReject(false)}
+                className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700 rounded-lg"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  if (rejectReason.trim()) {
+                    onReject(run.id, rejectReason)
+                  }
+                }}
+                disabled={!rejectReason.trim()}
+                className="px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+              >
+                Confirm Reject
+              </button>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

Closes #247

Rejection/feedback text on approval gates was capped at **1000 characters**, making it difficult to provide detailed feedback (e.g. when rejecting a Functional Design). This PR raises the limit to **10,000 characters** across the full stack and improves the input UX.

### Changes

**Backend (API validation)**
- `druppie/api/routes/approvals.py` — `RejectRequest.reason` max_length 1000 → 10000
- `druppie/api/routes/jobs.py` — `RejectJobRequest.reason` max_length 1000 → 10000
- No DB migration needed — columns already use `Text` (unlimited)

**Frontend (5 rejection input locations)**
- `SessionDetail.jsx` — `<input>` → `<textarea>` with character counter *(this is the main chat view used when rejecting FDs)*
- `ApprovalCard.jsx` — `<input>` → `<textarea>` with character counter
- `ToolDecisionCard.jsx` — `<input>` → `<textarea>` with character counter
- `Tasks.jsx` (TaskCard) — added `maxLength`, `resize-y`, and character counter
- `Tasks.jsx` (JobApprovalCard) — added `maxLength`, `resize-y`, and character counter

All textareas show a live `0 / 10,000` counter, are vertically resizable, and enforce `maxLength={10000}` on the client side.

## Test plan

- [ ] **Chat view (SessionDetail)**: Open a session with a pending approval → click Reject → verify textarea appears with `0 / 10,000` counter → type text and confirm counter updates live → paste text >1000 chars and confirm it's accepted → submit and verify it goes through
- [ ] **Tasks page (TaskCard)**: Go to Tasks → find a pending approval → click Reject → verify same textarea + counter behavior
- [ ] **Tasks page (JobApprovalCard)**: Same check for a pending job approval
- [ ] **Boundary check**: Try to paste >10,000 characters → verify the textarea stops accepting at 10,000
- [ ] **Empty submit**: Verify the Reject/Confirm button stays disabled when textarea is empty
- [ ] **Backend validation**: `POST /api/approvals/{id}/reject` with a body >10,000 chars returns 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)