### PR TITLE
fix: unbreak colab-dev build (backend import + module-docker context)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,8 +248,8 @@ services:
 
   module-docker:
     build:
-      context: ./druppie
-      dockerfile: mcp-servers/module-docker/Dockerfile
+      context: ./druppie/mcp-servers
+      dockerfile: module-docker/Dockerfile
     container_name: druppie-module-docker
     profiles: [infra, dev, prod]
     environment:

--- a/druppie/repositories/attachment_repository.py
+++ b/druppie/repositories/attachment_repository.py
@@ -18,7 +18,6 @@ class AttachmentRepository(BaseRepository):
         owner_user_id: UUID,
         session_id: UUID | None = None,
         extracted_text: str | None = None,
-        owner_user_id: UUID | None = None,
     ) -> MessageAttachment:
         attachment = MessageAttachment(
             owner_user_id=owner_user_id,
@@ -28,7 +27,6 @@ class AttachmentRepository(BaseRepository):
             file_size=file_size,
             storage_path=storage_path,
             extracted_text=extracted_text,
-            owner_user_id=owner_user_id,
         )
         self.db.add(attachment)
         self.db.flush()


### PR DESCRIPTION
## Problem

Two issues committed on `colab-dev` prevent a clean build/start for **everyone**, not just one machine:

1. **Backend won't import** — `druppie/repositories/attachment_repository.py` has a duplicate `owner_user_id` argument in `AttachmentRepository.create()`. That's a Python **`SyntaxError`**, so `uvicorn` fails to load the app on startup for anyone (introduced in `61d63361`).
2. **`docker compose --profile dev up --build` fails** — the `module-docker` service used `context: ./druppie` with an `mcp-servers/`-prefixed Dockerfile, but its `COPY module_router.py` / `COPY module-docker/` paths only resolve when the context is `./druppie/mcp-servers`. The build aborts on the `module-docker` stage (introduced in `8d8a0e08`).

## Fix

- Remove the duplicate `owner_user_id` parameter (and the duplicate keyword in the constructor call).
- Point `module-docker` at `context: ./druppie/mcp-servers` + `dockerfile: module-docker/Dockerfile`, matching the ~10 other module services.

## Scope

Build/startup blockers only. Deliberately **excludes** unrelated PDF-upload OCR behaviour.

## Verification

- `python -m compileall druppie/` — clean (no other syntax errors).
- Audited every `build:` context against its Dockerfile's COPY/ADD sources — `module-docker` was the only broken one.
- `docker compose build --no-cache module-docker` — builds clean (exit 0).
- Full `docker compose --profile dev up --build` — all services report healthy; backend `/health` returns `{"status":"healthy"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)