### PR TITLE
fix: improve FO translation quality — faster model, error fallback, single-file approval

### DIFF
--- a/druppie/core/translation.py
+++ b/druppie/core/translation.py
@@ -1,9 +1,9 @@
 """Translation service — translates text between languages via DeepInfra.
 
-Uses a dedicated lightweight LLM instance (Qwen/Qwen3-32B on DeepInfra) for
-translations. Raises TranslationNotAvailableError on first use when
-DEEPINFRA_API_KEY is not configured, so callers surface a clear error instead
-of silently serving untranslated text.
+Uses Mistral-Small-24B on DeepInfra for translations. Raises
+TranslationNotAvailableError when DEEPINFRA_API_KEY is not configured,
+and TranslationError on translation failures, so callers can surface
+clear errors instead of silently serving untranslated text.
 """
 
 import os
@@ -15,6 +15,10 @@ logger = structlog.get_logger()
 
 class TranslationNotAvailableError(RuntimeError):
     """Raised when translation is requested but cannot work (e.g. missing API key)."""
+
+
+class TranslationError(RuntimeError):
+    """Raised when a translation call fails (timeout, API error, empty result)."""
 
 
 def _language_name(code: str) -> str:
@@ -30,7 +34,7 @@ def _language_name(code: str) -> str:
 
 
 class TranslationService:
-    """Translates text between languages using Qwen/Qwen3-32B on DeepInfra."""
+    """Translates text between languages using Mistral-Small-24B on DeepInfra."""
 
     def __init__(self):
         self._llm = None
@@ -47,11 +51,11 @@ class TranslationService:
             from druppie.llm.litellm_provider import ChatLiteLLM
             self._llm = ChatLiteLLM(
                 provider="deepinfra",
-                model="Qwen/Qwen3-32B",
+                model="mistralai/Mistral-Small-24B-Instruct-2501",
                 temperature=0.1,
-                max_tokens=4096,
-                timeout=15.0,
-                max_retries=1,
+                max_tokens=16384,
+                timeout=120.0,
+                max_retries=2,
             )
         return self._llm
 
@@ -62,7 +66,11 @@ class TranslationService:
             return text
 
         lang_name = _language_name(source_language)
-        return await self._translate(text, lang_name, "English")
+        try:
+            return await self._translate(text, lang_name, "English")
+        except TranslationError:
+            logger.warning("translate_to_english_fallback", source_language=source_language)
+            return text
 
     async def translate_from_english(self, text: str, target_language: str) -> str:
         if not target_language or target_language == "en":
@@ -75,9 +83,11 @@ class TranslationService:
 
     @staticmethod
     def _strip_thinking(text: str) -> str:
-        """Remove <think>...</think> blocks from model output."""
+        """Remove <think>...</think> blocks from model output, including unclosed tags."""
         import re
-        return re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL).strip()
+        text = re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL)
+        text = re.sub(r"<think>.*", "", text, flags=re.DOTALL)
+        return text.strip()
 
     async def _translate(self, text: str, from_lang: str, to_lang: str) -> str:
         try:
@@ -86,10 +96,10 @@ class TranslationService:
                     {
                         "role": "system",
                         "content": (
-                            f"/no_think\n"
                             f"Translate the following {from_lang} text to {to_lang}. "
                             "Output ONLY the translation. No explanations, no extra text. "
-                            "Preserve all markdown formatting, code blocks, and special characters."
+                            "Preserve all markdown formatting exactly — including heading "
+                            "prefixes (##, ###), bullet points, code blocks, and special characters."
                         ),
                     },
                     {"role": "user", "content": text},
@@ -97,14 +107,12 @@ class TranslationService:
             )
             translated = self._strip_thinking(response.content)
             if not translated:
-                logger.warning("translation_empty_response", from_lang=from_lang, to_lang=to_lang)
-                return text
+                raise TranslationError(f"Empty response translating {from_lang} → {to_lang}")
             return translated
