### PR TITLE
fix(execution): use ContextVar for task-local DB sessions in ToolExecutor

### DIFF
--- a/druppie/execution/tool_executor.py
+++ b/druppie/execution/tool_executor.py
@@ -44,6 +44,10 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger()
 
+# Module-level by design: all ToolExecutor instances share this lookup point,
+# but asyncio copies the context per Task, so each concurrent tool-call sees
+# its own value.  Do NOT convert to instance state — that reintroduces the
+# cross-task race this ContextVar was added to fix.
 _task_db: contextvars.ContextVar["DBSession | None"] = contextvars.ContextVar(
     "_task_db", default=None
 )
@@ -158,21 +162,11 @@ class ToolExecutor:
         self._approval_repo = None
         self._question_repo = None
 
-    def _bind_session(self, db: "DBSession") -> None:
-        """Rebind this executor (and its repos) to a fresh session.
-
-        Used by the short-lived session wrapper in factory mode so each tool
-        execution gets its own connection.
-        """
-        self.db = db
-        self._execution_repo = None
-        self._approval_repo = None
-        self._question_repo = None
-
     @property
     def _active_db(self):
         """Return the task-local DB session if set, otherwise the instance session."""
-        return _task_db.get(None) or self.db
+        task_db = _task_db.get(None)
+        return task_db if task_db is not None else self.db
 
     @property
     def execution_repo(self):

--- a/druppie/execution/tool_executor.py
+++ b/druppie/execution/tool_executor.py
@@ -21,6 +21,7 @@ Flow:
 All database operations go through repositories (no raw db session usage).
 """
 
+import contextvars
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from uuid import UUID
@@ -42,6 +43,10 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session as DBSession
 
 logger = structlog.get_logger()
+
+_task_db: contextvars.ContextVar["DBSession | None"] = contextvars.ContextVar(
+    "_task_db", default=None
+)
 
 
 class ToolCallStatus:
@@ -165,27 +170,44 @@ class ToolExecutor:
         self._question_repo = None
 
     @property
+    def _active_db(self):
+        """Return the task-local DB session if set, otherwise the instance session."""
+        return _task_db.get(None) or self.db
+
+    @property
     def execution_repo(self):
         """ExecutionRepository for ToolCall operations."""
+        task_db = _task_db.get(None)
+        if task_db is not None:
+            from druppie.repositories import ExecutionRepository
+            return ExecutionRepository(task_db)
         if self._execution_repo is None:
             from druppie.repositories import ExecutionRepository
-            self._execution_repo = ExecutionRepository(self.db)
+            self._execution_repo = ExecutionRepository(self._active_db)
         return self._execution_repo
 
     @property
     def approval_repo(self):
         """ApprovalRepository for Approval operations."""
+        task_db = _task_db.get(None)
+        if task_db is not None:
+            from druppie.repositories import ApprovalRepository
+            return ApprovalRepository(task_db)
         if self._approval_repo is None:
             from druppie.repositories import ApprovalRepository
-            self._approval_repo = ApprovalRepository(self.db)
+            self._approval_repo = ApprovalRepository(self._active_db)
         return self._approval_repo
 
     @property
     def question_repo(self):
         """QuestionRepository for Question operations."""
+        task_db = _task_db.get(None)
+        if task_db is not None:
+            from druppie.repositories import QuestionRepository
+            return QuestionRepository(task_db)
         if self._question_repo is None:
             from druppie.repositories import QuestionRepository
-            self._question_repo = QuestionRepository(self.db)
+            self._question_repo = QuestionRepository(self._active_db)
         return self._question_repo
 
     def _apply_injection_rules(
@@ -237,7 +259,7 @@ class ToolExecutor:
         )
 
         # Create context for resolving paths
-        context = ToolContext(self.db, session_id, agent_run_id=agent_run_id)
+        context = ToolContext(self._active_db, session_id, agent_run_id=agent_run_id)
 
         # Apply each rule
         injected_args = dict(args)
@@ -308,7 +330,7 @@ class ToolExecutor:
         except Exception as e:
             # Rollback in case the exception left the transaction poisoned
             try:
-                self.db.rollback()
+                self._active_db.rollback()
             except Exception:
                 pass
             logger.warning(
@@ -420,7 +442,7 @@ class ToolExecutor:
             # Rollback in case the exception left the transaction poisoned
             # (e.g. failed flush during normalization).
             try:
-                self.db.rollback()
+                self._active_db.rollback()
             except Exception:
                 pass
             logger.warning(
@@ -480,32 +502,24 @@ class ToolExecutor:
 
     @contextmanager
     def _scoped_session(self):
-        """Yield a short-lived session for one tool execution (factory mode).
+        """Yield a short-lived, task-local session for one tool execution.
 
-        Opens a fresh session from the configured factory, rebinds this
-        executor's repos to it, and closes it on exit so the connection is
-        returned to the pool the moment the tool call finishes. In non-factory
-        (orchestrator) mode this is a no-op that leaves the injected session in
-        place.
+        Uses a ContextVar so concurrent async tasks each get their own DB
+        session without mutating shared instance state.  In non-factory
+        (orchestrator) mode this is a no-op.
         """
         if self._session_factory is None:
             yield
             return
         db = self._session_factory()
