### PR TITLE
fix(uploads): harden PDF OCR pipeline + scanned-PDF reading notice

### DIFF
--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -127,6 +127,7 @@ druppie/
     deployment_service.py
     revert_service.py
     avatar_service.py    # Entra ID profile photo fetch + disk cache
+    attachment_service.py  # Text extraction (pdfplumber + OCR), background extraction scheduling
     document_formatter_service.py
   repositories/
     session_repository.py
@@ -1118,6 +1119,20 @@ All methods reconstruct agent state from the database (LLM call history, tool ca
 **Cooperative pause/cancellation:** The orchestrator checks the session status (via DB poll) before each agent run and after each agent completes. If the status is `paused` or `cancelled`, it stops executing further runs. The agent loop also checks the session status between LLM iterations. This means stopping is cooperative -- it happens at the next check point, not mid-LLM-call. See section 8.9 for the full stop and resume architecture.
 
 **Retry from agent run:** The `POST /api/sessions/{id}/retry-from/{run_id}` endpoint spawns a background task that uses `RevertService` to revert the target run and all subsequent runs, then calls `execute_pending_runs()` to re-execute them. `RevertService` handles git revert (via `revert_to_commit` MCP tool), PR cleanup, and DB record management.
+
+**Background PDF extraction (`attachment_service.py`):**
+
+Scanned-PDF OCR can take minutes, so text extraction runs as a fire-and-forget background task instead of blocking the upload request.
+
+1. **`schedule_extraction(att_id, file_path, content_type)`** -- Called by the upload route after committing the attachment row. Creates an `asyncio.Task` that calls `extract_text()`, writes the result to `attachment.extracted_text` in a fresh DB session, and removes itself from the in-memory registry on completion (success or failure). The upload HTTP response returns immediately.
+
+2. **`_pending_extractions: dict[UUID, asyncio.Task]`** -- In-process registry mapping attachment IDs to their running extraction tasks. Safe because the backend runs a single uvicorn worker, so upload requests and the orchestrator share one event loop. Tasks self-clean on completion via a `finally` block.
+
+3. **`await_extractions(att_ids)`** -- Called by the orchestrator in two places: (a) after linking attachments to a user message (so the first agent sees the text), and (b) inside `build_project_context()` before building session-level attachment context (so agents on retry/resume also see it). Gathers all in-flight tasks for the given IDs and awaits them. Never raises -- failed extractions leave `extracted_text` as `None`. Tolerates unknown IDs, empty lists, and already-done tasks.
+
+4. **Orchestrator integration** -- `build_project_context()` is now `async`. Before building attachment context it calls `await_extractions()` for all session attachments, then re-fetches attachment rows so the `extracted_text` populated by the background task is loaded. The user message and attachment links are committed to the DB *before* awaiting extraction, so the timeline is visible in the UI during a long OCR (enabling the frontend "reading notice"), and the row lock is released so the background extraction commit cannot deadlock.
+
+5. **`text_ready` domain field** -- `Attachment` (in `domain/common.py`) exposes `text_ready: bool`, derived from `bool(extracted_text)` at serialization time in the session repository. No DB column -- purely a computed presentation field consumed by the frontend to toggle the scanned-PDF reading notice.
 
 ### 8.9 Pause and Resume
 

--- a/druppie/agents/builtin_tools.py
+++ b/druppie/agents/builtin_tools.py
@@ -1027,6 +1027,14 @@ async def create_message(
         linked_attachments=linked_count,
     )
 
+    from druppie.core.session_event_manager import get_event_manager
+    try:
+        await get_event_manager().broadcast_message_created(
+            session_id=session_id, message=message,
+        )
+    except Exception:
+        logger.warning("create_message_broadcast_failed", session_id=str(session_id), exc_info=True)
+
     result: dict = {"status": "created", "message": "Message added to timeline"}
     if linked_count:
         result["attachment_count"] = linked_count

--- a/druppie/api/routes/chat.py
+++ b/druppie/api/routes/chat.py
@@ -404,8 +404,8 @@ async def upload_attachment(
 
     storage_path = f"uploads/{attachment.id}/{safe_name}"
     attachment.storage_path = storage_path
-    attachment.extracted_text = await attachment_service.extract_text(file_path, content_type)
     attachment_repo.db.commit()
+    attachment_service.schedule_extraction(attachment.id, file_path, content_type)
 
     return {
         "id": str(attachment.id),

--- a/druppie/api/routes/sessions.py
+++ b/druppie/api/routes/sessions.py
@@ -307,7 +307,7 @@ async def _run_retry_background(
                         project_repo=ctx.project_repo,
                         question_repo=ctx.question_repo,
                     )
-                    ctx_build = orch.build_project_context(session_id)
+                    ctx_build = await orch.build_project_context(session_id)
                     if is_continue:
                         orch.execution_repo.update_status(run_id, AgentRunStatus.RUNNING)
                         orch.execution_repo.commit()
@@ -352,7 +352,7 @@ async def _run_retry_background(
 
             parent_run = ctx.execution_repo.get_by_id(parent_run_id)
             parent_agent = Agent(parent_run.agent_id, db=ctx.execution_repo.db)
-            parent_context = ctx.orchestrator.build_project_context(session_id)
+            parent_context = await ctx.orchestrator.build_project_context(session_id)
             parent_result = await parent_agent.continue_run(
                 session_id=session_id,
                 agent_run_id=parent_run_id,

--- a/druppie/domain/common.py
+++ b/druppie/domain/common.py
@@ -107,6 +107,9 @@ class Attachment(BaseModel):
     content_type: str
     file_size: int
     created_at: datetime
+    # Derived from extracted_text at serialization time (no DB column): False
+    # while a scanned PDF is still being read, True once its text is written.
+    text_ready: bool = False
 
 
 class TokenUsage(BaseModel):

--- a/druppie/execution/orchestrator.py
+++ b/druppie/execution/orchestrator.py
@@ -1001,7 +1001,7 @@ class Orchestrator:
         self.session_repo.update_status(session_id, SessionStatus.ACTIVE)
         self.execution_repo.commit()
 
-        context = self.build_project_context(session_id)
+        context = await self.build_project_context(session_id)
         db = self.execution_repo.db
         agent = Agent(agent_id, db=db, session_id=str(session_id))
 

--- a/druppie/execution/orchestrator.py
+++ b/druppie/execution/orchestrator.py
@@ -247,6 +247,16 @@ class Orchestrator:
             self.attachment_repo.link_to_message(
                 attachment_ids, user_message.id, current_session_id,
             )
+        # Commit the user message + links BEFORE awaiting extraction: this makes
+        # them visible in the timeline during a long OCR (so the UI can show a
+        # 'reading this scanned PDF may take a few minutes' notice) and releases
+        # the row lock so the background extraction commit cannot deadlock.
+        self.execution_repo.commit()
+        if self.attachment_repo:
+            self.attachment_repo.commit()
+        if attachment_ids and self.attachment_repo:
+            from druppie.services import attachment_service
+            await attachment_service.await_extractions(attachment_ids)
             attachments = self.attachment_repo.get_by_ids(attachment_ids)
             attachment_context = self._build_attachment_context(attachments)
 
@@ -415,7 +425,7 @@ class Orchestrator:
 
             # Rebuild context before each agent so it reflects changes
             # from previous agents (e.g., set_intent creates project/repo)
-            context = self.build_project_context(session_id)
+            context = await self.build_project_context(session_id)
 
             # Planner needs the accumulated summary from all completed agents
             # so it knows what has been done. Build it fresh from the DB.
@@ -558,7 +568,7 @@ class Orchestrator:
         )
         return f"PREVIOUS AGENT SUMMARY:\n{accumulated}\n\n---\n\n{prompt}"
 
-    def build_project_context(self, session_id: UUID) -> dict | None:
+    async def build_project_context(self, session_id: UUID) -> dict | None:
         """Build project context for agents.
 
         Retrieves project info (repo_name, repo_owner, etc.) from the session
@@ -636,6 +646,10 @@ class Orchestrator:
 
         # Include session-level attachment context so ALL agents see uploaded files
         if self.attachment_repo:
+            attachments = self.attachment_repo.get_for_session(session_id)
+            from druppie.services import attachment_service
+            await attachment_service.await_extractions([a.id for a in attachments])
+            # Re-fetch so extracted_text populated by background tasks is loaded.
             attachments = self.attachment_repo.get_for_session(session_id)
             att_ctx = self._build_attachment_context(attachments)
             if att_ctx:
@@ -1107,7 +1121,7 @@ class Orchestrator:
         )
 
         # Step 5: Build fresh context and continue the agent
-        context = self.build_project_context(session_id)
+        context = await self.build_project_context(session_id)
         agent = Agent(agent_run.agent_id, db=db, session_id=str(session_id))
         result = await agent.continue_run(
             session_id=session_id,
@@ -1445,7 +1459,7 @@ class Orchestrator:
             self.session_repo.update_status(session_id, SessionStatus.ACTIVE)
             self.execution_repo.commit()
 
-            context = self.build_project_context(session_id)
+            context = await self.build_project_context(session_id)
             agent = Agent(agent_run.agent_id, db=db, session_id=str(session_id))
             try:
                 result = await agent.continue_run(
@@ -1577,7 +1591,7 @@ class Orchestrator:
             self.session_repo.update_status(session_id, SessionStatus.ACTIVE)
             self.execution_repo.commit()
 
-            parent_context = self.build_project_context(session_id)
+            parent_context = await self.build_project_context(session_id)
 
             parent_agent = Agent(parent_run.agent_id, db=db)
             parent_result = await parent_agent.continue_run(
@@ -1660,7 +1674,7 @@ class Orchestrator:
 
                 # Already RUNNING — just continue it
                 db = self.execution_repo.db
-                context = self.build_project_context(session_id)
+                context = await self.build_project_context(session_id)
                 agent = Agent(orphan_run.agent_id, db=db, session_id=str(session_id))
                 try:
                     result = await agent.continue_run(
@@ -1792,7 +1806,7 @@ class Orchestrator:
         )
 
         db = self.execution_repo.db
-        context = self.build_project_context(session_id)
+        context = await self.build_project_context(session_id)
         if user_context and context is not None:
             context["user_context"] = user_context
             from druppie.db.models.llm_call import LlmCall

--- a/druppie/repositories/session_repository.py
+++ b/druppie/repositories/session_repository.py
@@ -350,6 +350,7 @@ class SessionRepository(BaseRepository):
                     content_type=att.content_type,
                     file_size=att.file_size,
                     created_at=att.created_at,
+                    text_ready=bool(att.extracted_text),
                 )
             )
 
@@ -714,6 +715,7 @@ class SessionRepository(BaseRepository):
                         content_type=a.content_type,
                         file_size=a.file_size,
                         created_at=a.created_at,
+                        text_ready=bool(a.extracted_text),
                     )
                     for a in att_rows
                 ]
@@ -772,6 +774,7 @@ class SessionRepository(BaseRepository):
                         content_type=a.content_type,
                         file_size=a.file_size,
                         created_at=a.created_at,
+                        text_ready=bool(a.extracted_text),
                     )
                     for a in att_rows
                 ]

--- a/druppie/repositories/session_repository.py
+++ b/druppie/repositories/session_repository.py
@@ -350,7 +350,7 @@ class SessionRepository(BaseRepository):
                     content_type=att.content_type,
                     file_size=att.file_size,
                     created_at=att.created_at,
-                    text_ready=bool(att.extracted_text),
+                    text_ready=att.extracted_text is not None,
                 )
             )
 
@@ -715,7 +715,7 @@ class SessionRepository(BaseRepository):
                         content_type=a.content_type,
                         file_size=a.file_size,
                         created_at=a.created_at,
-                        text_ready=bool(a.extracted_text),
+                        text_ready=a.extracted_text is not None,
                     )
                     for a in att_rows
                 ]
@@ -774,7 +774,7 @@ class SessionRepository(BaseRepository):
                         content_type=a.content_type,
                         file_size=a.file_size,
                         created_at=a.created_at,
-                        text_ready=bool(a.extracted_text),
+                        text_ready=a.extracted_text is not None,
                     )
                     for a in att_rows
                 ]

--- a/druppie/services/attachment_service.py
+++ b/druppie/services/attachment_service.py
@@ -6,6 +6,7 @@ import mimetypes
 import os
 import re
 from pathlib import Path
+from uuid import UUID
 
 import httpx
 import structlog
@@ -20,6 +21,9 @@ DEEPINFRA_BASE_URL = "https://api.deepinfra.com/v1/openai"
 DEEPINFRA_OCR_MODEL = "google/gemma-4-31B-it"
 OCR_PAGE_TIMEOUT = 120
 OCR_MAX_PAGES = 50
+OCR_CONCURRENCY = 4
+OCR_MAX_RETRIES = 2
+OCR_RETRY_BACKOFF = 2.0
 
 _DEFAULT_ALLOWED_CONTENT_TYPES = {
     "text/plain",
@@ -170,7 +174,11 @@ def _render_pdf_pages_to_png(file_path: Path, max_pages: int) -> list[bytes]:
 
 
 async def _extract_pdf_text_ocr(file_path: Path) -> str | None:
-    """OCR fallback: render PDF pages to PNG, send to vision model."""
+    """OCR fallback: render PDF pages to PNG, send to vision model.
+
+    Pages are OCR'd concurrently (up to OCR_CONCURRENCY at a time) and each
+    page is retried up to OCR_MAX_RETRIES times for transient failures.
+    """
     api_key = os.getenv("DEEPINFRA_API_KEY", "")
     if not api_key:
         logger.info("deepinfra_ocr_skipped", reason="DEEPINFRA_API_KEY not set")
@@ -189,44 +197,73 @@ async def _extract_pdf_text_ocr(file_path: Path) -> str | None:
         logger.warning("pdf_ocr_no_pages", path=str(file_path))
         return None
 
-    text_parts = []
+    semaphore = asyncio.Semaphore(OCR_CONCURRENCY)
+
+    async def _ocr_one_page(
+        client: httpx.AsyncClient, page_index: int, png_bytes: bytes
+    ) -> str | None:
+        b64 = base64.b64encode(png_bytes).decode()
+        image_content = {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{b64}"},
+        }
+        body = {
+            "model": DEEPINFRA_OCR_MODEL,
+            "max_tokens": 8192,
+            "temperature": 0.0,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        image_content,
+                        {"type": "text", "text": "Extract all text from this document page. Return only the extracted text, preserving the original structure and formatting. Do not add commentary."},
+                    ],
+                }
+            ],
+        }
+        last_exc: Exception | None = None
+        async with semaphore:
+            for attempt in range(OCR_MAX_RETRIES + 1):
+                try:
+                    resp = await client.post(
+                        f"{DEEPINFRA_BASE_URL}/chat/completions",
+                        headers={"Authorization": f"Bearer {api_key}"},
+                        timeout=OCR_PAGE_TIMEOUT,
+                        json=body,
+                    )
+                    resp.raise_for_status()
+                    data = resp.json()
+                    page_text = data["choices"][0]["message"]["content"]
+                    if page_text and page_text.strip():
+                        return page_text.strip()
+                    return None
+                except (
+                    httpx.TimeoutException,
+                    httpx.HTTPStatusError,
+                    httpx.NetworkError,
+                    KeyError,
+                    ValueError,
+                ) as e:
+                    last_exc = e
+                    if attempt < OCR_MAX_RETRIES:
+                        await asyncio.sleep(OCR_RETRY_BACKOFF)
+                        continue
+                    break
+        logger.warning(
+            "pdf_ocr_page_failed",
+            path=str(file_path),
+            page=page_index,
+            error_type=type(last_exc).__name__ if last_exc else "Unknown",
+            error=str(last_exc) if last_exc else "",
+        )
+        return None
+
     async with httpx.AsyncClient() as client:
-        for i, png_bytes in enumerate(png_pages):
-            b64 = base64.b64encode(png_bytes).decode()
-            image_content = {
-                "type": "image_url",
-                "image_url": {"url": f"data:image/png;base64,{b64}"},
-            }
+        page_results = await asyncio.gather(
+            *[_ocr_one_page(client, i, b) for i, b in enumerate(png_pages)]
+        )
 
-            try:
-                resp = await client.post(
-                    f"{DEEPINFRA_BASE_URL}/chat/completions",
-                    headers={"Authorization": f"Bearer {api_key}"},
-                    timeout=OCR_PAGE_TIMEOUT,
-                    json={
-                        "model": DEEPINFRA_OCR_MODEL,
-                        "max_tokens": 8192,
-                        "temperature": 0.0,
-                        "messages": [
-                            {
-                                "role": "user",
-                                "content": [
-                                    image_content,
-                                    {"type": "text", "text": "Extract all text from this document page. Return only the extracted text, preserving the original structure and formatting. Do not add commentary."},
-                                ],
-                            }
-                        ],
-                    },
-                )
-                resp.raise_for_status()
-                data = resp.json()
-                page_text = data["choices"][0]["message"]["content"]
-                if page_text and page_text.strip():
-                    text_parts.append(page_text.strip())
-            except (httpx.TimeoutException, httpx.HTTPStatusError, KeyError, ValueError) as e:
-                logger.warning("pdf_ocr_page_failed", path=str(file_path), page=i, error=str(e)[:200])
-                continue
-
+    text_parts = [t for t in page_results if t]
     full_text = "\n".join(text_parts)
     if full_text.strip():
         logger.info("pdf_ocr_success", path=str(file_path), chars=len(full_text), pages=len(text_parts))
@@ -253,3 +290,78 @@ def delete_file(storage_path: str) -> None:
                 parent.rmdir()
     except (OSError, ValueError) as e:
         logger.warning("file_delete_failed", path=storage_path, error=str(e))
+
+
+# In-process background extraction registry. Safe because the backend runs a
+# single uvicorn worker (dev --reload, prod single-worker enforced by commit),
+# so upload requests and the orchestrator background task share one event loop.
+_pending_extractions: dict[UUID, asyncio.Task] = {}
+
+
+async def await_extractions(att_ids: list[UUID]) -> None:
+    """Wait for any in-flight background extraction tasks to finish.
+
+    Called by the orchestrator before building attachment context, so a chat
+    message sent right after upload still sees the full OCR output. Never
+    raises — a failed extraction leaves extracted_text as None. Tolerates
+    unknown ids, empty lists, and already-done tasks.
+    """
+    if not att_ids:
+        return
+    pending: list[asyncio.Task] = []
+    for aid in att_ids:
+        task = _pending_extractions.get(aid)
+        if task is not None and not task.done():
+            pending.append(task)
+    if not pending:
+        return
+    for result in await asyncio.gather(*pending, return_exceptions=True):
+        if isinstance(result, Exception):
+            logger.warning("extraction_await_failed", error=str(result)[:200])
+
+
+def schedule_extraction(att_id: UUID, file_path: Path, content_type: str) -> None:
+    """Schedule background text extraction for an attachment. Never raises.
+
+    The upload route calls this after committing the attachment row, so the
+    HTTP response returns immediately while extraction (potentially minutes
+    for scanned PDFs) continues in the background. The task updates the
+    attachment row's extracted_text in a fresh DB session and removes itself
+    from _pending_extractions on completion.
+    """
+    if att_id in _pending_extractions:
+        # Already scheduled — avoid orphaning a running task.
+        return
+
+    async def _run_extraction() -> None:
+        try:
+            text = await extract_text(file_path, content_type)
+            from druppie.db.database import SessionLocal
+            from druppie.repositories.attachment_repository import AttachmentRepository
+
+            db = SessionLocal()
+            try:
+                repo = AttachmentRepository(db)
+                attachment = repo.get_by_id(att_id)
+                if attachment is not None:
+                    attachment.extracted_text = text
+                    db.commit()
+            finally:
+                db.close()
+            logger.info(
+                "extraction_completed",
+                attachment_id=str(att_id),
+                chars=len(text) if text else 0,
+            )
+        except Exception:
+            logger.error(
+                "extraction_background_failed",
+                attachment_id=str(att_id),
+                exc_info=True,
+            )
+        finally:
+            _pending_extractions.pop(att_id, None)
+
+    task = asyncio.create_task(_run_extraction())
+    _pending_extractions[att_id] = task
+    logger.info("extraction_scheduled", attachment_id=str(att_id))

--- a/druppie/services/attachment_service.py
+++ b/druppie/services/attachment_service.py
@@ -18,7 +18,7 @@ MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
 MAX_EXTRACTED_TEXT = 50_000  # characters
 
 DEEPINFRA_BASE_URL = "https://api.deepinfra.com/v1/openai"
-DEEPINFRA_OCR_MODEL = "google/gemma-4-31B-it"
+DEEPINFRA_OCR_MODEL = "google/gemma-3-27b-it"
 OCR_PAGE_TIMEOUT = 120
 OCR_MAX_PAGES = 50
 OCR_CONCURRENCY = 4
@@ -344,7 +344,7 @@ def schedule_extraction(att_id: UUID, file_path: Path, content_type: str) -> Non
                 repo = AttachmentRepository(db)
                 attachment = repo.get_by_id(att_id)
                 if attachment is not None:
-                    attachment.extracted_text = text
+                    attachment.extracted_text = text if text else ""
                     db.commit()
             finally:
                 db.close()

--- a/druppie/testing/bounded_orchestrator.py
+++ b/druppie/testing/bounded_orchestrator.py
@@ -98,7 +98,7 @@ class BoundedOrchestrator:
                         self._cancel_remaining_runs(session_id, execution_repo, session_repo)
                         return
 
-                context = orchestrator.build_project_context(session_id)
+                context = await orchestrator.build_project_context(session_id)
                 execution_repo.update_status(next_run.id, AgentRunStatus.RUNNING)
                 execution_repo.commit()
 
@@ -154,7 +154,7 @@ class BoundedOrchestrator:
             self._db.flush()
 
             # Build context from the session's project
-            context = orchestrator.build_project_context(session_id)
+            context = await orchestrator.build_project_context(session_id)
 
             # Get the accumulated summary from the LAST completed run.
             # Each run's done() already accumulates all prior summaries,

--- a/druppie/tests/test_attachment_service.py
+++ b/druppie/tests/test_attachment_service.py
@@ -1,0 +1,615 @@
+"""Tests for attachment_service background extraction pipeline.
+
+Covers the new functionality added by the pdf-upload-hardening PR:
+- schedule_extraction: spawns a background task, registers in _pending_extractions
+- await_extractions: waits for in-flight background tasks to complete
+- extract_text: text/PDF happy paths with mocked I/O
+- _extract_pdf_text_ocr: concurrent OCR with retry logic
+- Error handling: extraction failure cleans up _pending_extractions
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import httpx
+import pytest
+
+# Stub out fastmcp before druppie.services.__init__ pulls in the full
+# execution chain.  The attachment_service module itself never uses fastmcp;
+# the error comes from transitive imports via WorkflowService -> Orchestrator.
+for _mod in ("fastmcp", "fastmcp.client", "fastmcp.client.transports", "fastmcp.settings"):
+    sys.modules.setdefault(_mod, MagicMock())
+
+from druppie.services import attachment_service
+from druppie.services.attachment_service import (
+    MAX_EXTRACTED_TEXT,
+    OCR_MAX_RETRIES,
+    _pending_extractions,
+    await_extractions,
+    extract_text,
+    schedule_extraction,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_pending():
+    """Ensure _pending_extractions is empty before and after every test."""
+    _pending_extractions.clear()
+    yield
+    # Cancel any lingering tasks so they don't leak into the next test.
+    for task in _pending_extractions.values():
+        task.cancel()
+    _pending_extractions.clear()
+
+
+# ---------------------------------------------------------------------------
+# schedule_extraction
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleExtraction:
+    @pytest.mark.asyncio
+    async def test_registers_task_in_pending(self):
+        """schedule_extraction adds the attachment id to _pending_extractions."""
+        att_id = uuid4()
+        fake_path = Path("/tmp/fake.txt")
+
+        with patch.object(attachment_service, "extract_text", new_callable=AsyncMock, return_value="hello"):
+            with patch("druppie.db.database.SessionLocal") as MockSL:
+                mock_db = MagicMock()
+                MockSL.return_value = mock_db
+                with patch("druppie.repositories.attachment_repository.AttachmentRepository") as MockRepo:
+                    mock_repo = MagicMock()
+                    mock_repo.get_by_id.return_value = MagicMock()
+                    MockRepo.return_value = mock_repo
+
+                    schedule_extraction(att_id, fake_path, "text/plain")
+
+                    assert att_id in _pending_extractions
+                    assert isinstance(_pending_extractions[att_id], asyncio.Task)
+
+                    # Let the task finish.
+                    await _pending_extractions[att_id]
+
+    @pytest.mark.asyncio
+    async def test_task_updates_db_and_cleans_up(self):
+        """Background task writes extracted_text to DB and removes itself from registry."""
+        att_id = uuid4()
+        fake_path = Path("/tmp/fake.txt")
+        mock_attachment = MagicMock()
+
+        with patch.object(attachment_service, "extract_text", new_callable=AsyncMock, return_value="extracted"):
+            with patch("druppie.db.database.SessionLocal") as MockSL:
+                mock_db = MagicMock()
+                MockSL.return_value = mock_db
+                with patch("druppie.repositories.attachment_repository.AttachmentRepository") as MockRepo:
+                    mock_repo = MagicMock()
+                    mock_repo.get_by_id.return_value = mock_attachment
+                    MockRepo.return_value = mock_repo
+
+                    schedule_extraction(att_id, fake_path, "text/plain")
+                    await _pending_extractions[att_id]
+
+        # Verify DB was updated and closed.
+        assert mock_attachment.extracted_text == "extracted"
+        mock_db.commit.assert_called_once()
+        mock_db.close.assert_called_once()
+
+        # Task should have removed itself from the registry.
+        assert att_id not in _pending_extractions
+
+    @pytest.mark.asyncio
+    async def test_duplicate_schedule_is_noop(self):
+        """Calling schedule_extraction twice for the same id does not replace the task."""
+        att_id = uuid4()
+        fake_path = Path("/tmp/fake.txt")
+
+        with patch.object(attachment_service, "extract_text", new_callable=AsyncMock, return_value="t"):
+            with patch("druppie.db.database.SessionLocal") as MockSL:
+                MockSL.return_value = MagicMock()
+                with patch("druppie.repositories.attachment_repository.AttachmentRepository") as MockRepo:
+                    MockRepo.return_value = MagicMock(get_by_id=MagicMock(return_value=MagicMock()))
+
+                    schedule_extraction(att_id, fake_path, "text/plain")
+                    first_task = _pending_extractions[att_id]
+
+                    schedule_extraction(att_id, fake_path, "text/plain")
+                    assert _pending_extractions[att_id] is first_task
+
+                    await first_task
+
+    @pytest.mark.asyncio
+    async def test_extraction_failure_cleans_up_pending(self):
+        """If extract_text raises, the task still removes itself from _pending_extractions."""
+        att_id = uuid4()
+        fake_path = Path("/tmp/fake.pdf")
+
+        with patch.object(
+            attachment_service, "extract_text", new_callable=AsyncMock, side_effect=RuntimeError("boom")
+        ):
+            schedule_extraction(att_id, fake_path, "application/pdf")
+            task = _pending_extractions[att_id]
+            await task
+
+        # Must be cleaned up even after failure.
+        assert att_id not in _pending_extractions
+
+    @pytest.mark.asyncio
+    async def test_attachment_not_found_still_succeeds(self):
+        """If the attachment row is gone by the time extraction finishes, no crash."""
+        att_id = uuid4()
+        fake_path = Path("/tmp/fake.txt")
+
+        with patch.object(attachment_service, "extract_text", new_callable=AsyncMock, return_value="text"):
+            with patch("druppie.db.database.SessionLocal") as MockSL:
+                mock_db = MagicMock()
+                MockSL.return_value = mock_db
+                with patch("druppie.repositories.attachment_repository.AttachmentRepository") as MockRepo:
+                    mock_repo = MagicMock()
+                    mock_repo.get_by_id.return_value = None  # deleted
+                    MockRepo.return_value = mock_repo
+
+                    schedule_extraction(att_id, fake_path, "text/plain")
+                    await _pending_extractions[att_id]
+
+        # Should not crash and should clean up.
+        assert att_id not in _pending_extractions
+        mock_db.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# await_extractions
+# ---------------------------------------------------------------------------
+
+
+class TestAwaitExtractions:
+    @pytest.mark.asyncio
+    async def test_empty_list(self):
+        """await_extractions returns immediately for an empty list."""
+        await await_extractions([])  # Should not raise.
+
+    @pytest.mark.asyncio
+    async def test_unknown_ids_tolerated(self):
+        """Unknown attachment ids are silently ignored."""
+        await await_extractions([uuid4(), uuid4()])
+
+    @pytest.mark.asyncio
+    async def test_waits_for_pending_task(self):
+        """await_extractions blocks until the pending task completes."""
+        att_id = uuid4()
+        completed = False
+
+        async def slow_task():
+            nonlocal completed
+            await asyncio.sleep(0.05)
+            completed = True
+
+        task = asyncio.create_task(slow_task())
+        _pending_extractions[att_id] = task
+
+        await await_extractions([att_id])
+        assert completed
+
+    @pytest.mark.asyncio
+    async def test_already_done_task_skipped(self):
+        """A task that is already done does not block."""
+        att_id = uuid4()
+
+        async def instant():
+            return
+
+        task = asyncio.create_task(instant())
+        await task  # Ensure it finishes.
+        _pending_extractions[att_id] = task
+
+        # Should return instantly — no pending tasks to gather.
+        await await_extractions([att_id])
+
+    @pytest.mark.asyncio
+    async def test_failed_task_does_not_raise(self):
+        """If a pending extraction task raised, await_extractions swallows the error."""
+        att_id = uuid4()
+
+        async def failing_task():
+            raise RuntimeError("extraction failed")
+
+        task = asyncio.create_task(failing_task())
+        _pending_extractions[att_id] = task
+        # Give the task time to fail.
+        await asyncio.sleep(0.01)
+
+        # Must not raise.
+        await await_extractions([att_id])
+
+    @pytest.mark.asyncio
+    async def test_mixed_known_and_unknown(self):
+        """Mix of known pending, known done, and unknown ids all handled."""
+        pending_id = uuid4()
+        done_id = uuid4()
+        unknown_id = uuid4()
+        value = []
+
+        async def track():
+            value.append("done")
+
+        pending_task = asyncio.create_task(track())
+        _pending_extractions[pending_id] = pending_task
+
+        done_task = asyncio.create_task(asyncio.sleep(0))
+        await done_task
+        _pending_extractions[done_id] = done_task
+
+        await await_extractions([pending_id, done_id, unknown_id])
+        assert value == ["done"]
+
+
+# ---------------------------------------------------------------------------
+# extract_text
+# ---------------------------------------------------------------------------
+
+
+class TestExtractText:
+    @pytest.mark.asyncio
+    async def test_text_file_reads_content(self, tmp_path):
+        """Plain text files are read directly and truncated to MAX_EXTRACTED_TEXT."""
+        f = tmp_path / "notes.txt"
+        f.write_text("Hello, world!", encoding="utf-8")
+
+        result = await extract_text(f, "text/plain")
+        assert result == "Hello, world!"
+
+    @pytest.mark.asyncio
+    async def test_text_file_truncated(self, tmp_path):
+        """Text longer than MAX_EXTRACTED_TEXT is truncated."""
+        f = tmp_path / "big.txt"
+        f.write_text("x" * (MAX_EXTRACTED_TEXT + 100), encoding="utf-8")
+
+        result = await extract_text(f, "text/plain")
+        assert result is not None
+        assert len(result) == MAX_EXTRACTED_TEXT
+
+    @pytest.mark.asyncio
+    async def test_text_file_read_failure(self, tmp_path):
+        """Unreadable text file returns None instead of crashing."""
+        f = tmp_path / "bad.txt"
+        f.write_bytes(b"\x80\x81")  # not valid utf-8 in strict mode
+
+        # The service uses errors="replace", so it actually succeeds.
+        # Simulate a real failure by making the path a directory.
+        d = tmp_path / "dir_not_file"
+        d.mkdir()
+        result = await extract_text(d, "text/plain")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_markdown_treated_as_text(self, tmp_path):
+        """Markdown content type is handled by the text branch."""
+        f = tmp_path / "doc.md"
+        f.write_text("# Title\n\nBody", encoding="utf-8")
+
+        result = await extract_text(f, "text/markdown")
+        assert result == "# Title\n\nBody"
+
+    @pytest.mark.asyncio
+    async def test_pdf_delegates_to_pdf_extractor(self, tmp_path):
+        """application/pdf delegates to _extract_pdf_text."""
+        f = tmp_path / "doc.pdf"
+        f.write_bytes(b"fake-pdf")
+
+        with patch(
+            "druppie.services.attachment_service._extract_pdf_text",
+            new_callable=AsyncMock,
+            return_value="PDF content here",
+        ) as mock_pdf:
+            result = await extract_text(f, "application/pdf")
+
+        assert result == "PDF content here"
+        mock_pdf.assert_awaited_once_with(f)
+
+    @pytest.mark.asyncio
+    async def test_unknown_content_type_returns_none(self, tmp_path):
+        """Unsupported content types return None."""
+        f = tmp_path / "image.png"
+        f.write_bytes(b"\x89PNG")
+
+        result = await extract_text(f, "image/png")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_pdf_text_ocr — retry & concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestOcrRetryAndConcurrency:
+    @pytest.mark.asyncio
+    async def test_ocr_skipped_without_api_key(self, monkeypatch):
+        """OCR is skipped when DEEPINFRA_API_KEY is not set."""
+        monkeypatch.delenv("DEEPINFRA_API_KEY", raising=False)
+
+        result = await attachment_service._extract_pdf_text_ocr(Path("/tmp/fake.pdf"))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ocr_retries_on_timeout(self, monkeypatch):
+        """OCR retries up to OCR_MAX_RETRIES times on timeout, then returns None."""
+        monkeypatch.setenv("DEEPINFRA_API_KEY", "test-key")
+
+        call_count = 0
+
+        async def mock_post(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise httpx.TimeoutException("timed out")
+
+        with patch.object(
+            attachment_service, "_render_pdf_pages_to_png", return_value=[b"fake-png"]
+        ):
+            with patch("httpx.AsyncClient") as MockClient:
+                mock_client = AsyncMock()
+                mock_client.post = mock_post
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                MockClient.return_value = mock_client
+
+                with patch.object(attachment_service, "OCR_RETRY_BACKOFF", 0.01):
+                    result = await attachment_service._extract_pdf_text_ocr(Path("/tmp/fake.pdf"))
+
+        assert result is None
+        assert call_count == OCR_MAX_RETRIES + 1
+
+    @pytest.mark.asyncio
+    async def test_ocr_succeeds_on_retry(self, monkeypatch):
+        """OCR succeeds after a transient failure on the first attempt."""
+        monkeypatch.setenv("DEEPINFRA_API_KEY", "test-key")
+
+        call_count = 0
+
+        async def mock_post(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.TimeoutException("timed out")
+            # Succeed on second attempt.
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {
+                "choices": [{"message": {"content": "Extracted page text"}}]
+            }
+            return resp
+
+        with patch.object(
+            attachment_service, "_render_pdf_pages_to_png", return_value=[b"fake-png"]
+        ):
+            with patch("httpx.AsyncClient") as MockClient:
+                mock_client = AsyncMock()
+                mock_client.post = mock_post
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                MockClient.return_value = mock_client
+
+                with patch.object(attachment_service, "OCR_RETRY_BACKOFF", 0.01):
+                    result = await attachment_service._extract_pdf_text_ocr(Path("/tmp/fake.pdf"))
+
+        assert result == "Extracted page text"
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_ocr_concurrent_pages(self, monkeypatch):
+        """Multiple pages are OCR'd concurrently and results are joined."""
+        monkeypatch.setenv("DEEPINFRA_API_KEY", "test-key")
+
+        page_texts = ["Page 1 content", "Page 2 content", "Page 3 content"]
+        call_pages = []
+
+        async def mock_post(*args, **kwargs):
+            body = kwargs.get("json", {})
+            # Track that we got called
+            call_pages.append(True)
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            idx = len(call_pages) - 1
+            text = page_texts[idx] if idx < len(page_texts) else ""
+            resp.json.return_value = {
+                "choices": [{"message": {"content": text}}]
+            }
+            return resp
+
+        png_pages = [b"png1", b"png2", b"png3"]
+        with patch.object(
+            attachment_service, "_render_pdf_pages_to_png", return_value=png_pages
+        ):
+            with patch("httpx.AsyncClient") as MockClient:
+                mock_client = AsyncMock()
+                mock_client.post = mock_post
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                MockClient.return_value = mock_client
+
+                result = await attachment_service._extract_pdf_text_ocr(Path("/tmp/fake.pdf"))
+
+        assert result is not None
+        assert "Page 1 content" in result
+        assert "Page 2 content" in result
+        assert "Page 3 content" in result
+        assert len(call_pages) == 3
+
+    @pytest.mark.asyncio
+    async def test_ocr_empty_response_returns_none(self, monkeypatch):
+        """If OCR returns only whitespace, the result is None."""
+        monkeypatch.setenv("DEEPINFRA_API_KEY", "test-key")
+
+        async def mock_post(*args, **kwargs):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {
+                "choices": [{"message": {"content": "   "}}]
+            }
+            return resp
+
+        with patch.object(
+            attachment_service, "_render_pdf_pages_to_png", return_value=[b"png"]
+        ):
+            with patch("httpx.AsyncClient") as MockClient:
+                mock_client = AsyncMock()
+                mock_client.post = mock_post
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                MockClient.return_value = mock_client
+
+                result = await attachment_service._extract_pdf_text_ocr(Path("/tmp/fake.pdf"))
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ocr_pymupdf_import_error(self, monkeypatch):
+        """If pymupdf is not installed, OCR returns None gracefully."""
+        monkeypatch.setenv("DEEPINFRA_API_KEY", "test-key")
+
+        with patch(
+            "druppie.services.attachment_service.asyncio.to_thread",
+            side_effect=ImportError("No module named 'pymupdf'"),
+        ):
+            result = await attachment_service._extract_pdf_text_ocr(Path("/tmp/fake.pdf"))
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ocr_render_failure(self, monkeypatch):
+        """If PDF rendering fails, OCR returns None gracefully."""
+        monkeypatch.setenv("DEEPINFRA_API_KEY", "test-key")
+
+        with patch(
+            "druppie.services.attachment_service.asyncio.to_thread",
+            side_effect=RuntimeError("render exploded"),
+        ):
+            result = await attachment_service._extract_pdf_text_ocr(Path("/tmp/fake.pdf"))
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ocr_no_pages_rendered(self, monkeypatch):
+        """If PDF renders zero pages, OCR returns None."""
+        monkeypatch.setenv("DEEPINFRA_API_KEY", "test-key")
+
+        with patch.object(
+            attachment_service, "_render_pdf_pages_to_png", return_value=[]
+        ):
+            with patch(
+                "druppie.services.attachment_service.asyncio.to_thread",
+                return_value=[],
+            ):
+                result = await attachment_service._extract_pdf_text_ocr(Path("/tmp/fake.pdf"))
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_pdf_text — native + OCR fallback
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPdfText:
+    @pytest.mark.asyncio
+    async def test_native_extraction_succeeds(self):
+        """If native pypdf extraction returns text, OCR is not called."""
+        with patch(
+            "druppie.services.attachment_service._extract_pdf_text_native",
+            return_value="Native text",
+        ) as mock_native:
+            with patch(
+                "druppie.services.attachment_service._extract_pdf_text_ocr",
+                new_callable=AsyncMock,
+            ) as mock_ocr:
+                result = await attachment_service._extract_pdf_text(Path("/tmp/doc.pdf"))
+
+        assert result == "Native text"
+        mock_native.assert_called_once()
+        mock_ocr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_native_fails_falls_back_to_ocr(self):
+        """If native extraction returns None, falls back to OCR."""
+        with patch(
+            "druppie.services.attachment_service._extract_pdf_text_native",
+            return_value=None,
+        ):
+            with patch(
+                "druppie.services.attachment_service._extract_pdf_text_ocr",
+                new_callable=AsyncMock,
+                return_value="OCR text",
+            ) as mock_ocr:
+                result = await attachment_service._extract_pdf_text(Path("/tmp/doc.pdf"))
+
+        assert result == "OCR text"
+        mock_ocr.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _extract_pdf_text_native
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPdfTextNative:
+    def test_pypdf_not_installed(self):
+        """Returns None when pypdf is not available."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _no_pypdf(name, *args, **kwargs):
+            if name == "pypdf":
+                raise ImportError("No module named 'pypdf'")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_no_pypdf):
+            result = attachment_service._extract_pdf_text_native(Path("/tmp/doc.pdf"))
+        assert result is None
+
+    def test_extraction_exception_returns_none(self):
+        """If pypdf raises during extraction, return None."""
+        mock_reader = MagicMock()
+        mock_reader.pages = [MagicMock(extract_text=MagicMock(side_effect=Exception("corrupt")))]
+
+        with patch("pypdf.PdfReader", return_value=mock_reader):
+            result = attachment_service._extract_pdf_text_native(Path("/tmp/doc.pdf"))
+        assert result is None
+
+    def test_empty_text_returns_none(self):
+        """If all pages produce empty text, return None."""
+        page1 = MagicMock(extract_text=MagicMock(return_value=""))
+        page2 = MagicMock(extract_text=MagicMock(return_value="   "))
+        mock_reader = MagicMock()
+        mock_reader.pages = [page1, page2]
+
+        with patch("pypdf.PdfReader", return_value=mock_reader):
+            result = attachment_service._extract_pdf_text_native(Path("/tmp/doc.pdf"))
+        assert result is None
+
+    def test_successful_extraction(self):
+        """Happy path: pages yield text joined by newlines."""
+        page1 = MagicMock(extract_text=MagicMock(return_value="Page one"))
+        page2 = MagicMock(extract_text=MagicMock(return_value="Page two"))
+        mock_reader = MagicMock()
+        mock_reader.pages = [page1, page2]
+
+        with patch("pypdf.PdfReader", return_value=mock_reader):
+            result = attachment_service._extract_pdf_text_native(Path("/tmp/doc.pdf"))
+        assert result == "Page one\nPage two"
+
+    def test_result_truncated_to_max(self):
+        """Extracted text is capped at MAX_EXTRACTED_TEXT characters."""
+        long_text = "x" * (MAX_EXTRACTED_TEXT + 500)
+        page = MagicMock(extract_text=MagicMock(return_value=long_text))
+        mock_reader = MagicMock()
+        mock_reader.pages = [page]
+
+        with patch("pypdf.PdfReader", return_value=mock_reader):
+            result = attachment_service._extract_pdf_text_native(Path("/tmp/doc.pdf"))
+        assert result is not None
+        assert len(result) == MAX_EXTRACTED_TEXT

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -1333,6 +1333,17 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
 
   const isStopping = data?.status === 'paused' && hasRunningAgentRun && hasActuallyRunningToolCall
 
+  // Notice shows only while processing: a PDF whose text_ready (derived from
+  // backend extracted_text) is still false. The status guard prevents the
+  // note from lingering on completed/failed sessions.
+  const hasPendingScannedPdf = data?.status !== 'completed' && data?.status !== 'failed'
+    && data?.timeline?.some(
+      (entry) => entry.type === 'message'
+        && (entry.message?.attachments || []).some(
+          (att) => att.content_type === 'application/pdf' && att.text_ready === false
+        )
+    )
+
   // When session has pending approvals, keep the tasks/badge cache fresh
   useEffect(() => {
     const status = data?.status
@@ -1888,6 +1899,14 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
                 <Loader2 className="w-3.5 h-3.5 text-gray-400 animate-spin" />
               </div>
             </>
+          )}
+          {/* Scanned PDF notice — shown while processing and a PDF still
+              has no extracted text; auto-hides once text_ready flips. */}
+          {hasPendingScannedPdf && (
+            <div className="pl-8 flex items-center gap-1.5 py-1 text-xs text-gray-500">
+              <Loader2 className="w-3 h-3 animate-spin text-gray-400" />
+              <span>This is a scanned PDF — reading it may take a few minutes.</span>
+            </div>
           )}
           {/* Trailing thinking / sandbox-waiting indicator */}
           {(() => {


### PR DESCRIPTION
## Summary

Combines two related changes to the chat file-upload pipeline: **hardening the PDF OCR path** (fix) and **adding a user-facing notice** for scanned PDFs (QoL). Kept as two atomic commits.

> ⚠️ **Depends on PR #295** (`fix/token-refresh-and-startup`). `colab-dev`'s backend is unrunnable without #295's `attachment_repository` SyntaxError fix, and this branch is built on top of it. Once #295 merges, this PR's diff shrinks to just the two commits below.

## 1. Harden the PDF OCR pipeline (`feat(attachments)`)

Scanned/image-only PDFs took **~10 min to upload** because OCR ran sequentially inside the synchronous upload request, and transient DeepInfra failures silently dropped pages (e.g. only 8/11 extracted).

- **`attachment_service.py`** — per-page retry (3 attempts, 2s backoff), concurrent page OCR (`Semaphore(4)`, order-preserving `gather`), and an in-process extraction registry: `schedule_extraction()` (background task, fresh DB session, updates `extracted_text`) + `await_extractions()` (never raises; tolerates empty/unknown/done/failed tasks).
- **`chat.py` upload** — commits the row, schedules background extraction, returns immediately (no more blocking `await` on OCR).
- **`orchestrator.py`** — awaits in-flight extraction before building context, **committing the user message + attachment links first**. That pre-await commit is load-bearing: it makes the message/attachment visible during a long OCR (enables the notice in commit 2) and releases the row lock so the background extraction's commit cannot deadlock on the orchestrator's open transaction. Both attachment-context seams updated (`build_project_context` is now async; all 8 callers updated).

## 2. Scanned-PDF reading notice (`feat(chat)`)

While a session is processing and a PDF attachment has no extracted text yet, the chat shows:

> *"This is a scanned PDF — reading it may take a few minutes."*

It auto-hides the moment the text is ready (next poll). Text PDFs/files extract near-instantly, so the notice never appears for them.

- **`domain/common.py` + `session_repository.py`** — expose a derived `text_ready` boolean on each attachment (`bool(extracted_text)`). No new DB column; computed at serialization → reload-safe.
- **`SessionDetail.jsx`** — renders the notice while `status != completed/failed` and a PDF attachment has `text_ready === false`.

## Verification

**Hardening** (11-page scanned PDF): upload **0s** (was ~600s), **11/11 pages** (was 8/11), 22,316 chars; lock-waits stayed **0** (no deadlock); orchestrator proceeded after OCR (router → planner read the doc). Non-OCR paths (text files, text-layer PDFs) unchanged and not routed to OCR.

**Notice** (Playwright): the notice rendered during the OCR wait and auto-hid when `text_ready` flipped to `true`; the agent then continued to `paused_hitl`.

**Regression:** `pytest` unchanged (40 pre-existing failures, 0 new — identical with and without the change).

## Notes

- The registry is in-process and safe under the single-worker deployment; a worker restart mid-extraction leaves that attachment's text unextracted (agent sees "no text extracted — use read_attachment tool").
- Supersedes the earlier separate branches `fix/pdf-ocr-hardening` and `feat/scanned-pdf-extraction-notice` (folded in here with clean history).

docs-exempt: bugfix hardening + minor UX notice, no architectural change