-        except TranslationNotAvailableError:
+        except (TranslationNotAvailableError, TranslationError):
             raise
         except Exception as e:
-            logger.warning("translation_failed", error=str(e), from_lang=from_lang, to_lang=to_lang)
-            return text
+            raise TranslationError(f"Translation {from_lang} → {to_lang} failed: {e}") from e
 
 
 _translation_service: TranslationService | None = None

--- a/druppie/execution/tool_executor.py
+++ b/druppie/execution/tool_executor.py
@@ -957,6 +957,8 @@ class ToolExecutor:
         is_translated = False
 
         # Translate question and choices to the user's language
+        session_repo = None
+        session = None
         try:
             from druppie.repositories import SessionRepository
             from druppie.core.translation import get_translation_service
@@ -989,13 +991,14 @@ class ToolExecutor:
                     target_language=session.language,
                 )
         except TranslationNotAvailableError:
-            self._notify_translation_unavailable(
-                tool_call.session_id, session_repo,
-                reason="De vertalingsservice is niet geconfigureerd (DEEPINFRA_API_KEY ontbreekt).",
-            )
+            if session_repo:
+                self._notify_translation_unavailable(
+                    tool_call.session_id, session_repo,
+                    reason="De vertalingsservice is niet geconfigureerd (DEEPINFRA_API_KEY ontbreekt).",
+                )
         except Exception as e:
             logger.warning("hitl_question_translation_failed", error=str(e))
-            if session and session.language and session.language != "en":
+            if session and session_repo and session.language and session.language != "en":
                 self._notify_translation_unavailable(
                     tool_call.session_id, session_repo,
                     reason=f"Er is een fout opgetreden bij het vertalen: {str(e)[:150]}",

--- a/druppie/execution/tool_executor.py
+++ b/druppie/execution/tool_executor.py
@@ -27,7 +27,7 @@ from uuid import UUID
 import structlog
 
 from druppie.core.mcp_config import MCPConfig
-from druppie.core.translation import TranslationNotAvailableError
+from druppie.core.translation import TranslationError, TranslationNotAvailableError
 from druppie.execution.mcp_http import MCPHttp, MCPHttpError
 
 if TYPE_CHECKING:
@@ -734,11 +734,13 @@ class ToolExecutor:
     }
 
     async def _translate_design_content(self, tool_call) -> None:
-        """Translate design content to Dutch before the approval gate.
+        """Translate design content to the session language before the approval gate.
 
-        For make_design calls in Dutch sessions, translates the English content
+        For make_design calls in non-English sessions, translates the English content
         and adds translated_content/translated_path to tool_call.arguments.
