### PR TITLE
[TEST] docs-gate probe 2 — exempt via description (svp negeren)

### DIFF
--- a/druppie/_docs_gate_probe2.py
+++ b/druppie/_docs_gate_probe2.py
@@ -1,0 +1,11 @@
+"""Temporary throwaway probe (docs-gate-probe2).
+
+This module exists solely to demonstrate that the mandatory-docs CI gate
+can be skipped via a `docs-exempt:` directive in the PR description
+(not via a label). It is intended to be deleted together with its PR.
+"""
+
+
+def probe() -> str:
+    """Return a marker string identifying this throwaway probe."""
+    return "docs-gate-probe2"


### PR DESCRIPTION
Tijdelijke test: bewijst dat de mandatory-docs gate wordt overgeslagen via een docs-exempt-regel in de PR-description (geen label).

docs-exempt: demonstratie van exempt via PR-description
