### PR TITLE
fix: remove duplicate user message in chat timeline (#262)

### DIFF
--- a/druppie/execution/orchestrator.py
+++ b/druppie/execution/orchestrator.py
@@ -163,26 +163,6 @@ class Orchestrator:
         # This ensures follow-up messages don't collide with existing runs
         next_seq = self.execution_repo.get_next_sequence_number(current_session_id)
 
-        # Step 3b: Save user message to the timeline
-        message_id = self.execution_repo.create_message(
-            session_id=current_session_id,
-            role="user",
-            content=message,
-            sequence_number=next_seq,
-        )
-        next_seq += 1
-
-        # Step 3c: Link uploaded attachments to the user message
-        attachment_context = ""
-        if attachment_ids and self.attachment_repo:
-            self.attachment_repo.link_to_message(
-                attachment_ids, message_id, current_session_id,
-            )
-            attachments = self.attachment_repo.get_by_ids(attachment_ids)
-            attachment_context = self._build_attachment_context(attachments)
-
-        self.execution_repo.commit()
-
         # Step 3.5: Detect and update language (only if detection succeeds)
         human_input = HumanInput(message, self.language_detector)
         self._last_language_info = human_input.language_info()
@@ -221,7 +201,7 @@ class Orchestrator:
                 )
 
         # Step 3b: Save user message to the timeline (after translation so we can store both versions)
-        self.execution_repo.create_message(
+        message_id = self.execution_repo.create_message(
             session_id=current_session_id,
             role="user",
             content=message,
@@ -229,6 +209,16 @@ class Orchestrator:
             sequence_number=next_seq,
         )
         next_seq += 1
+
+        # Step 3c: Link uploaded attachments to the user message
+        attachment_context = ""
+        if attachment_ids and self.attachment_repo:
+            self.attachment_repo.link_to_message(
+                attachment_ids, message_id, current_session_id,
+            )
+            attachments = self.attachment_repo.get_by_ids(attachment_ids)
+            attachment_context = self._build_attachment_context(attachments)
+
         self.execution_repo.commit()
 
         # Step 4: Get user's projects for router injection


### PR DESCRIPTION
Fixes #262

## Summary

- The first user message in a session was displayed twice in the chat timeline
- **Root cause**: `process_message()` in `orchestrator.py` contained two `create_message(role="user")` calls (both labeled "Step 3b"), a merge artifact from combining the file-upload branch (needed `message_id` for attachment linking) with the translation branch (needed `content_english` for bilingual storage)
- **Fix**: Consolidated into a single `create_message` call placed after translation, which both returns `message_id` (for attachments) and includes `content_english` (for bilingual storage)

## Test plan

- [x] Backend tests pass (138/139, 1 pre-existing failure in `test_modules_api.py`)
- [x] Created a new session via `POST /api/chat`, verified only 1 user message in the timeline API response
- [x] Confirmed only 1 `role='user'` row in the database for the test session
- [x] Verified `grep` shows exactly one `create_message` call in `orchestrator.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)