-        The approval card shows the Dutch version; the MCP tool writes both files.
+        The approval card shows the translated version; the MCP tool writes both files.
+
+        On translation failure, switches the session to English and notifies the user.
         """
         if tool_call.tool_name != "make_design":
             return
@@ -747,7 +749,7 @@ class ToolExecutor:
         session_repo = SessionRepository(self.db)
         session = session_repo.get_by_id(tool_call.session_id)
 
-        if not session or not session.language or session.language != "nl":
+        if not session or not session.language or session.language == "en":
             return
 
         args = tool_call.arguments or {}
@@ -764,7 +766,7 @@ class ToolExecutor:
             from druppie.core.translation import get_translation_service
             translator = get_translation_service()
             translated_content = await self._translate_long_content(
-                translator, content, "nl"
+                translator, content, session.language
             )
             if translated_content and translated_content != content:
                 enriched_args = dict(args)
@@ -782,7 +784,10 @@ class ToolExecutor:
                     translated_path=translated_path,
                 )
         except TranslationNotAvailableError:
-            logger.warning("translation_skipped_no_api_key", tool_call_id=str(tool_call.id))
+            self._notify_translation_unavailable(
+                tool_call.session_id, session_repo,
+                reason="De vertalingsservice is niet geconfigureerd (DEEPINFRA_API_KEY ontbreekt).",
+            )
         except Exception as e:
             logger.warning(
                 "design_translation_failed",
@@ -790,11 +795,40 @@ class ToolExecutor:
                 path=path,
                 error=str(e),
             )
+            self._notify_translation_unavailable(
+                tool_call.session_id, session_repo,
+                reason=f"Er is een fout opgetreden bij het vertalen: {str(e)[:150]}",
+            )
+
+    def _notify_translation_unavailable(
+        self, session_id, session_repo, *, reason: str
+    ) -> None:
+        """Switch session to English and inject a user-facing message."""
+        session_repo.update_language(session_id, "en")
+
+        message = (
+            f"⚠️ **Vertaling niet beschikbaar** — {reason}\n\n"
+            "De sessie gaat verder in het Engels. Alle documenten worden in het Engels opgesteld.\n\n"
+            "---\n\n"
+            f"⚠️ **Translation unavailable** — The translation service encountered an error. "
+            "This session will continue in English."
+        )
+
+        seq = self.execution_repo.get_next_sequence_number(session_id)
+        self.execution_repo.create_message(
+            session_id=session_id,
+            role="system",
+            content=message,
+            sequence_number=seq,
+        )
+        self.db.flush()
+        logger.info("translation_fallback_to_english", session_id=str(session_id))
 
     async def _translate_long_content(
         self, translator, content: str, target_language: str
     ) -> str:
         """Translate long markdown by splitting on heading boundaries."""
+        import asyncio
         import re
 
         if len(content) < 3000:
@@ -814,15 +848,43 @@ class ToolExecutor:
         if current:
             chunks.append(current)
 
-        import asyncio
+        untranslated_count = 0
 
         async def _translate_chunk(chunk):
-            if chunk.strip():
-                return await translator.translate_from_english(chunk, target_language)
-            return chunk
+            nonlocal untranslated_count
+            if not chunk.strip():
+                return chunk
+
+            heading_prefix = ""
+            heading_match = re.match(r"^(#{1,3}\s+)", chunk)
+            if heading_match:
+                heading_prefix = heading_match.group(1)
+
+            try:
+                result = await translator.translate_from_english(chunk, target_language)
+                if heading_prefix and not re.match(r"^#{1,3}\s+", result):
+                    result = heading_prefix + result
+                return result
+            except TranslationError as e:
+                untranslated_count += 1
+                logger.warning(
+                    "translation_chunk_failed",
+                    error=str(e)[:200],
+                    chunk_length=len(chunk),
+                )
+                return f"\n\n> **[NIET VERTAALD / NOT TRANSLATED]**\n\n{chunk}"
 
         translated = await asyncio.gather(*[_translate_chunk(c) for c in chunks])
-        return "".join(translated)
+        result = "".join(translated)
+
+        if untranslated_count:
+            logger.warning(
+                "translation_partially_failed",
+                untranslated_chunks=untranslated_count,
+                total_chunks=len(chunks),
+            )
+
+        return result
 
     async def _create_approval_and_wait(self, tool_call, required_role: str | None) -> str:
         """Create an Approval record and set tool call to waiting.
@@ -927,9 +989,17 @@ class ToolExecutor:
                     target_language=session.language,
                 )
         except TranslationNotAvailableError:
-            logger.warning("translation_skipped_no_api_key", tool_call_id=str(tool_call.id))
+            self._notify_translation_unavailable(
+                tool_call.session_id, session_repo,
+                reason="De vertalingsservice is niet geconfigureerd (DEEPINFRA_API_KEY ontbreekt).",
+            )
         except Exception as e:
             logger.warning("hitl_question_translation_failed", error=str(e))
+            if session and session.language and session.language != "en":
+                self._notify_translation_unavailable(
+                    tool_call.session_id, session_repo,
+                    reason=f"Er is een fout opgetreden bij het vertalen: {str(e)[:150]}",
+                )
 
         choices = [{"text": c} for c in raw_choices] if raw_choices else None
 

