### PR TITLE
fix: unblock colab-dev build/startup + transparent token refresh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,8 +248,8 @@ services:
 
   module-docker:
     build:
-      context: ./druppie
-      dockerfile: mcp-servers/module-docker/Dockerfile
+      context: ./druppie/mcp-servers
+      dockerfile: module-docker/Dockerfile
     container_name: druppie-module-docker
     profiles: [infra, dev, prod]
     environment:

--- a/druppie/db/models/message_attachment.py
+++ b/druppie/db/models/message_attachment.py
@@ -20,7 +20,6 @@ class MessageAttachment(Base):
     session_id = Column(UUID(as_uuid=True), ForeignKey("sessions.id", ondelete="CASCADE"), nullable=True)
     question_id = Column(UUID(as_uuid=True), ForeignKey("questions.id", ondelete="CASCADE"), nullable=True)
     approval_id = Column(UUID(as_uuid=True), ForeignKey("approvals.id", ondelete="CASCADE"), nullable=True)
-    owner_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
 
     original_filename = Column(String(500), nullable=False)
     content_type = Column(String(100), nullable=False)

--- a/druppie/repositories/attachment_repository.py
+++ b/druppie/repositories/attachment_repository.py
@@ -18,7 +18,6 @@ class AttachmentRepository(BaseRepository):
         owner_user_id: UUID,
         session_id: UUID | None = None,
         extracted_text: str | None = None,
-        owner_user_id: UUID | None = None,
     ) -> MessageAttachment:
         attachment = MessageAttachment(
             owner_user_id=owner_user_id,
@@ -28,7 +27,6 @@ class AttachmentRepository(BaseRepository):
             file_size=file_size,
             storage_path=storage_path,
             extracted_text=extracted_text,
-            owner_user_id=owner_user_id,
         )
         self.db.add(attachment)
         self.db.flush()

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -5,11 +5,13 @@
  * Sessions replace Plans, and endpoints use the new API structure.
  */
 
-import { getToken } from './keycloak'
+import { getToken, ensureValidToken, redirectToLogin } from './keycloak'
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
 
 const request = async (endpoint, options = {}) => {
+  await ensureValidToken(30)
+
   const token = getToken()
 
   const isFormData = options.body instanceof FormData
@@ -34,6 +36,15 @@ const request = async (endpoint, options = {}) => {
       ...options,
       headers,
     })
+
+    if (response.status === 401 && !options.__retried) {
+      const refreshed = await ensureValidToken(60)
+      if (refreshed) {
+        return request(endpoint, { ...options, __retried: true })
+      }
+      redirectToLogin()
+      throw new Error('Session expired — please log in again')
+    }
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: 'Unknown error' }))

--- a/frontend/src/services/keycloak.js
+++ b/frontend/src/services/keycloak.js
@@ -146,6 +146,25 @@ export const getToken = () => {
   return keycloakInstance?.token
 }
 
+export const ensureValidToken = async (minValidity = 30) => {
+  if (!keycloakInstance || !keycloakInstance.authenticated) {
+    return false
+  }
+  try {
+    const refreshed = await keycloakInstance.updateToken(minValidity)
+    if (refreshed) {
+      saveTokens(keycloakInstance.token, keycloakInstance.refreshToken)
+    }
+    return true
+  } catch (error) {
+    return false
+  }
+}
+
+export const redirectToLogin = () => {
+  keycloakInstance?.login?.()
+}
+
 export const isAuthenticated = () => {
   return keycloakInstance?.authenticated || false
 }


### PR DESCRIPTION
## Summary

Two independent fixes from debugging the running stack on `colab-dev`. Kept as separate atomic commits since they address unrelated problems.

### 1. `colab-dev` did not build and the backend could not start

- **`docker-compose.yml`** — the `module-docker` service had build `context: ./druppie`, but its Dockerfile does `COPY module-docker/ .` and `COPY module_router.py .`, both of which live in `mcp-servers/`. The image failed to build (`/module-docker: not found`). Set context to `./druppie/mcp-servers` to match every sibling module (`module-coding`, `module-llm`, …).
- **`druppie/db/models/message_attachment.py`** — `owner_user_id` Column was declared twice (merge artifact from `feature/documenter-subsystem`). The second declaration silently shadowed the `nullable=False` owner column. Removed the stale duplicate.
- **`druppie/repositories/attachment_repository.py`** — same merge artifact: `owner_user_id` appeared twice in the `create()` signature and constructor call, raising `SyntaxError: duplicate argument` and preventing the backend from importing. Removed the duplicates.

After these, all 14 images build and the backend starts healthy.

### 2. Expired access tokens surfaced as page errors (e.g. "Failed to load model configuration")

The `request()` helper attached the token but had no refresh/retry logic. When the Keycloak access token expired (60 min lifespan, or SSO idle timeout at 30 min — both set in `iac/realm.yaml`), API calls returned **401** and the UI showed a broken page until the user manually re-logged in. The only refresh mechanism was `onTokenExpired`, which fires *at* expiry and races with in-flight requests.

- **`frontend/src/services/keycloak.js`** — added `ensureValidToken(minValidity)` (wraps `updateToken`, persists via `saveTokens`, returns `false` instead of throwing when unauthenticated or refresh fails) and `redirectToLogin()`.
- **`frontend/src/services/api.js`** — proactively call `ensureValidToken(30)` before each request, and on a **401** refresh once and retry the same request (loop-guarded with a `__retried` flag). If refresh fails, redirect to login instead of leaving a broken page.

Applies to all API calls, not just the Models page.

## Verification

**Build/startup:**
- All 14 images build; `module-docker` healthy.
- Backend `/health` → `{"status":"healthy","version":"2.0.0"}`; no `SyntaxError`.

**Token refresh (Playwright):** logged in as `admin`, forced a 401 on `GET /api/admin/models` via route interception, then triggered a refresh:

```
#115 GET /api/admin/models → 401   (simulated expired token)
#116 GET /api/admin/models → 200   (automatic retry — recovered)
```

The Models page rendered the full config (Providers: 5) with **no** "Failed to load model configuration" error and no JS exceptions.

## Notes

- No backend changes for the token fix; no DB migration needed for the model change (duplicate Column was a silent shadow).
- One pre-existing untracked file (`hitl-card-verification.png`) was intentionally left out of this PR.