-        previous_db = self.db
+        token = _task_db.set(db)
         try:
-            self._bind_session(db)
             yield
         finally:
             try:
                 db.close()
             finally:
-                # Restore prior binding (None in factory mode) so a stale,
-                # now-closed session is never reused on the next call.
-                self.db = previous_db
-                self._execution_repo = None
-                self._approval_repo = None
-                self._question_repo = None
+                _task_db.reset(token)
 
     async def execute(self, tool_call_id: UUID) -> str:
         """Execute a tool call (public entry — opens a short-lived session in factory mode)."""
@@ -574,7 +588,7 @@ class ToolExecutor:
                 status=ToolCallStatus.FAILED,
                 error=validation_error,
             )
-            self.db.commit()
+            self._active_db.commit()
             return ToolCallStatus.FAILED
 
         # Step 2.6: Generic pre-validation via meta.pre_validate
@@ -624,7 +638,7 @@ class ToolExecutor:
                         status=ToolCallStatus.FAILED,
                         error=content_error,
                     )
-                    self.db.commit()
+                    self._active_db.commit()
                     return ToolCallStatus.FAILED
             except Exception as e:
                 # Pre-validation infrastructure failure — block execution rather than
@@ -644,7 +658,7 @@ class ToolExecutor:
                     status=ToolCallStatus.FAILED,
                     error=error_msg,
                 )
-                self.db.commit()
+                self._active_db.commit()
                 return ToolCallStatus.FAILED
 
         # Step 3: Check tool access and approval for MCP tools (not builtin)
@@ -681,7 +695,7 @@ class ToolExecutor:
                         status=ToolCallStatus.FAILED,
                         error=error_msg,
                     )
-                    self.db.commit()
+                    self._active_db.commit()
                     return ToolCallStatus.FAILED
 
             # Validate file-path access for specialist agents
@@ -693,7 +707,7 @@ class ToolExecutor:
                     status=ToolCallStatus.FAILED,
                     error=path_error,
                 )
-                self.db.commit()
+                self._active_db.commit()
                 return ToolCallStatus.FAILED
 
             needs_approval, required_role = self.mcp_config.needs_approval(
@@ -758,7 +772,7 @@ class ToolExecutor:
                     status=ToolCallStatus.FAILED,
                     error=f"Tool call was rejected by a human reviewer. Reason: {rejection_reason}",
                 )
-                self.db.commit()
+                self._active_db.commit()
             logger.info(
                 "approval_rejected",
                 approval_id=str(approval_id),
@@ -848,7 +862,7 @@ class ToolExecutor:
         # (weaker models won't call read_attachment on their own)
         from druppie.db.models import MessageAttachment
         question_attachments = (
-            self.db.query(MessageAttachment)
+            self._active_db.query(MessageAttachment)
             .filter(MessageAttachment.question_id == question_id)
             .all()
         )
@@ -868,7 +882,7 @@ class ToolExecutor:
             status=ToolCallStatus.COMPLETED,
             result=result,
         )
