### PR TITLE
fix(repositories): remove duplicate owner_user_id crashing backend startup

### DIFF
--- a/druppie/repositories/attachment_repository.py
+++ b/druppie/repositories/attachment_repository.py
@@ -18,7 +18,6 @@ class AttachmentRepository(BaseRepository):
         owner_user_id: UUID,
         session_id: UUID | None = None,
         extracted_text: str | None = None,
-        owner_user_id: UUID | None = None,
     ) -> MessageAttachment:
         attachment = MessageAttachment(
             owner_user_id=owner_user_id,
@@ -28,7 +27,6 @@ class AttachmentRepository(BaseRepository):
             file_size=file_size,
             storage_path=storage_path,
             extracted_text=extracted_text,
-            owner_user_id=owner_user_id,
         )
         self.db.add(attachment)
         self.db.flush()


### PR DESCRIPTION
## Summary

`colab-dev` currently crash-loops the backend on startup due to a Python `SyntaxError` in `druppie/repositories/attachment_repository.py`. A bad merge left `owner_user_id` declared **twice** in `AttachmentRepository.create()` — once in the function signature and once as a keyword argument in the `MessageAttachment(...)` constructor. Python forbids duplicate parameter names, so the module fails to import, and since `repositories/__init__.py` imports `AttachmentRepository` at module load, the entire `druppie.api.main` import chain fails and uvicorn cannot start.

This removes both duplicates (2 lines deleted), restoring a bootable backend.

## Root cause

`owner_user_id` appeared twice in `create()`:

```python
def create(
    self,
    original_filename: str,
    content_type: str,
    file_size: int,
    storage_path: str,
    owner_user_id: UUID,                    # original (required) — kept
    session_id: UUID | None = None,
    extracted_text: str | None = None,
    owner_user_id: UUID | None = None,      # DUPLICATE — removed
) -> MessageAttachment:
    attachment = MessageAttachment(
        owner_user_id=owner_user_id,        # original kwarg — kept
        session_id=session_id,
        ...
        extracted_text=extracted_text,
        owner_user_id=owner_user_id,        # DUPLICATE — removed
    )
```

The duplicate optional declaration (`UUID | None = None`) and the duplicate constructor kwarg look like merge/rebase leftovers — someone added an optional version without removing the original required one. The body uses the parameter exactly once, so only one declaration is needed.

Startup error (before fix):
```
File "/app/druppie/repositories/attachment_repository.py", line 21
    owner_user_id: UUID | None = None,
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: duplicate argument 'owner_user_id' in function definition
```

## The fix

Removed the two duplicate lines; kept the original required declaration (`owner_user_id: UUID`) and the original constructor kwarg. Net change: **2 deletions, 0 additions**.

## Verification

- **Bug reproduced on `origin/colab-dev`** — both duplicates confirmed present (lines 21 & 31) before the fix.
- **Module parses** — `python3 -c "import ast; ast.parse(open(...).read())"` → `OK` after the fix.
- **Backend boots** — `GET /health` returns `{"status":"healthy","version":"2.0.0"}`; API calls (`/api/status`, `/api/approvals`, `/api/questions/pending`) return 200. No more `SyntaxError` in logs.
- **No callers affected** — `AttachmentRepository.create()` has zero call sites in the codebase (verified via codegraph). The method is currently unused, so this is a pure syntax fix with no behavioral change.
- **No other merge artifacts** — an AST scan of every `.py` file under `druppie/` (checking for duplicate function parameters and duplicate keyword arguments in calls) found **zero** other instances. This was the only file corrupted by this type of merge artifact.

## Test plan for the reviewer

1. **Before applying the fix (reproduce):** on a clean checkout of `colab-dev`, start the dev stack —
   ```bash
   docker compose --profile dev up -d --build druppie-backend-dev
   docker compose logs --tail=20 druppie-backend-dev
   ```
   Observe the backend crash-loop with `SyntaxError: duplicate argument 'owner_user_id' in function definition` and `GET /health` returning no response.
2. **After applying this PR:** rebuild/reload the backend —
   ```bash
   docker compose --profile dev up -d --build druppie-backend-dev
   curl -s http://localhost:${BACKEND_PORT}/health
   ```
   Expect `{"status":"healthy","version":"2.0.0"}` and no `SyntaxError` in `docker compose logs druppie-backend-dev`.
3. **Sanity check the app loads:** open the frontend, log in, confirm the session list renders and a new chat can be started (proves the full import chain is healthy).
4. **(Optional) Confirm no other duplicate-arg bugs** — run a quick AST scan:
   ```bash
   python3 -c "import ast,os; [print(p) for p,_,fs in os.walk('druppie') for f in fs if f.endswith('.py') for n in ast.walk(ast.parse(open(os.path.join(p,f)).read())) if isinstance(n,(ast.FunctionDef,ast.AsyncFunctionDef)) and len(set(a.arg for a in (n.args.posonlyargs or [])+(n.args.args or [])+(n.args.kwonlyargs or []))) < len((n.args.posonlyargs or [])+(n.args.args or [])+(n.args.kwonlyargs or []))]"
   ```
   Expect no output (no duplicate params anywhere).

## Notes

- This is unrelated to PR #287 — it's a pre-existing `colab-dev` regression that was blocking all local development.
- No new columns, no migrations, no config changes — purely a 2-line syntax fix.
