### PR TITLE
[TEST] docs-gate probe — svp negeren/sluiten (PBI 9744)

### DIFF
--- a/druppie/_docs_gate_probe.py
+++ b/druppie/_docs_gate_probe.py
@@ -1,0 +1,8 @@
+"""TEMPORARY probe — demonstrates that the docs mandatory-gate flags a code
+change that ships without documentation (PBI 9744). This PR is a test and
+will be closed; the file is throwaway.
+"""
+
+
+def _probe() -> str:
+    return "docs-gate-probe"


### PR DESCRIPTION
Tijdelijke test-PR om te bewijzen dat de mandatory-docs gate een code-wijziging zonder documentatie flagt (warn-mode). Wordt gesloten zodra het bewijs is vastgelegd. Bevat alleen een throwaway `druppie/_docs_gate_probe.py`.