-        self.db.commit()
+        self._active_db.commit()
 
         logger.info(
             "hitl_tool_completed",
@@ -898,7 +912,7 @@ class ToolExecutor:
             return
 
         from druppie.repositories import SessionRepository
-        session_repo = SessionRepository(self.db)
+        session_repo = SessionRepository(self._active_db)
         session = session_repo.get_by_id(tool_call.session_id)
 
         if not session or not session.language or session.language == "en":
@@ -928,7 +942,7 @@ class ToolExecutor:
                 self.execution_repo.update_tool_call_arguments(
                     tool_call.id, enriched_args
                 )
-                self.db.flush()
+                self._active_db.flush()
                 logger.info(
                     "design_content_translated",
                     tool_call_id=str(tool_call.id),
@@ -973,7 +987,7 @@ class ToolExecutor:
             content=message,
             sequence_number=seq,
         )
-        self.db.flush()
+        self._active_db.flush()
         logger.info("translation_fallback_to_english", session_id=str(session_id))
 
     async def _translate_long_content(
@@ -1067,7 +1081,7 @@ class ToolExecutor:
             tool_call.id,
             status=ToolCallStatus.WAITING_APPROVAL,
         )
-        self.db.commit()
+        self._active_db.commit()
 
         logger.info(
             "approval_created",
@@ -1120,7 +1134,7 @@ class ToolExecutor:
         try:
             from druppie.repositories import SessionRepository
             from druppie.core.translation import get_translation_service
-            session_repo = SessionRepository(self.db)
+            session_repo = SessionRepository(self._active_db)
             session = session_repo.get_by_id(tool_call.session_id)
             if session and session.language and session.language != "en":
                 translator = get_translation_service()
@@ -1182,7 +1196,7 @@ class ToolExecutor:
                     status=ToolCallStatus.FAILED,
                     error=error,
                 )
-                self.db.commit()
+                self._active_db.commit()
                 return ToolCallStatus.FAILED
 
             agent_definition = self._get_agent_definition(tool_call.agent_run_id)
@@ -1199,7 +1213,7 @@ class ToolExecutor:
                     status=ToolCallStatus.FAILED,
                     error=error,
                 )
-                self.db.commit()
+                self._active_db.commit()
                 return ToolCallStatus.FAILED
             if expert_role not in allowed:
                 error = (
@@ -1212,7 +1226,7 @@ class ToolExecutor:
                     status=ToolCallStatus.FAILED,
                     error=error,
                 )
-                self.db.commit()
+                self._active_db.commit()
                 return ToolCallStatus.FAILED
 
         # Create question record via repository
@@ -1233,7 +1247,7 @@ class ToolExecutor:
             tool_call.id,
             status=ToolCallStatus.WAITING_ANSWER,
         )
-        self.db.commit()
+        self._active_db.commit()
 
         logger.info(
             "question_created",
@@ -1286,7 +1300,7 @@ class ToolExecutor:
                     result=result,
                     sandbox_waiting_at=datetime.now(timezone.utc),
                 )
-                self.db.commit()
+                self._active_db.commit()
                 logger.info(
                     "builtin_tool_waiting_sandbox",
                     tool_call_id=str(tool_call.id),
@@ -1306,7 +1320,7 @@ class ToolExecutor:
                 result=result,
                 error=result.get("error") if (not is_success and isinstance(result, dict)) else None,
             )
-            self.db.commit()
+            self._active_db.commit()
 
             logger.info(
                 "builtin_tool_completed",
@@ -1331,7 +1345,7 @@ class ToolExecutor:
                 status=ToolCallStatus.FAILED,
                 error=str(e),
             )
-            self.db.commit()
+            self._active_db.commit()
             return ToolCallStatus.FAILED
 
     async def _execute_mcp_tool(self, tool_call) -> str:
@@ -1388,7 +1402,7 @@ class ToolExecutor:
                 tool_call.id,
                 status=ToolCallStatus.EXECUTING,
             )
-            self.db.commit()
+            self._active_db.commit()
 
             if tool_call.tool_name == "bash":
                 args["tool_call_id"] = str(tool_call.id)
@@ -1446,7 +1460,7 @@ class ToolExecutor:
                 result=result,
                 error=result.get("error") or result.get("stderr") if not is_success else None,
             )
-            self.db.commit()
+            self._active_db.commit()
 
             logger.info(
                 "mcp_tool_completed",
@@ -1472,7 +1486,7 @@ class ToolExecutor:
                 status=ToolCallStatus.FAILED,
                 error=str(e),
             )
-            self.db.commit()
+            self._active_db.commit()
             return ToolCallStatus.FAILED
 
         except Exception as e:
