### PR TITLE
fix: chat UX, inline attachments for agents, and translation quality

### DIFF
--- a/druppie/core/translation.py
+++ b/druppie/core/translation.py
@@ -67,7 +67,16 @@ class TranslationService:
 
         lang_name = _language_name(source_language)
         try:
-            return await self._translate(text, lang_name, "English")
+            result = await self._translate(text, lang_name, "English")
+            if len(result) > len(text) * 3 + 50:
+                logger.warning(
+                    "translation_hallucination_detected",
+                    input_len=len(text),
+                    output_len=len(result),
+                    input_preview=text[:60],
+                )
+                return text
+            return result
         except TranslationError:
             logger.warning("translate_to_english_fallback", source_language=source_language)
             return text

--- a/druppie/core/translation.py
+++ b/druppie/core/translation.py
@@ -1,6 +1,6 @@
 """Translation service — translates text between languages via DeepInfra.
 
-Uses Mistral-Small-24B on DeepInfra for translations. Raises
+Uses Gemma 3 27B on DeepInfra for translations. Raises
 TranslationNotAvailableError when DEEPINFRA_API_KEY is not configured,
 and TranslationError on translation failures, so callers can surface
 clear errors instead of silently serving untranslated text.
@@ -34,7 +34,7 @@ def _language_name(code: str) -> str:
 
 
 class TranslationService:
-    """Translates text between languages using Mistral-Small-24B on DeepInfra."""
+    """Translates text between languages using Gemma 3 27B on DeepInfra."""
 
     def __init__(self):
         self._llm = None
@@ -51,7 +51,7 @@ class TranslationService:
             from druppie.llm.litellm_provider import ChatLiteLLM
             self._llm = ChatLiteLLM(
                 provider="deepinfra",
-                model="mistralai/Mistral-Small-24B-Instruct-2501",
+                model="google/gemma-3-27b-it",
                 temperature=0.1,
                 max_tokens=16384,
                 timeout=120.0,
@@ -80,6 +80,62 @@ class TranslationService:
 
         lang_name = _language_name(target_language)
         return await self._translate(text, "English", lang_name)
+
+    async def translate_label(self, text: str, target_language: str) -> str:
+        """Translate a short label (e.g. a multiple-choice option).
+
+        Uses a tighter prompt than translate_from_english to prevent
+        the model from expanding a short phrase into an explanation.
+        Falls back to the full translate method if the result looks untranslated.
+        """
+        if not target_language or target_language == "en":
+            return text
+        if len(text.strip()) < 3:
+            return text
+
+        lang_name = _language_name(target_language)
+        try:
+            response = await self.llm.achat(
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            f"Translate this short label from English to {lang_name}. "
+                            "Output ONLY the translated label, nothing else."
+                        ),
+                    },
+                    {"role": "user", "content": text},
+                ],
+            )
+            translated = self._strip_thinking(response.content)
+            if not translated:
+                return text
+            if self._looks_untranslated(text, translated):
+                logger.warning(
+                    "label_translation_looks_english_retrying",
+                    original=text[:60],
+                    result=translated[:60],
+                )
+                return await self._translate(text, "English", lang_name)
+            return translated
+        except (TranslationNotAvailableError, TranslationError):
+            raise
+        except Exception as e:
+            raise TranslationError(
+                f"Label translation English → {lang_name} failed: {e}"
+            ) from e
+
+    @staticmethod
+    def _looks_untranslated(original: str, translated: str) -> bool:
+        """Heuristic: detect if translated text is still English / unchanged."""
+        if translated.strip().lower() == original.strip().lower():
+            return True
+        orig_words = set(original.lower().split())
+        trans_words = set(translated.lower().split())
+        if not orig_words:
+            return False
+        overlap = len(orig_words & trans_words) / len(orig_words)
+        return overlap > 0.6
 
     @staticmethod
     def _strip_thinking(text: str) -> str:

--- a/druppie/execution/orchestrator.py
+++ b/druppie/execution/orchestrator.py
@@ -265,17 +265,21 @@ class Orchestrator:
 
     @staticmethod
     def _build_attachment_context(attachments) -> str:
-        """Build a file listing for LLM prompts (agents use read_attachment tool for content)."""
+        """Build attachment context with inline extracted text so agents see content directly."""
         if not attachments:
             return ""
-        lines = ["\n\nUPLOADED FILES (use the read_attachment tool to read file contents):"]
+        parts = ["\n\nUPLOADED FILES:"]
         for att in attachments:
             size_kb = att.file_size / 1024
-            lines.append(
-                f"- {att.original_filename} (id: {att.id}, type: {att.content_type}, "
-                f"size: {size_kb:.1f} KB)"
+            parts.append(
+                f"\n--- {att.original_filename} (id: {att.id}, type: {att.content_type}, "
+                f"size: {size_kb:.1f} KB) ---"
             )
-        return "\n".join(lines)
+            if att.extracted_text:
+                parts.append(att.extracted_text)
+            else:
+                parts.append("(no text extracted — use read_attachment tool to access)")
+        return "\n".join(parts)
 
     def _format_projects_for_router(self, projects: list) -> str:
         """Format user's projects for injection into router prompt."""

