### PR TITLE
feat: OpenRouter provider with Cerebras-pinned GLM-4.7 (includes PR #264)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,7 @@ GITEA_TOKEN=
 # =============================================================================
 # Both providers use LiteLLM internally for standardized tool calling.
 
-# Provider: zai, deepinfra, deepseek, azure_foundry, ollama
+# Provider: zai, deepinfra, deepseek, azure_foundry, openrouter, ollama
 LLM_PROVIDER=zai
 
 # Override: force ALL agents to use this provider/model (ignores YAML per-agent config)
@@ -76,6 +76,14 @@ ZAI_BASE_URL=https://api.z.ai/api/coding/paas/v4
 # Uncomment and set to use DeepInfra instead:
 # DEEPINFRA_API_KEY=
 # DEEPINFRA_MODEL=Qwen/Qwen3-Next-80B-A3B-Instruct
+
+# --- OpenRouter Configuration ---
+# Routes through OpenRouter to any upstream provider (e.g. Cerebras, z-ai).
+# OPENROUTER_PROVIDER_ORDER pins requests to a specific upstream provider and
+# disables load balancing/fallbacks (e.g. "Cerebras" for Cerebras only).
+# OPENROUTER_API_KEY=
+# OPENROUTER_MODEL=z-ai/glm-4.7
+# OPENROUTER_PROVIDER_ORDER=Cerebras
 
 # --- Embedding Provider (for module-vectorstore / RAG) ---
 # Required when the chat provider doesn't support embeddings (e.g. Z.AI coding API).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       KC_HOSTNAME_STRICT: "false"
       KC_HOSTNAME_STRICT_HTTPS: "false"
       KC_HTTP_ENABLED: "true"
-      KC_PROXY: edge
+      KC_PROXY: ${KC_PROXY:-edge}
       KC_HEALTH_ENABLED: "true"
       JAVA_OPTS_APPEND: "-Xms256m -Xmx512m -XX:MaxGCPauseMillis=100 -Djava.net.preferIPv4Stack=true"
       KC_CACHE: local
@@ -217,8 +217,8 @@ services:
 
   module-docker:
     build:
-      context: ./druppie/mcp-servers
-      dockerfile: module-docker/Dockerfile
+      context: ./druppie
+      dockerfile: mcp-servers/module-docker/Dockerfile
     container_name: druppie-module-docker
     profiles: [infra, dev, prod]
     environment:
@@ -271,8 +271,8 @@ services:
 
   module-archimate:
     build:
-      context: ./druppie/mcp-servers
-      dockerfile: module-archimate/Dockerfile
+      context: ./druppie
+      dockerfile: mcp-servers/module-archimate/Dockerfile
     container_name: druppie-module-archimate
     profiles: [infra, dev, prod]
     environment:
@@ -340,8 +340,8 @@ services:
 
   module-registry:
     build:
-      context: ./druppie/mcp-servers
-      dockerfile: module-registry/Dockerfile
+      context: ./druppie
+      dockerfile: mcp-servers/module-registry/Dockerfile
     container_name: druppie-module-registry
     profiles: [infra, dev, prod]
     environment:
@@ -635,6 +635,9 @@ services:
       LLM_PROVIDER: ${LLM_PROVIDER:-zai}
       LLM_FORCE_PROVIDER: ${LLM_FORCE_PROVIDER:-}
       LLM_FORCE_MODEL: ${LLM_FORCE_MODEL:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      OPENROUTER_MODEL: ${OPENROUTER_MODEL:-z-ai/glm-4.7}
+      OPENROUTER_PROVIDER_ORDER: ${OPENROUTER_PROVIDER_ORDER:-Cerebras}
       ZAI_API_KEY: ${ZAI_API_KEY:-}
       ZAI_MODEL: ${ZAI_MODEL:-glm-4.7}
       ZAI_BASE_URL: ${ZAI_BASE_URL:-https://api.z.ai/api/coding/paas/v4}
@@ -725,6 +728,9 @@ services:
       LLM_PROVIDER: ${LLM_PROVIDER:-zai}
       LLM_FORCE_PROVIDER: ${LLM_FORCE_PROVIDER:-}
       LLM_FORCE_MODEL: ${LLM_FORCE_MODEL:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      OPENROUTER_MODEL: ${OPENROUTER_MODEL:-z-ai/glm-4.7}
+      OPENROUTER_PROVIDER_ORDER: ${OPENROUTER_PROVIDER_ORDER:-Cerebras}
       ZAI_API_KEY: ${ZAI_API_KEY:-}
       ZAI_MODEL: ${ZAI_MODEL:-glm-4.7}
       ZAI_BASE_URL: ${ZAI_BASE_URL:-https://api.z.ai/api/coding/paas/v4}

--- a/druppie/agents/definitions/llm_profiles.yaml
+++ b/druppie/agents/definitions/llm_profiles.yaml
@@ -5,41 +5,27 @@
 # and optionally sets up the second as a FallbackLLM.
 #
 # Agents reference a profile by name in their YAML: llm_profile: standard
+#
+# All profiles route through OpenRouter. The primary entry is pinned to
+# Cerebras via OPENROUTER_PROVIDER_ORDER. The second entry lets OpenRouter
+# choose the upstream itself (default price-weighted load balancing) as a
+# fallback when Cerebras is unavailable.
 
 profiles:
   standard:
-    - provider: zai
-      model: glm-5
-    - provider: deepinfra
-      model: moonshotai/Kimi-K2.5-Turbo
-    - provider: zai
-      model: glm-4.7
-    - provider: ollama
-      model: gpt-oss:120b
-    - provider: azure_foundry
-      model: GPT-5-MINI
+    - provider: openrouter
+      model: z-ai/glm-4.7
+    - provider: openrouter_balanced
+      model: z-ai/glm-4.7
 
   cheap:
-    - provider: zai
-      model: glm-5
-    - provider: deepinfra
-      model: moonshotai/Kimi-K2.5-Turbo
-    - provider: zai
-      model: glm-4.7
-    - provider: ollama
-      model: gpt-oss:20b
-    - provider: azure_foundry
-      model: GPT-5-MINI
-
+    - provider: openrouter
+      model: z-ai/glm-4.7
+    - provider: openrouter_balanced
+      model: z-ai/glm-4.7
 
   ollama:
-    - provider: ollama
-      model: gpt-oss:120b
-    - provider: ollama
-      model: gpt-oss:20b
-    - provider: ollama
-      model: qwen3-coder:30b
-    - provider: ollama
-      model: deepseek-r1:32b
-    - provider: ollama
-      model: gemma3:27b
+    - provider: openrouter
+      model: z-ai/glm-4.7
+    - provider: openrouter_balanced
+      model: z-ai/glm-4.7

--- a/druppie/core/config.py
+++ b/druppie/core/config.py
@@ -112,7 +112,7 @@ class LLMSettings(BaseSettings):
     provider: str = Field(
         default="auto",
         alias="LLM_PROVIDER",
-        description="LLM provider (auto, zai, mock)",
+        description="LLM provider (auto, zai, deepinfra, azure_foundry, openrouter, ollama, mock)",
     )
     zai_api_key: str = Field(
         default="",
@@ -128,6 +128,21 @@ class LLMSettings(BaseSettings):
         default="https://api.z.ai/api/coding/paas/v4",
         alias="ZAI_BASE_URL",
         description="Z.AI API base URL",
+    )
+    openrouter_api_key: str = Field(
+        default="",
+        alias="OPENROUTER_API_KEY",
+        description="OpenRouter API key",
+    )
+    openrouter_model: str = Field(
+        default="z-ai/glm-4.7",
+        alias="OPENROUTER_MODEL",
+        description="OpenRouter model slug (e.g. z-ai/glm-4.7)",
+    )
+    openrouter_provider_order: str = Field(
+        default="Cerebras",
+        alias="OPENROUTER_PROVIDER_ORDER",
+        description="Comma-separated upstream providers to pin (e.g. Cerebras). Disables load balancing/fallbacks.",
     )
     foundry_api_key: str = Field(
         default="",

--- a/druppie/execution/orchestrator.py
+++ b/druppie/execution/orchestrator.py
@@ -163,26 +163,6 @@ class Orchestrator:
         # This ensures follow-up messages don't collide with existing runs
         next_seq = self.execution_repo.get_next_sequence_number(current_session_id)
 
-        # Step 3b: Save user message to the timeline
-        message_id = self.execution_repo.create_message(
-            session_id=current_session_id,
-            role="user",
-            content=message,
-            sequence_number=next_seq,
-        )
-        next_seq += 1
-
-        # Step 3c: Link uploaded attachments to the user message
-        attachment_context = ""
-        if attachment_ids and self.attachment_repo:
-            self.attachment_repo.link_to_message(
-                attachment_ids, message_id, current_session_id,
-            )
-            attachments = self.attachment_repo.get_by_ids(attachment_ids)
-            attachment_context = self._build_attachment_context(attachments)
-
-        self.execution_repo.commit()
-
         # Step 3.5: Detect and update language (only if detection succeeds)
         human_input = HumanInput(message, self.language_detector)
         self._last_language_info = human_input.language_info()
@@ -221,7 +201,7 @@ class Orchestrator:
                 )
 
         # Step 3b: Save user message to the timeline (after translation so we can store both versions)
-        self.execution_repo.create_message(
+        message_id = self.execution_repo.create_message(
             session_id=current_session_id,
             role="user",
             content=message,
@@ -229,6 +209,16 @@ class Orchestrator:
             sequence_number=next_seq,
         )
         next_seq += 1
+
+        # Step 3c: Link uploaded attachments to the user message
+        attachment_context = ""
+        if attachment_ids and self.attachment_repo:
+            self.attachment_repo.link_to_message(
+                attachment_ids, message_id, current_session_id,
+            )
+            attachments = self.attachment_repo.get_by_ids(attachment_ids)
+            attachment_context = self._build_attachment_context(attachments)
+
         self.execution_repo.commit()
 
         # Step 4: Get user's projects for router injection

--- a/druppie/llm/litellm_provider.py
+++ b/druppie/llm/litellm_provider.py
@@ -4,7 +4,7 @@ Uses LiteLLM for standardized tool calling across all providers.
 This is the only LLM implementation - all providers go through LiteLLM.
 
 Environment variables:
-    LLM_PROVIDER: zai, deepinfra, deepseek, azure_foundry, ollama
+    LLM_PROVIDER: zai, deepinfra, deepseek, azure_foundry, openrouter, ollama
 
     For ZAI:
         ZAI_API_KEY, ZAI_MODEL, ZAI_BASE_URL
@@ -17,6 +17,9 @@ Environment variables:
 
     For Azure Foundry:
         FOUNDRY_API_KEY, FOUNDRY_MODEL, FOUNDRY_API_URL
+
+    For OpenRouter:
+        OPENROUTER_API_KEY, OPENROUTER_MODEL, OPENROUTER_PROVIDER_ORDER
 
     For Ollama:
         OLLAMA_MODEL, OLLAMA_BASE_URL (API key optional)
@@ -223,6 +226,32 @@ PROVIDER_CONFIGS = {
         "default_base_url": "https://ollama.waterschap.org/v1",
         "ssl_verify": False,  # Self-signed certificate
     },
+    "openrouter": {
+        "prefix": "openrouter",  # LiteLLM native OpenRouter support
+        "default_model": "z-ai/glm-4.7",
+        "api_key_env": "OPENROUTER_API_KEY",
+        "model_env": "OPENROUTER_MODEL",
+        "base_url_env": "OPENROUTER_BASE_URL",
+        "default_base_url": "https://openrouter.ai/api/v1",
+        # Pin every request to a single upstream provider (no load balancing /
+        # fallbacks). Controlled by OPENROUTER_PROVIDER_ORDER (comma-separated),
+        # e.g. "Cerebras" to only use Cerebras. Falls back to default routing
+        # when unset.
+        "provider_order_env": "OPENROUTER_PROVIDER_ORDER",
+    },
+    "openrouter_balanced": {
+        # Same OpenRouter endpoint/key as "openrouter", but WITHOUT provider
+        # pinning — OpenRouter chooses the upstream itself via its default
+        # price-weighted load balancing. Used as a fallback beneath the
+        # Cerebras-pinned entry in llm_profiles.yaml: if Cerebras is down,
+        # OpenRouter routes to any other provider serving the model.
+        "prefix": "openrouter",  # LiteLLM native OpenRouter support
+        "default_model": "z-ai/glm-4.7",
+        "api_key_env": "OPENROUTER_API_KEY",
+        "model_env": "OPENROUTER_MODEL",
+        "base_url_env": "OPENROUTER_BASE_URL",
+        "default_base_url": "https://openrouter.ai/api/v1",
+    },
 }
 
 
@@ -298,6 +327,16 @@ class ChatLiteLLM(BaseLLM):
         self._extra_headers: dict[str, str] = {}
         if self._auth_type == "bearer" and self.api_key:
             self._extra_headers["Authorization"] = f"Bearer {self.api_key}"
+
+        # OpenRouter provider pinning — when OPENROUTER_PROVIDER_ORDER is set,
+        # force every request to the listed upstream provider(s) with no
+        # fallbacks. Passed to the API via extra_body (merged by LiteLLM).
+        self._extra_body: dict[str, Any] = {}
+        provider_order_env = config.get("provider_order_env")
+        if provider_order_env:
+            order = [p.strip() for p in os.getenv(provider_order_env, "").split(",") if p.strip()]
+            if order:
+                self._extra_body["provider"] = {"order": order, "allow_fallbacks": False}
 
         # Azure API version (required for azure/ prefix)
         self._api_version = config.get("api_version")
@@ -402,6 +441,9 @@ class ChatLiteLLM(BaseLLM):
 
         if self._extra_headers:
             kwargs["extra_headers"] = self._extra_headers
+
+        if self._extra_body:
+            kwargs["extra_body"] = self._extra_body
 
         if effective_tools:
             kwargs["tools"] = effective_tools

--- a/druppie/llm/service.py
+++ b/druppie/llm/service.py
@@ -4,7 +4,7 @@ Supports per-agent LLM profiles with ordered provider chains.
 Profiles are defined in agents/definitions/llm_profiles.yaml.
 
 Environment variables:
-    LLM_PROVIDER: Global default provider (zai, deepinfra, azure_foundry, ollama)
+    LLM_PROVIDER: Global default provider (zai, deepinfra, azure_foundry, openrouter, ollama)
     LLM_FORCE_PROVIDER: Force all agents to use this provider (overrides profiles)
     LLM_FORCE_MODEL: Force all agents to use this model (requires LLM_FORCE_PROVIDER)
 """
@@ -43,6 +43,8 @@ class LLMService:
         "zai": "ZAI_API_KEY",
         "deepinfra": "DEEPINFRA_API_KEY",
         "azure_foundry": "FOUNDRY_API_KEY",
+        "openrouter": "OPENROUTER_API_KEY",
+        "openrouter_balanced": "OPENROUTER_API_KEY",
         "ollama": None,
         "mock": None,
     }

--- a/druppie/opencode/credentials.py
+++ b/druppie/opencode/credentials.py
@@ -15,6 +15,7 @@ PROVIDER_BASE_URLS: dict[str, str] = {
     "deepseek": "https://api.deepseek.com",
     # NOTE: /v1 not /v1/openai — the sandbox LLM proxy appends its own path segments
     "deepinfra": "https://api.deepinfra.com/v1",
+    "openrouter": "https://openrouter.ai/api/v1",
     "openai": "https://api.openai.com",
     "anthropic": "https://api.anthropic.com",
 }

--- a/druppie/opencode/model_resolver.py
+++ b/druppie/opencode/model_resolver.py
@@ -36,6 +36,7 @@ PROVIDER_API_KEYS = {
     "zai": "ZAI_API_KEY",
     "deepseek": "DEEPSEEK_API_KEY",
     "deepinfra": "DEEPINFRA_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
 }


### PR DESCRIPTION
## Summary

Adds a new OpenRouter LLM provider routing to GLM-4.7 (`z-ai/glm-4.7`), with Cerebras as the pinned upstream and an OpenRouter-managed fallback.

- **Primary**: `openrouter` provider — every request pinned to **Cerebras** via `OPENROUTER_PROVIDER_ORDER=Cerebras` (`allow_fallbacks: false`, no load balancing).
- **Fallback**: `openrouter_balanced` provider — same model, but lets OpenRouter choose the upstream itself (default price-weighted routing) when Cerebras is unavailable.

## Changes
- `llm/litellm_provider.py`: `openrouter` + `openrouter_balanced` provider configs; generic `extra_body` support for provider-order pinning.
- `llm/service.py`, `core/config.py`, `opencode/model_resolver.py`, `opencode/credentials.py`: register the new providers/settings.
- `docker-compose.yml`: pass `OPENROUTER_API_KEY` / `OPENROUTER_MODEL` / `OPENROUTER_PROVIDER_ORDER` into both backend services (dev + prod).
- `agents/definitions/llm_profiles.yaml`: `standard` / `cheap` / `ollama` profiles now lead with `openrouter` (Cerebras) + `openrouter_balanced` fallback — all other providers removed.
- `.env.example`: document the new provider.

## Includes
- PR #264 (`fix: remove duplicate user message creation in process_message`)

## Verification
- Live-tested `z-ai/glm-4.7` via OpenRouter: Cerebras pin returns `provider: Cerebras`; balanced routing returns `provider: Z.AI`.
- Backend rebuilt and started with `llm_provider=openrouter`; `OPENROUTER_*` env vars confirmed present in the container.
- Tool calling verified working through the Cerebras-pinned route.