@@ -1486,5 +1500,5 @@ class ToolExecutor:
                 status=ToolCallStatus.FAILED,
                 error=str(e),
             )
-            self.db.commit()
+            self._active_db.commit()
             return ToolCallStatus.FAILED

--- a/druppie/tests/execution/test_tool_executor_scoped_session.py
+++ b/druppie/tests/execution/test_tool_executor_scoped_session.py
@@ -1,0 +1,182 @@
+"""Regression test for ContextVar-based task-local DB session isolation in ToolExecutor.
+
+Guards PR #284 (fix/tool-executor-db-race): ``_scoped_session()`` previously
+mutated shared instance state (``self.db``), so concurrent tool executions
+clobbered each other's DB session — the last task to enter its scope "won" and
+every sibling silently used that session.
+
+The fix uses a module-level ``ContextVar`` (``_task_db``). asyncio copies the
+context when it creates each ``Task``, so every concurrent ``_scoped_session()``
+scope sees its own session via ``_task_db.set(db)`` / ``_task_db.reset(token)``.
+
+These tests FAIL if ``_scoped_session`` is reverted to mutating shared instance
+state (the old race), because the concurrent scopes would collapse onto a single
+shared session.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from druppie.execution.tool_executor import ToolExecutor, _task_db
+
+# Number of concurrent scopes spawned by asyncio.gather. Must be > 1 to exercise
+# cross-task isolation; kept modest to stay fast and deterministic.
+NUM_CONCURRENT = 8
+
+
+def _make_factory():
+    """Return ``(session_factory, created)`` where each call yields a fresh mock.
+
+    ``created`` captures every session the factory produces, in creation order,
+    so tests can assert distinctness by object identity.
+    """
+    created: list[MagicMock] = []
+
+    def factory() -> MagicMock:
+        session = MagicMock(name=f"db-session-{len(created)}")
+        created.append(session)
+        return session
+
+    return factory, created
+
+
+def _make_executor(session_factory) -> ToolExecutor:
+    """Build a ToolExecutor in factory mode with mocked MCP dependencies."""
+    return ToolExecutor(
+        db=None,
+        mcp_http=MagicMock(),
+        mcp_config=MagicMock(),
+        session_factory=session_factory,
+    )
+
+
+class TestScopedSessionTaskIsolation:
+    """Prove concurrent _scoped_session() scopes get distinct task-local sessions."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_scopes_get_distinct_sessions(self):
+        """(c)+(d) Each concurrent scope sees its OWN session, stable across awaits."""
+        factory, created = _make_factory()
+        executor = _make_executor(factory)
+
+        seen_at_entry: dict[int, MagicMock] = {}
+        seen_after_yield: dict[int, MagicMock] = {}
+
+        async def worker(task_index: int) -> None:
+            # asyncio.gather wraps this coroutine in a Task, which copies the
+            # context — so _task_db.set() inside _scoped_session only affects
+            # this task. Under the old shared-state bug, self.db would be
+            # clobbered by sibling tasks during the awaits below.
+            with executor._scoped_session():
+                seen_at_entry[task_index] = executor._active_db
+                # Yield repeatedly so every sibling task enters its own scope
+                # and assigns its session. If isolation were broken, the value
+                # read after these yields would belong to another task.
+                for _ in range(NUM_CONCURRENT):
+                    await asyncio.sleep(0)
+                seen_after_yield[task_index] = executor._active_db
+
+        await asyncio.gather(*(worker(i) for i in range(NUM_CONCURRENT)))
+
+        # (c) The factory produced exactly one fresh session per concurrent scope.
+        assert len(created) == NUM_CONCURRENT
+
+        # (c) Every scope observed a DISTINCT session at entry — no clobbering.
+        entry_ids = {id(s) for s in seen_at_entry.values()}
+        assert len(entry_ids) == NUM_CONCURRENT, "concurrent scopes shared a session"
+
+        # The sessions seen at entry are exactly the ones the factory built.
+        created_ids = {id(s) for s in created}
+        assert entry_ids == created_ids
+
+        # (d) _active_db stayed stable inside each scope across awaits and matched
+        #     the entry value. Under the race bug these would collapse to the
+        #     last-assigned shared session.
+        after_yield_ids = set()
+        for i in range(NUM_CONCURRENT):
+            assert seen_at_entry[i] is seen_after_yield[i], (
+                f"task {i}: _active_db changed mid-scope (session clobbered)"
+            )
+            after_yield_ids.add(id(seen_after_yield[i]))
+        assert len(after_yield_ids) == NUM_CONCURRENT, (
+            "concurrent scopes collapsed to a shared session after yielding"
+        )
+
+    @pytest.mark.asyncio
+    async def test_each_factory_session_closed_on_scope_exit(self):
+        """The finally block in _scoped_session closes every session exactly once."""
+        factory, created = _make_factory()
+        executor = _make_executor(factory)
+
+        async def worker(_) -> None:
+            with executor._scoped_session():
+                await asyncio.sleep(0)
+
+        await asyncio.gather(*(worker(i) for i in range(NUM_CONCURRENT)))
+
+        assert len(created) == NUM_CONCURRENT
+        for session in created:
+            assert session.close.called, "scoped session was not closed on exit"
+
+    @pytest.mark.asyncio
+    async def test_task_db_reset_to_none_within_task_after_scope_exits(self):
+        """(e) Within a task, _task_db reverts to None once the scope exits."""
+        factory, _created = _make_factory()
+        executor = _make_executor(factory)
+
+        assert _task_db.get(None) is None  # baseline before entering
+
+        with executor._scoped_session():
+            # Inside the scope the task-local session is live.
+            assert _task_db.get(None) is not None
+            assert executor._active_db is _task_db.get(None)
+
+        # Scope exited → reset(token) restored the prior (None) value, so there
+        # is no leakage across sequential scopes within the same task.
+        assert _task_db.get(None) is None
+        # _active_db falls back to the instance db (None in factory mode).
+        assert executor._active_db is None
+
+    @pytest.mark.asyncio
+    async def test_no_leakage_into_parent_context_after_concurrent_run(self):
+        """(e) After asyncio.gather returns, the parent context's _task_db is None."""
+        factory, _created = _make_factory()
+        executor = _make_executor(factory)
+
+        assert _task_db.get(None) is None  # parent baseline
+
+        async def worker(_) -> None:
+            with executor._scoped_session():
+                # Inside the child task the task-local session is set.
+                assert _task_db.get(None) is not None
+                await asyncio.sleep(0)
+
+        await asyncio.gather(*(worker(i) for i in range(NUM_CONCURRENT)))
+
+        # No child task's _task_db value leaked into the parent context.
+        assert _task_db.get(None) is None
+        assert executor._active_db is None  # falls back to instance db
+
+    @pytest.mark.asyncio
+    async def test_non_factory_mode_is_noop(self):
+        """Without a session_factory, _scoped_session never touches _task_db."""
+        instance_db = MagicMock(name="instance-db")
+        executor = ToolExecutor(
+            db=instance_db,
+            mcp_http=MagicMock(),
+            mcp_config=MagicMock(),
+            session_factory=None,
+        )
+
+        assert _task_db.get(None) is None
+
+        with executor._scoped_session():
+            # No task-local session set → _active_db falls back to instance db.
+            assert _task_db.get(None) is None
+            assert executor._active_db is instance_db
+
+        assert _task_db.get(None) is None
+        # The instance db was never closed (no-op scope owns no session).
+        assert not instance_db.close.called


### PR DESCRIPTION
## Summary

- **Bug:** `ToolExecutor._scoped_session()` mutated shared instance state (`self.db` and cached repos) when opening short-lived DB sessions. During concurrent subagent fan-out, one task could overwrite another's session mid-execution — causing `InvalidRequestError`, stale reads, or `NoneType` crashes.
- **Fix:** Replaced mutable instance state with a module-level `ContextVar` (`_task_db`) so each async task gets its own isolated DB session. The `_active_db` property checks the ContextVar first, falling back to `self.db` for the orchestrator (non-factory) path.
- All `self.db.*` calls now go through `self._active_db.*`, and repo properties create fresh repos from the ContextVar when set. No shared state is mutated during `_scoped_session` anymore.

## Test plan

- [x] Run `setup-yaml-flow-hello-world` test and verify pipeline completes
- [ ] Verify concurrent tool executions in subagent fan-out scenarios no longer cause DB session errors
- [ ] Check that orchestrator path (non-factory mode) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)