--- a/frontend/src/components/chat/ChatHelpers.jsx
+++ b/frontend/src/components/chat/ChatHelpers.jsx
@@ -507,10 +507,7 @@ export const buildApprovalFileList = (args) => {
     return Object.entries(batchFiles).map(([p, c]) => ({ path: p, content: c }))
   }
   if (hasTranslation) {
-    return [
-      { path: args.translated_path, content: args.translated_content },
-      { path: filePath + ' (English)', content },
-    ]
+    return [{ path: args.translated_path, content: args.translated_content }]
   }
   return [{ path: filePath || 'file', content }]
 }

--- a/frontend/src/components/chat/ChatHelpers.test.jsx
+++ b/frontend/src/components/chat/ChatHelpers.test.jsx
@@ -146,21 +146,17 @@ describe('buildApprovalFileList', () => {
     ])
   })
 
-  it('returns translated file first when translation exists', () => {
+  it('returns only translated file when translation exists', () => {
     const files = buildApprovalFileList({
       path: 'docs/functional-design.md',
       content: '# Functional Design',
       translated_path: 'docs/functioneel-ontwerp.md',
       translated_content: '# Functioneel Ontwerp',
     })
-    expect(files).toHaveLength(2)
+    expect(files).toHaveLength(1)
     expect(files[0]).toEqual({
       path: 'docs/functioneel-ontwerp.md',
       content: '# Functioneel Ontwerp',
-    })
-    expect(files[1]).toEqual({
-      path: 'docs/functional-design.md (English)',
-      content: '# Functional Design',
     })
   })
 

--- a/testing/tools/ba-fd-translated-approval-pending.yaml
+++ b/testing/tools/ba-fd-translated-approval-pending.yaml
@@ -1,0 +1,101 @@
+## Seeded session: BA wrote a Functional Design with Dutch translation,
+## approval gate PENDING.
+##
+## Tests the single-file approval card for translated sessions (PR #272).
+## The make_design call includes both the English original (path/content)
+## and the Dutch translation (translated_path/translated_content), exactly
+## as production does for non-English sessions.
+##
+## To test:
+##   1. Run this test from the evaluations page → green.
+##   2. Log in as the session owner (admin by default).
+##   3. Go to /tasks — you should see a pending approval for a session
+##      named "vertaal-test-app".
+##   4. Click "View file" — the button should say
+##      "View docs/functioneel-ontwerp.md" (NOT "View 2 files").
+##   5. The file preview modal should show ONLY the Dutch translation,
+##      not the English original alongside it.
+##   6. Approve or reject to verify the flow still works end-to-end.
+##
+## Chain: router → planner → BA calls coding:make_design → PENDING.
+## Deterministic (no LLM).
+
+tool-test:
+  name: ba-fd-translated-approval-pending
+  description: "BA wrote FD with Dutch translation — approval card should show single translated file"
+  tags: [seed, paused, business_analyst, approval-gate, translation]
+  session_status: paused_approval
+
+  chain:
+    # --- Router ---
+    - agent: router
+      tool: builtin:set_intent
+      arguments:
+        intent: create_project
+        project_name: vertaal-test-app
+        description: "Test app for verifying single-file translated approval card"
+      assert:
+        result:
+          - not_empty
+
+    - agent: router
+      tool: builtin:done
+      arguments:
+        summary: "Agent router: Classified as create_project for vertaal-test-app"
+      assert:
+        completed: true
+
+    # --- Planner → BA ---
+    - agent: planner
+      tool: builtin:make_plan
+      arguments:
+        steps:
+          - agent_id: business_analyst
+            prompt: "Gather requirements and create functional design"
+          - agent_id: planner
+            prompt: "Re-evaluate after business analyst completes"
+
+    - agent: planner
+      tool: builtin:done
+      arguments:
+        summary: "Agent planner: Planned business_analyst to gather requirements and create functional design"
+
+    # --- BA writes the FD with translated fields — approval gate PENDING ---
+    - agent: business_analyst
+      tool: coding:make_design
+      approval:
+        status: pending
+      arguments:
+        path: docs/functional-design.md
+        content: |
+          # Functional Design: Translation Test App
+
+          ## 1. Current vs Desired Situation
+          Users need a way to verify that the approval card shows
+          only the translated file, not both English and Dutch.
+
+          ## 2. Functional Requirements
+          - FR-01: The approval modal shows a single file when a translation exists
+          - FR-02: The displayed file is the Dutch translation, not the English original
+          - FR-03: The "View file" button shows the translated filename
+
+          ## 3. Non-Functional Requirements
+          - NFR-01: No regression in the approval flow for non-translated sessions
+        translated_path: docs/functioneel-ontwerp.md
+        translated_content: |
+          # Functioneel Ontwerp: Vertaaltest App
+
+          ## 1. Huidige vs Gewenste Situatie
+          Gebruikers moeten kunnen verifiëren dat de goedkeuringskaart
+          alleen het vertaalde bestand toont, niet zowel Engels als Nederlands.
+
+          ## 2. Functionele Eisen
+          - FR-01: De goedkeuringsmodal toont één bestand wanneer een vertaling bestaat
+          - FR-02: Het getoonde bestand is de Nederlandse vertaling, niet het Engelse origineel
+          - FR-03: De "Bekijk bestand"-knop toont de vertaalde bestandsnaam
+
+          ## 3. Niet-Functionele Eisen
+          - NFR-01: Geen regressie in de goedkeuringsstroom voor niet-vertaalde sessies
+
+  verify:
+    - gitea_repo_exists: true


### PR DESCRIPTION
## Summary
Fixes #269 — FO translation was broken: mixed English/Dutch, truncated text, missing headings.

- **Faster, cheaper model**: Switched from Qwen3-32B ($0.08/$0.28) to Mistral-Small-24B ($0.05/$0.08) — 3-4x cheaper, faster, comparable Dutch quality
- **No more truncation**: `timeout` 15s → 120s, `max_tokens` 4096 → 16384, `max_retries` 1 → 2
- **No more silent English fallback**: `TranslationError` raised on failure instead of silently returning English. Failed chunks get visible `[NIET VERTAALD / NOT TRANSLATED]` markers
- **User notification on failure**: New `_notify_translation_unavailable` switches session to English and injects a bilingual system message explaining the issue
- **Heading preservation**: After translation, verifies heading prefixes (`##`, `###`) survived; re-attaches if model stripped them
- **Single-file approval card**: Dutch sessions now show only the translated FD in the approval modal (English original still saved in background)
- **Fixed `_strip_thinking`**: Handles unclosed `<think>` tags from truncated model output

## Files changed
- `druppie/core/translation.py` — Model switch, timeout/token increases, TranslationError, strip_thinking fix
- `druppie/execution/tool_executor.py` — Per-chunk error handling, heading preservation, fallback notification
- `frontend/src/components/chat/ChatHelpers.jsx` — Show only session-language file in approval card

## Test plan
- [x] Side-by-side model comparison (Qwen3-32B vs Mistral-Small-24B vs Mistral-Nemo vs Llama-3.1-8B)
- [x] Full FD translation with 8 headings — all preserved
- [x] TranslationError propagation (no silent fallback)
- [x] translate_to_english graceful fallback for user input
- [x] _strip_thinking edge cases (closed, unclosed, mixed, none)
- [x] Chunked translation with simulated failure — [NIET VERTAALD] marker on failed chunk
- [x] _notify_translation_unavailable — switches language, injects bilingual message
- [x] Approval card shows 1 file for Dutch sessions
- [x] Backend test suite: 180 passed (2 pre-existing failures unrelated)
- [x] `vg-assistent-fo-volledig-gesprek` seed test: PASSED (3/3 assertions)
- [x] `ba-bilingual-fd` agent test: 6/6 assertions passed, 4/5 judge checks passed (1 judge parse error, translation confirmed working in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)