### PR TITLE
fix: align build context for module-archimate and module-registry Dockerfiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -300,8 +300,8 @@ services:
 
   module-archimate:
     build:
-      context: ./druppie/mcp-servers
-      dockerfile: module-archimate/Dockerfile
+      context: ./druppie
+      dockerfile: mcp-servers/module-archimate/Dockerfile
     profiles: [infra, dev, prod]
     environment:
       MODELS_DIR: /models
@@ -369,8 +369,8 @@ services:
 
   module-registry:
     build:
-      context: ./druppie/mcp-servers
-      dockerfile: module-registry/Dockerfile
+      context: ./druppie
+      dockerfile: mcp-servers/module-registry/Dockerfile
     profiles: [infra, dev, prod]
     environment:
       DATA_DIR: /data


### PR DESCRIPTION
## Summary

Fixes broken `docker compose build` for `module-archimate` and `module-registry` caused by a mismatch between the Dockerfile COPY paths and the build context.

## Root Cause

Both Dockerfiles reference files with a `mcp-servers/` path prefix (e.g. `COPY mcp-servers/module-archimate/models/ /models/`), and module-registry also needs siblings like `agents/`, `core/`, `skills/`. These paths assume the build context is `./druppie`, but docker-compose.yml was passing `./druppie/mcp-servers`, causing:

```
failed to calculate checksum: "/mcp-servers/module-archimate/models": not found
```

## Fix

Changed the build context from `./druppie/mcp-servers` → `./druppie` and adjusted the dockerfile path accordingly for both modules. module-docker was already using paths relative to the mcp-servers context root so it was unaffected.

## Verification

- `docker compose build module-archimate module-registry` — both build successfully