--- a/druppie/execution/tool_executor.py
+++ b/druppie/execution/tool_executor.py
@@ -710,6 +710,24 @@ class ToolExecutor:
         if selected_choices is not None and choices:
             result["selected_choices"] = [choices[i] for i in selected_choices if i < len(choices)]
 
+        # Include uploaded file contents so the agent sees them immediately
+        # (weaker models won't call read_attachment on their own)
+        from druppie.db.models import MessageAttachment
+        question_attachments = (
+            self.db.query(MessageAttachment)
+            .filter(MessageAttachment.question_id == question_id)
+            .all()
+        )
+        if question_attachments:
+            file_contents = []
+            for att in question_attachments:
+                if att.extracted_text:
+                    file_contents.append(
+                        f"--- {att.original_filename} ---\n{att.extracted_text}"
+                    )
+            if file_contents:
+                result["uploaded_file_contents"] = "\n\n".join(file_contents)
+
         # Update tool call with result
         self.execution_repo.update_tool_call(
             tool_call_id,
@@ -973,7 +991,7 @@ class ToolExecutor:
                     translated_choices = []
                     for c in raw_choices:
                         translated_choices.append(
-                            await translator.translate_from_english(c, session.language)
+                            await translator.translate_label(c, session.language)
                         )
                     raw_choices = translated_choices
                 context_text = args.get("context", "")

--- a/frontend/src/components/chat/NewSessionPanel.jsx
+++ b/frontend/src/components/chat/NewSessionPanel.jsx
@@ -55,7 +55,7 @@ const NewSessionPanel = ({ onSessionCreated }) => {
     setUploadError(null)
     const fallback = attachments.length
       ? attachments.map((a) => a.original_filename).join(', ')
-      : 'See attached'
+      : 'Zie bijlage'
     const message = trimmed || fallback
     pendingMessageRef.current = message
     pendingAttachmentsRef.current = attachments.map((a) => ({ id: a.id, original_filename: a.original_filename, content_type: a.content_type }))
@@ -64,7 +64,7 @@ const NewSessionPanel = ({ onSessionCreated }) => {
 
   if (mutation.isPending) {
     const atts = pendingAttachmentsRef.current
-    const isAttachmentOnly = atts.length > 0 && (pendingMessageRef.current === atts.map((a) => a.original_filename).join(', ') || pendingMessageRef.current === 'See attached')
+    const isAttachmentOnly = atts.length > 0 && (pendingMessageRef.current === atts.map((a) => a.original_filename).join(', ') || pendingMessageRef.current === 'Zie bijlage')
     return (
       <div className="flex flex-col h-full">
         <div className="flex-1 overflow-y-auto">

--- a/frontend/src/components/chat/NewSessionPanel.jsx
+++ b/frontend/src/components/chat/NewSessionPanel.jsx
@@ -4,16 +4,17 @@
 
 import { useState, useRef, useEffect } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { Send, Shield } from 'lucide-react'
+import { Send, Shield, Loader2, FileType, FileText } from 'lucide-react'
 import { sendChat } from '../../services/api'
+import { setPending } from '../../services/pendingChat'
 import FileUploadButton from './FileUploadButton'
 import AttachmentChips from './AttachmentChips'
 
 const NEW_SESSION_SUGGESTIONS = [
-  'Set up a new project',
-  'Review my code architecture',
-  'Help me deploy an app',
-  'Write a feature specification',
+  'Start een nieuw project',
+  'Beoordeel mijn code-architectuur',
+  'Help me een app te deployen',
+  'Schrijf een feature-specificatie',
 ]
 
 const NewSessionPanel = ({ onSessionCreated }) => {
@@ -21,15 +22,20 @@ const NewSessionPanel = ({ onSessionCreated }) => {
   const [attachments, setAttachments] = useState([])
   const [uploadError, setUploadError] = useState(null)
   const inputRef = useRef(null)
+  const pendingMessageRef = useRef(null)
+  const pendingAttachmentsRef = useRef([])
   const queryClient = useQueryClient()
 
   const mutation = useMutation({
     mutationFn: ({ message, attachmentIds }) => sendChat(message, null, null, attachmentIds),
     onSuccess: (data) => {
+      const msg = pendingMessageRef.current
+      pendingMessageRef.current = null
       setInput('')
       setAttachments([])
       queryClient.invalidateQueries({ queryKey: ['sessions'] })
       if (data.session_id) {
+        setPending(data.session_id, msg, pendingAttachmentsRef.current)
         onSessionCreated(data.session_id)
       }
     },
@@ -51,7 +57,45 @@ const NewSessionPanel = ({ onSessionCreated }) => {
       ? attachments.map((a) => a.original_filename).join(', ')
       : 'See attached'
     const message = trimmed || fallback
+    pendingMessageRef.current = message
+    pendingAttachmentsRef.current = attachments.map((a) => ({ id: a.id, original_filename: a.original_filename, content_type: a.content_type }))
     mutation.mutate({ message, attachmentIds: attachments.map((a) => a.id) })
+  }
+
+  if (mutation.isPending) {
+    const atts = pendingAttachmentsRef.current
+    const isAttachmentOnly = atts.length > 0 && (pendingMessageRef.current === atts.map((a) => a.original_filename).join(', ') || pendingMessageRef.current === 'See attached')
+    return (
+      <div className="flex flex-col h-full">
+        <div className="flex-1 overflow-y-auto">
+          <div className="max-w-3xl mx-auto px-4 py-6 space-y-6">
+            <div className="flex justify-end gap-2">
+              <div className="max-w-[85%] rounded-2xl px-4 py-2.5 text-sm bg-gray-100 text-gray-900 overflow-hidden">
+                {!isAttachmentOnly && (
+                  <div className="whitespace-pre-wrap break-words">{pendingMessageRef.current}</div>
+                )}
+                {atts.length > 0 && (
+                  <div className={`flex flex-wrap gap-1.5${isAttachmentOnly ? '' : ' mt-2'}`}>
+                    {atts.map((att) => {
+                      const Icon = att.content_type === 'application/pdf' ? FileType : FileText
+                      return (
+                        <span key={att.id} className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-white/60 rounded-lg text-xs text-gray-600">
+                          <Icon className="w-3.5 h-3.5 text-gray-400" />
+                          <span className="truncate max-w-[120px]">{att.original_filename}</span>
+                        </span>
+                      )
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center py-1">
+              <Loader2 className="w-3.5 h-3.5 text-gray-400 animate-spin" />
+            </div>
+          </div>
+        </div>
+      </div>
+    )
   }
 
   return (
@@ -62,18 +106,17 @@ const NewSessionPanel = ({ onSessionCreated }) => {
           <Shield className="w-7 h-7 text-white" />
         </div>
         <h1 className="text-2xl font-semibold text-gray-900 mb-2">
-          What would you like to build?
+          Wat wil je bouwen?
         </h1>
         <p className="text-gray-400 text-sm mb-8">
-          Start a new governance session with Druppie
+          Start een nieuwe governance-sessie
         </p>
         <div className="flex flex-wrap justify-center gap-2 max-w-lg">
           {NEW_SESSION_SUGGESTIONS.map((s) => (
             <button
               key={s}
               onClick={() => handleSend(s)}
-              disabled={mutation.isPending}
-              className="px-4 py-2 text-sm border border-gray-200 rounded-full text-gray-600 hover:bg-gray-50 hover:border-gray-300 transition-colors disabled:opacity-50"
+              className="px-4 py-2 text-sm border border-gray-200 rounded-full text-gray-600 hover:bg-gray-50 hover:border-gray-300 transition-colors"
             >
               {s}
             </button>
@@ -93,33 +136,27 @@ const NewSessionPanel = ({ onSessionCreated }) => {
               <FileUploadButton
                 onUpload={(att) => { setUploadError(null); setAttachments((prev) => [...prev, att]) }}
                 onError={setUploadError}
-                disabled={mutation.isPending}
               />
               <textarea
                 ref={inputRef}
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey && !mutation.isPending) {
+                  if (e.key === 'Enter' && !e.shiftKey) {
                     e.preventDefault()
                     handleSend()
                   }
                 }}
-                placeholder="Describe what you'd like to build..."
+                placeholder="Beschrijf wat je wilt bouwen..."
                 rows={1}
                 className="flex-1 resize-none bg-transparent outline-none text-sm leading-6 py-1 max-h-40"
-                disabled={mutation.isPending}
               />
               <button
                 onClick={() => handleSend()}
-                disabled={(!input.trim() && !attachments.length) || mutation.isPending}
+                disabled={!input.trim() && !attachments.length}
                 className="flex-shrink-0 p-2 rounded-xl bg-gray-900 text-white hover:bg-gray-700 disabled:opacity-30 disabled:hover:bg-gray-900 transition-colors"
               >
-                {mutation.isPending ? (
-                  <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                ) : (
-                  <Send className="w-4 h-4" />
-                )}
+                <Send className="w-4 h-4" />
               </button>
             </div>
           </div>

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -318,17 +318,14 @@ const InlineApproval = ({ tc, sessionId, sessionUserId }) => {
 
 const TimelineQuestion = ({ tc, agentId, sessionId, attachments = [], onAttachmentsConsumed, onAnswerSubmitted }) => {
   const queryClient = useQueryClient()
-  const lastAnswerRef = useRef(null)
 
   const answerMut = useMutation({
-    mutationFn: ({ questionId, answer, selectedChoices = null, attachmentIds = [] }) => {
-      lastAnswerRef.current = answer
-      return answerQuestion(questionId, answer, selectedChoices, attachmentIds)
-    },
+    mutationFn: ({ questionId, answer, selectedChoices = null, attachmentIds = [] }) =>
+      answerQuestion(questionId, answer, selectedChoices, attachmentIds),
     onSuccess: () => {
       onAttachmentsConsumed?.()
       markResuming()
-      onAnswerSubmitted?.(lastAnswerRef.current)
+      onAnswerSubmitted?.()
       queryClient.invalidateQueries({ queryKey: ['session', sessionId] })
     },
   })

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -19,6 +19,7 @@ import HITLQuestionMessage from './HITLQuestionMessage'
 import WorkflowPipeline from './WorkflowPipeline'
 import DebugEventLog from './DebugEventLog'
 import AnnotationBar from './AnnotationBar'
+import { consumePending } from '../../services/pendingChat'
 import {
   chatMarkdownComponents,
   CopyJsonButton,
@@ -315,14 +316,19 @@ const InlineApproval = ({ tc, sessionId, sessionUserId }) => {
 
 // --- Timeline HITL Question ---
 
-const TimelineQuestion = ({ tc, agentId, sessionId, attachments = [], onAttachmentsConsumed }) => {
+const TimelineQuestion = ({ tc, agentId, sessionId, attachments = [], onAttachmentsConsumed, onAnswerSubmitted }) => {
   const queryClient = useQueryClient()
+  const lastAnswerRef = useRef(null)
 
   const answerMut = useMutation({
-    mutationFn: ({ questionId, answer, selectedChoices = null, attachmentIds = [] }) => answerQuestion(questionId, answer, selectedChoices, attachmentIds),
+    mutationFn: ({ questionId, answer, selectedChoices = null, attachmentIds = [] }) => {
+      lastAnswerRef.current = answer
+      return answerQuestion(questionId, answer, selectedChoices, attachmentIds)
+    },
     onSuccess: () => {
       onAttachmentsConsumed?.()
       markResuming()
+      onAnswerSubmitted?.(lastAnswerRef.current)
       queryClient.invalidateQueries({ queryKey: ['session', sessionId] })
     },
   })
@@ -405,7 +411,7 @@ const TimelineQuestion = ({ tc, agentId, sessionId, attachments = [], onAttachme
 
 // --- Agent Run ---
 
-const AgentRunItem = ({ run, timelineIndex, sessionId, hasFollowingMessage, sessionUserId, surfacedFiles, attachments, onAttachmentsConsumed }) => {
+const AgentRunItem = ({ run, timelineIndex, sessionId, hasFollowingMessage, sessionUserId, surfacedFiles, attachments, onAttachmentsConsumed, onAnswerSubmitted }) => {
   const orderedItems = extractOrderedItems(run, hasFollowingMessage)
 
   // Show agent trace for completed runs that have no following message
@@ -440,7 +446,7 @@ const AgentRunItem = ({ run, timelineIndex, sessionId, hasFollowingMessage, sess
         if (item.type === 'question') {
           return (
             <div key={i} className="mt-3">
-              <TimelineQuestion tc={item.tc} agentId={item.agentId} sessionId={sessionId} attachments={attachments} onAttachmentsConsumed={onAttachmentsConsumed} />
+              <TimelineQuestion tc={item.tc} agentId={item.agentId} sessionId={sessionId} attachments={attachments} onAttachmentsConsumed={onAttachmentsConsumed} onAnswerSubmitted={onAnswerSubmitted} />
             </div>
           )
         }
@@ -737,6 +743,12 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
   const [attachments, setAttachments] = useState([])
   const [uploadError, setUploadError] = useState(null)
   const [transcriptPdfLoading, setTranscriptPdfLoading] = useState(false)
+  const [pendingMessage, setPendingMessage] = useState(() => {
+    const cached = consumePending(sessionId)
+    return cached?.message || null
+  })
+  const [isAnswering, setIsAnswering] = useState(false)
+  const pendingSetAtLength = useRef(pendingMessage ? 0 : null)
   const savedInspectScroll = useRef(0)
   const [viewMode, _setViewMode] = useState(() => {
     if (initialViewMode && VALID_VIEW_MODES.has(initialViewMode)) return initialViewMode
@@ -788,6 +800,9 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
       setUploadError(null)
       queryClient.invalidateQueries({ queryKey: ['session', sessionId] })
       queryClient.invalidateQueries({ queryKey: ['sessions'] })
+    },
+    onError: () => {
+      setPendingMessage(null)
     },
   })
 
@@ -867,6 +882,38 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
     }
   }, [continueInput])
 
+  const isBusy = continueMutation.isPending || isAnswering
+
+  // Clear optimistic message once server data catches up (new timeline entries)
+  useEffect(() => {
+    if (pendingMessage === null) return
+    const len = data?.timeline?.length || 0
+    if (pendingSetAtLength.current !== null && len > pendingSetAtLength.current) {
+      setPendingMessage(null)
+      setIsAnswering(false)
+    }
+  }, [data?.timeline?.length, pendingMessage])
+
+  // Safety: clear pending message after 30s in case data never arrives
+  useEffect(() => {
+    if (!pendingMessage) return
+    const timer = setTimeout(() => {
+      setPendingMessage(null)
+      setIsAnswering(false)
+    }, 30000)
+    return () => clearTimeout(timer)
+  }, [pendingMessage])
+
+  // Scroll to bottom when optimistic message appears
+  useEffect(() => {
+    if (pendingMessage) {
+      requestAnimationFrame(() => {
+        const el = timelineRef.current
+        if (el) el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
+      })
+    }
+  }, [pendingMessage])
+
   if (isLoading) {
     return (
       <div className="flex flex-col h-full min-w-0">
@@ -943,15 +990,22 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
       const answer = trimmed
         || (attachments.length ? `See uploaded files: ${fileNames}` : '')
       if (!answer) return
+      setPendingMessage(trimmed || true)
+      setIsAnswering(true)
+      pendingSetAtLength.current = data?.timeline?.length || 0
+      setContinueInput('')
+      setAttachments([])
       const attIds = attachments.map((a) => a.id)
       answerQuestion(pendingQuestion.tc.question_id, answer, null, attIds)
         .then(() => {
-          setContinueInput('')
-          setAttachments([])
+          setIsAnswering(false)
+          markResuming()
           queryClient.invalidateQueries({ queryKey: ['session', sessionId] })
         })
         .catch((err) => {
           console.error('Failed to answer question:', err.message || err)
+          setPendingMessage(null)
+          setIsAnswering(false)
         })
       return
     }
@@ -960,6 +1014,8 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
       ? attachments.map((a) => a.original_filename).join(', ')
       : 'See attached'
     const message = trimmed || fallback
+    setPendingMessage(trimmed || true)
+    pendingSetAtLength.current = data?.timeline?.length || 0
     continueMutation.mutate({ message, attachmentIds: attachments.map((a) => a.id) })
   }
 
@@ -1129,11 +1185,17 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
       ) : (
         <div ref={timelineRef} className="flex-1 overflow-y-auto overflow-x-hidden">
           <div className="max-w-3xl mx-auto px-4 py-6 space-y-6">
-          {(!data.timeline || data.timeline.length === 0) && (
-            <div className="text-center py-12 flex flex-col items-center gap-2">
-              <MessageSquare className="w-8 h-8 text-gray-300" />
-              <p className="text-gray-400 text-sm">No timeline entries yet</p>
-            </div>
+          {(!data.timeline || data.timeline.length === 0) && !pendingMessage && (
+            data.status === 'active' || data.status === 'running' ? (
+              <div className="flex items-center justify-center py-12">
+                <Loader2 className="w-5 h-5 text-gray-400 animate-spin" />
+              </div>
+            ) : (
+              <div className="text-center py-12 flex flex-col items-center gap-2">
+                <MessageSquare className="w-8 h-8 text-gray-300" />
+                <p className="text-gray-400 text-sm">No timeline entries yet</p>
+              </div>
+            )
           )}
           {(() => {
             // messageRunMap: pairs each agent's last non-user message with its run
@@ -1235,6 +1297,10 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
                       surfacedFiles={surfacedFiles}
                       attachments={attachments}
                       onAttachmentsConsumed={() => { setAttachments([]); setUploadError(null) }}
+                      onAnswerSubmitted={() => {
+                        setPendingMessage(true)
+                        pendingSetAtLength.current = data?.timeline?.length || 0
+                      }}
                     />
                     {renderAnnotation(i)}
                   </div>
@@ -1244,6 +1310,21 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
               return null
             })
           })()}
+          {/* Optimistic user message + processing indicator */}
+          {pendingMessage && (
+            <>
+              {typeof pendingMessage === 'string' && (
+                <div className="flex justify-end gap-2">
+                  <div className="max-w-[85%] rounded-2xl px-4 py-2.5 text-sm bg-gray-100 text-gray-900 overflow-hidden">
+                    <div className="whitespace-pre-wrap break-words">{pendingMessage}</div>
+                  </div>
+                </div>
+              )}
+              <div className="flex items-center py-1">
+                <Loader2 className="w-3.5 h-3.5 text-gray-400 animate-spin" />
+              </div>
+            </>
+          )}
           {/* Trailing thinking / sandbox-waiting indicator */}
           {(() => {
             // Don't show thinking indicator if session itself has ended
@@ -1347,14 +1428,14 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
                 onUpload={(att) => { setUploadError(null); setAttachments((prev) => [...prev, att]) }}
                 onError={setUploadError}
                 sessionId={sessionId}
-                disabled={continueMutation.isPending}
+                disabled={isBusy}
               />
               <textarea
                 ref={inputRef}
                 value={continueInput}
                 onChange={(e) => setContinueInput(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey && !continueMutation.isPending) {
+                  if (e.key === 'Enter' && !e.shiftKey && !isBusy) {
                     e.preventDefault()
                     handleContinueSend()
                   }
@@ -1369,7 +1450,7 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
                 rows={1}
                 className="flex-1 resize-none bg-transparent outline-none text-sm leading-6 py-1 max-h-40"
                 aria-label="Chat message input"
-                disabled={continueMutation.isPending}
+                disabled={isBusy}
               />
               {isStopping ? (
                 <button
@@ -1408,11 +1489,11 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
               ) : (
                 <button
                   onClick={handleContinueSend}
-                  disabled={(!continueInput.trim() && !attachments.length) || continueMutation.isPending}
+                  disabled={(!continueInput.trim() && !attachments.length) || isBusy}
                   className="flex-shrink-0 p-2 rounded-xl bg-gray-900 text-white hover:bg-gray-700 disabled:opacity-30 disabled:hover:bg-gray-900 transition-colors"
                   aria-label="Send message"
                 >
-                  {continueMutation.isPending ? (
+                  {isBusy ? (
                     <Loader2 className="w-4 h-4 animate-spin" />
                   ) : (
                     <ArrowUp className="w-4 h-4" />

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -377,11 +377,11 @@ const TimelineQuestion = ({ tc, agentId, sessionId, attachments = [], onAttachme
       {isAnswered && displayAnswer && (
         <div className="flex justify-end">
           <div className="max-w-[85%] rounded-2xl px-4 py-2.5 text-sm bg-gray-100 text-gray-900">
-            {!(tc.attachments?.length > 0 && displayAnswer.startsWith('See uploaded files:')) && (
+            {!(tc.attachments?.length > 0 && (displayAnswer.startsWith('See uploaded files:') || displayAnswer.startsWith('Zie geüploade bestanden:'))) && (
               <div className="whitespace-pre-wrap">{displayAnswer}</div>
             )}
             {tc.attachments?.length > 0 && (
-              <div className={`flex flex-wrap gap-1.5${displayAnswer && !displayAnswer.startsWith('See uploaded files:') ? ' mt-2' : ''}`}>
+              <div className={`flex flex-wrap gap-1.5${displayAnswer && !displayAnswer.startsWith('See uploaded files:') && !displayAnswer.startsWith('Zie geüploade bestanden:') ? ' mt-2' : ''}`}>
                 {tc.attachments.map((att) => {
                   const Icon = att.content_type === 'application/pdf' ? FileType : FileText
                   return (
@@ -485,7 +485,7 @@ const MessageItem = ({ message, agentRun, sessionId }) => {
   if (isUser) {
     const atts = message.attachments || []
     const attNames = atts.map((a) => a.original_filename).join(', ')
-    const isAttachmentOnly = atts.length > 0 && (message.content === 'See attached' || message.content === attNames)
+    const isAttachmentOnly = atts.length > 0 && (message.content === 'See attached' || message.content === 'Zie bijlage' || message.content === attNames)
     return (
       <div className="group flex justify-end gap-2">
         <span className="text-xs text-gray-300 self-end pb-1">
@@ -988,7 +988,7 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
     if (pendingQuestion) {
       const fileNames = attachments.map((a) => a.original_filename).join(', ')
       const answer = trimmed
-        || (attachments.length ? `See uploaded files: ${fileNames}` : '')
+        || (attachments.length ? `Zie geüploade bestanden: ${fileNames}` : '')
       if (!answer) return
       setPendingMessage(trimmed || true)
       setIsAnswering(true)
@@ -1012,7 +1012,7 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
     setUploadError(null)
     const fallback = attachments.length
       ? attachments.map((a) => a.original_filename).join(', ')
-      : 'See attached'
+      : 'Zie bijlage'
     const message = trimmed || fallback
     setPendingMessage(trimmed || true)
     pendingSetAtLength.current = data?.timeline?.length || 0

--- a/frontend/src/services/pendingChat.js
+++ b/frontend/src/services/pendingChat.js
@@ -1,0 +1,21 @@
+/**
+ * Module-level store for pending chat messages during the
+ * NewSessionPanel → SessionDetail transition.
+ *
+ * Survives React re-renders because it lives outside the component tree.
+ */
+
+let _pending = null
+
+export function setPending(sessionId, message, attachments = []) {
+  _pending = { sessionId, message, attachments }
+}
+
+export function consumePending(sessionId) {
+  if (_pending && _pending.sessionId === sessionId) {
+    const val = _pending
+    _pending = null
+    return val
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

- **Agents can now read uploaded files directly** — extracted text is included inline in agent prompts instead of requiring a `read_attachment` tool call. The BA (using cheap glm-5) never called the tool, leaving it blind to uploaded documents. Also includes file contents in HITL answer results for the same reason.
- **Dutch localization of NewSessionPanel** — headings, suggestions, placeholder, and fallback texts all in Dutch. Removed "Druppie" branding.
- **Smooth new-session transition** — eliminated "No timeline entries yet" flash when creating a session. Uses a module-level store (`pendingChat.js`) to pass the optimistic message across React Router navigation, since `setSearchParams` doesn't batch with `useState`.
- **File-only uploads no longer flash English text** — changed "See uploaded files: ..." and "See attached" fallbacks to Dutch equivalents ("Zie geüploade bestanden: ..." / "Zie bijlage").
- **Translation hallucination guard** — the translation model hallucinated an entire fake "Project Phoenix" document when asked to translate a short filename ("technical-design.md" misdetected as Spanish). Added a length-ratio check: if output exceeds 3x input + 50 chars, it's rejected as hallucinated.
- **Label translation fallback** — added `translate_label` method with `_looks_untranslated` heuristic. If a translated multiple-choice option still looks English (>60% word overlap), retries with the full translate prompt. Zero overhead on successful translations.

## Files changed

| File | Change |
|------|--------|
| `druppie/core/translation.py` | Model updated (Mistral → Gemma 3 27B), hallucination guard, `translate_label` with English-detection fallback |
| `druppie/execution/orchestrator.py` | `_build_attachment_context` includes extracted text inline |
| `druppie/execution/tool_executor.py` | `complete_after_answer` includes `uploaded_file_contents`; choices use `translate_label` |
| `frontend/src/components/chat/NewSessionPanel.jsx` | Dutch text, loading state with file chips, `pendingChat` integration |
| `frontend/src/components/chat/SessionDetail.jsx` | Optimistic message via `consumePending`, Dutch fallbacks, spinner for active empty sessions |
| `frontend/src/services/pendingChat.js` | New module-level store for cross-component message passing |

## Test plan

### Agent file reading (backend)
- [x] Start a new Dutch session, upload a PDF at session start → the BA should reference the file's actual content in its first question (not say "no attachments accessible")
- [x] Mid-conversation, answer a HITL question by uploading a PDF without typing text → the BA should read the file and respond to its contents

### Dutch localization (frontend)
- [x] Open the chat page with no session selected → NewSessionPanel shows Dutch headings ("Wat wil je bouwen?"), Dutch suggestions, Dutch placeholder, no "Druppie" text
- [x] Upload a file without text as a HITL answer → answer bubble shows file chips, no "See uploaded files: ..." English text
- [x] Upload a file without text at session start → loading state shows file chips with PDF icon, no English fallback

### Transition smoothness (frontend)
- [x] Start a new session by typing a message → message appears immediately as optimistic bubble with spinner, no "No timeline entries yet" flash
- [x] Start a new session by uploading a file only → file chips appear immediately, spinner shows, no flash

### Translation quality (backend)
- [x] Upload a file with only a filename as message text (e.g. "technical-design.md") → should NOT hallucinate a fake document as translation; router prompt should contain the original filename
- [x] Multiple choice options should all appear in Dutch — check that no option is left in English
- [x] Check backend logs: `label_translation_looks_english_retrying` should appear if/when the fallback fires, `translation_hallucination_detected` if a hallucination is caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)