### PR TITLE
fix: resolve merge regressions from PR #287 and PR #294

### DIFF
--- a/druppie/agents/builtin_tools.py
+++ b/druppie/agents/builtin_tools.py
@@ -967,7 +967,7 @@ async def create_message(
     except Exception:
         logger.debug("caller_agent_id_lookup_failed", agent_run_id=str(agent_run_id))
 
-    message_id = execution_repo.create_message(
+    message = execution_repo.create_message(
         session_id=session_id,
         role="assistant",
         content=display_content,
@@ -976,6 +976,7 @@ async def create_message(
         agent_id=caller_agent_id,
         sequence_number=seq,
     )
+    message_id = message.id
     execution_repo.flush()
 
     linked_count = 0

--- a/druppie/api/routes/approvals.py
+++ b/druppie/api/routes/approvals.py
@@ -25,11 +25,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 import structlog
 
-from druppie.api.deps import get_attachment_repository, get_current_user, get_user_roles, get_approval_service
-from druppie.repositories import AttachmentRepository
-from druppie.services import ApprovalService
+from druppie.api.deps import get_approval_repository, get_attachment_repository, get_current_user, get_session_service, get_user_roles, get_approval_service
+from druppie.repositories import ApprovalRepository, AttachmentRepository
+from druppie.services import ApprovalService, SessionService
 from druppie.domain import ApprovalDetail, ApprovalHistoryList, PendingApprovalList
-from druppie.core.background_tasks import create_tracked_task, run_session_task
+from druppie.core.background_tasks import create_session_task, run_session_task, SessionTaskConflict
 
 logger = structlog.get_logger()
 
@@ -133,6 +133,8 @@ async def approval_history(
 async def approve(
     approval_id: UUID,
     approval_service: ApprovalService = Depends(get_approval_service),
+    session_service: SessionService = Depends(get_session_service),
+    approval_repo: ApprovalRepository = Depends(get_approval_repository),
     user: dict = Depends(get_current_user),
 ) -> ApprovalResponse:
     """Approve a pending tool execution.
@@ -160,27 +162,66 @@ async def approve(
         user_id=str(user_id),
     )
 
-    # Step 1: Record approval in database (fast)
-    approval = approval_service.approve(
-        approval_id=approval_id,
-        user_id=user_id,
-        user_roles=user_roles,
-    )
+    # Step 1: Fetch approval to get session_id for locking
+    raw_approval = approval_repo.get_by_id(approval_id)
+    if not raw_approval:
+        raise HTTPException(status_code=404, detail="Approval not found")
 
-    # Step 2: Spawn background task to resume workflow
+    # Step 1b: Validate approval is still pending BEFORE acquiring the lock.
+    # This prevents lock_for_hitl_resume() from committing session status to
+    # 'active' when the subsequent approve() call would fail (e.g., approval
+    # already processed), which would leave the session stuck at 'active'.
+    if raw_approval.status != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Approval already {raw_approval.status}",
+        )
+
+    # Step 2: Atomically lock session BEFORE recording the approval.
+    # This prevents a race where a concurrent resume endpoint reverts
+    # the session status back to paused_hitl between approve() and lock().
     try:
-        create_tracked_task(
+        previous_status = session_service.lock_for_hitl_resume(raw_approval.session_id)
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
+    # Step 3: Record approval in database (fast)
+    # Wrapped in try/except so we can restore the session status if this fails
+    # unexpectedly (lock_for_hitl_resume already committed status to 'active').
+    try:
+        approval = approval_service.approve(
+            approval_id=approval_id,
+            user_id=user_id,
+            user_roles=user_roles,
+        )
+    except Exception:
+        logger.warning(
+            "approve_failed_restoring_session_status",
+            approval_id=str(approval_id),
+            session_id=str(raw_approval.session_id),
+        )
+        session_service.revert_to_hitl_paused(raw_approval.session_id, previous_status)
+        raise
+
+    # Step 4: Spawn background task to resume workflow
+    try:
+        create_session_task(
+            approval.session_id,
             _resume_workflow_after_approval(
                 session_id=approval.session_id,
                 approval_id=approval_id,
             ),
             name=f"resume-approve-{approval_id}",
+            skip_lock=True,
+        )
+    except SessionTaskConflict:
+        raise HTTPException(
+            status_code=409,
+            detail="A task is already running for this session",
         )
     except Exception:
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to start background task",
-        )
+        session_service.mark_failed(approval.session_id, "Failed to start approval resume background task")
+        raise
 
     logger.info(
         "approval_recorded_resuming_in_background",
@@ -199,6 +240,8 @@ async def reject(
     approval_id: UUID,
     request: RejectRequest,
     approval_service: ApprovalService = Depends(get_approval_service),
+    session_service: SessionService = Depends(get_session_service),
+    approval_repo: ApprovalRepository = Depends(get_approval_repository),
     attachment_repo: AttachmentRepository = Depends(get_attachment_repository),
     user: dict = Depends(get_current_user),
 ) -> ApprovalResponse:
@@ -232,15 +275,49 @@ async def reject(
         reason=request.reason,
     )
 
-    # Step 1: Record rejection in database (fast)
-    approval = approval_service.reject(
-        approval_id=approval_id,
-        user_id=user_id,
-        user_roles=user_roles,
-        reason=request.reason,
-    )
+    # Step 1: Fetch approval to get session_id for locking
+    raw_approval = approval_repo.get_by_id(approval_id)
+    if not raw_approval:
+        raise HTTPException(status_code=404, detail="Approval not found")
 
-    # Step 1b: Link attachments to approval
+    # Step 1b: Validate approval is still pending BEFORE acquiring the lock.
+    # This prevents lock_for_hitl_resume() from committing session status to
+    # 'active' when the subsequent reject() call would fail (e.g., approval
+    # already processed), which would leave the session stuck at 'active'.
+    if raw_approval.status != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Approval already {raw_approval.status}",
+        )
+
+    # Step 2: Atomically lock session BEFORE recording the rejection.
+    # This prevents a race where a concurrent resume endpoint reverts
+    # the session status back to paused_hitl between reject() and lock().
+    try:
+        previous_status = session_service.lock_for_hitl_resume(raw_approval.session_id)
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
+    # Step 3: Record rejection in database (fast)
+    # Wrapped in try/except so we can restore the session status if this fails
+    # unexpectedly (lock_for_hitl_resume already committed status to 'active').
+    try:
+        approval = approval_service.reject(
+            approval_id=approval_id,
+            user_id=user_id,
+            user_roles=user_roles,
+            reason=request.reason,
+        )
+    except Exception:
+        logger.warning(
+            "reject_failed_restoring_session_status",
+            approval_id=str(approval_id),
+            session_id=str(raw_approval.session_id),
+        )
+        session_service.revert_to_hitl_paused(raw_approval.session_id, previous_status)
+        raise
+
+    # Step 3b: Link attachments to approval
     if request.attachment_ids:
         try:
             attachment_uuids = [UUID(aid) for aid in request.attachment_ids]
@@ -255,20 +332,25 @@ async def reject(
         )
         attachment_repo.db.commit()
 
-    # Step 2: Spawn background task to resume workflow
+    # Step 4: Spawn background task to resume workflow
     try:
-        create_tracked_task(
+        create_session_task(
+            approval.session_id,
             _resume_workflow_after_approval(
                 session_id=approval.session_id,
                 approval_id=approval_id,
             ),
             name=f"resume-reject-{approval_id}",
+            skip_lock=True,
+        )
+    except SessionTaskConflict:
+        raise HTTPException(
+            status_code=409,
+            detail="A task is already running for this session",
         )
     except Exception:
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to start background task",
-        )
+        session_service.mark_failed(approval.session_id, "Failed to start rejection resume background task")
+        raise
 
     logger.info(
         "rejection_recorded_resuming_in_background",

--- a/druppie/api/routes/questions.py
+++ b/druppie/api/routes/questions.py
@@ -28,11 +28,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 import structlog
 
-from druppie.api.deps import get_attachment_repository, get_current_user, get_question_service, get_user_roles
-from druppie.repositories import AttachmentRepository
-from druppie.services import QuestionService
+from druppie.api.deps import get_attachment_repository, get_current_user, get_question_repository, get_question_service, get_session_service, get_user_roles
+from druppie.repositories import AttachmentRepository, QuestionRepository
+from druppie.services import QuestionService, SessionService
 from druppie.domain import QuestionDetail, PendingQuestionList
-from druppie.core.background_tasks import create_tracked_task, run_session_task
+from druppie.core.background_tasks import create_session_task, run_session_task, SessionTaskConflict
 
 logger = structlog.get_logger()
 
@@ -125,6 +125,8 @@ async def answer_question(
     question_id: UUID,
     request: AnswerRequest,
     question_service: QuestionService = Depends(get_question_service),
+    session_service: SessionService = Depends(get_session_service),
+    question_repo: QuestionRepository = Depends(get_question_repository),
     attachment_repo: AttachmentRepository = Depends(get_attachment_repository),
     user: dict = Depends(get_current_user),
 ) -> AnswerResponse:
@@ -157,18 +159,53 @@ async def answer_question(
         answer_preview=request.answer[:50] if request.answer else "",
     )
 
-    # Step 1: Save answer to database (fast)
-    roles = get_user_roles(user)
-    question = question_service.answer(
-        question_id=question_id,
-        user_id=user_id,
-        answer=request.answer,
-        selected_choices=request.selected_choices,
-        is_admin="admin" in roles,
-        user_roles=roles,
-    )
+    # Step 1: Fetch question to get session_id for locking
+    raw_question = question_repo.get_by_id(question_id)
+    if not raw_question:
+        raise HTTPException(status_code=404, detail="Question not found")
 
-    # Step 1b: Link attachments to question
+    # Step 1b: Validate question is still pending BEFORE acquiring the lock.
+    # This prevents lock_for_hitl_resume() from committing session status to
+    # 'active' when the subsequent answer() call would fail (e.g., question
+    # already answered), which would leave the session stuck at 'active'.
+    if raw_question.status != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Question already {raw_question.status}",
+        )
+
+    # Step 2: Atomically lock session BEFORE saving the answer.
+    # This prevents a race where a concurrent resume endpoint reverts
+    # the session status back to paused_hitl between answer() and lock().
+    try:
+        previous_status = session_service.lock_for_hitl_resume(raw_question.session_id)
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
+    # Step 3: Save answer to database (fast)
+    # Wrapped in try/except so we can restore the session status if this fails
+    # unexpectedly (lock_for_hitl_resume already committed status to 'active').
+    roles = get_user_roles(user)
+    try:
+        question = question_service.answer(
+            question_id=question_id,
+            user_id=user_id,
+            answer=request.answer,
+            selected_choices=request.selected_choices,
+            is_admin="admin" in roles,
+            user_roles=roles,
+        )
+    except Exception:
+        # Restore session to its previous paused status so it doesn't get stuck at 'active'
+        logger.warning(
+            "answer_failed_restoring_session_status",
+            question_id=str(question_id),
+            session_id=str(raw_question.session_id),
+        )
+        session_service.revert_to_hitl_paused(raw_question.session_id, previous_status)
+        raise
+
+    # Step 3b: Link attachments to question
     if request.attachment_ids:
         try:
             attachment_uuids = [UUID(aid) for aid in request.attachment_ids]
@@ -183,9 +220,10 @@ async def answer_question(
         )
         attachment_repo.db.commit()
 
-    # Step 2: Spawn background task to resume workflow
+    # Step 4: Spawn background task to resume workflow
     try:
-        create_tracked_task(
+        create_session_task(
+            question.session_id,
             _resume_workflow_after_answer(
                 session_id=question.session_id,
                 question_id=question_id,
@@ -193,12 +231,16 @@ async def answer_question(
                 selected_choices=request.selected_choices,
             ),
             name=f"resume-answer-{question_id}",
+            skip_lock=True,
+        )
+    except SessionTaskConflict:
+        raise HTTPException(
+            status_code=409,
+            detail="A task is already running for this session",
         )
     except Exception:
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to start background task",
-        )
+        session_service.mark_failed(question.session_id, "Failed to start answer resume background task")
+        raise
 
     logger.info(
         "answer_recorded_resuming_in_background",

--- a/druppie/api/routes/sessions.py
+++ b/druppie/api/routes/sessions.py
@@ -283,7 +283,7 @@ async def _run_retry_background(
                 for s in paused_siblings
             ]
 
-            all_results = await asyncio.gather(*tasks)
+            all_results = await asyncio.gather(*tasks, return_exceptions=True)
 
             if any(r == "paused" for r in all_results):
                 return

--- a/druppie/core/session_event_manager.py
+++ b/druppie/core/session_event_manager.py
@@ -10,7 +10,7 @@ import json
 import os
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import structlog
 from fastapi import WebSocket
@@ -43,6 +43,7 @@ class SessionEventManager:
     """
 
     def __init__(self) -> None:
+        self._instance_id: str = str(uuid4())
         self._connections: dict[UUID, list[WebSocket]] = {}
         self._lock = asyncio.Lock()
         self._redis: Any | None = None
@@ -80,6 +81,12 @@ class SessionEventManager:
                         continue
                     try:
                         data = json.loads(message["data"])
+                        # Skip messages that originated from this instance —
+                        # broadcast() already called _broadcast_local() for
+                        # those.  Other replicas (different instance_id) still
+                        # process the message normally.
+                        if data.get("origin_instance_id") == self._instance_id:
+                            continue
                         session_id = UUID(data["session_id"])
                         event = data["event"]
                         await self._broadcast_local(session_id, event)
@@ -191,7 +198,11 @@ class SessionEventManager:
                 await self._redis.publish(
                     f"session:{session_id}",
                     json.dumps(
-                        {"session_id": str(session_id), "event": event},
+                        {
+                            "session_id": str(session_id),
+                            "event": event,
+                            "origin_instance_id": self._instance_id,
+                        },
                         default=str,
                     ),
                 )

--- a/druppie/execution/orchestrator.py
+++ b/druppie/execution/orchestrator.py
@@ -1024,6 +1024,7 @@ class Orchestrator:
         The agent's continue_run() method loads all LLM calls and tool results
         from the database, so the tool result is automatically included.
         """
+        from druppie.agents.runtime_v2 import AgentV2 as Agent
         from druppie.core.mcp_config import MCPConfig
         from druppie.execution.mcp_http import MCPHttp
         from druppie.execution.tool_executor import ToolCallStatus, ToolExecutor
@@ -1128,7 +1129,7 @@ class Orchestrator:
             if parent_chain_completed:
                 await self.execute_pending_runs(session_id)
 
-        return await self._resume_agent(session_id, agent_run.id, agent_run.agent_id)
+        return session_id
 
     async def resume_after_answer(
         self,
@@ -1261,15 +1262,9 @@ class Orchestrator:
             status=AgentRunStatus.RUNNING.value,
         )
 
-        # Step 5: Build fresh context and continue the agent
-        context = self.build_project_context(session_id)
-        agent = Agent(agent_run.agent_id, db=db, session_id=str(session_id))
-        result = await agent.continue_run(
-            session_id=session_id,
-            agent_run_id=agent_run.id,
-            context=context,
-        )
+        # Step 5: Resume the agent (builds context, continues run, handles result)
         return await self._resume_agent(session_id, agent_run.id, agent_run.agent_id)
+
     async def resume_after_entra_auth(
         self,
         session_id: UUID,
@@ -1320,11 +1315,14 @@ class Orchestrator:
                 status=ToolCallStatus.FAILED,
                 error=error_msg,
             )
-            await _event_mgr.broadcast_agent_run_updated(
-                session_id=session_id,
-                agent_run_id=agent_run.id,
-                status=AgentRunStatus.COMPLETED.value,
-            )
+            agent_run = self.execution_repo.get_by_id(waiting_tc.agent_run_id)
+            _event_mgr = get_event_manager()
+            if agent_run:
+                await _event_mgr.broadcast_agent_run_updated(
+                    session_id=session_id,
+                    agent_run_id=agent_run.id,
+                    status=AgentRunStatus.COMPLETED.value,
+                )
             db.commit()
             logger.warning(
                 "entra_token_retrieval_failed",
@@ -1333,7 +1331,6 @@ class Orchestrator:
                 error=error_msg,
             )
             # Still resume the agent so it sees the error
-            agent_run = self.execution_repo.get_by_id(waiting_tc.agent_run_id)
             if agent_run:
                 return await self._resume_agent(
                     session_id, agent_run.id, agent_run.agent_id,
@@ -1417,7 +1414,7 @@ class Orchestrator:
           1 — switch all agents in this session
           2 — cancel the request
         """
-        from druppie.agents.runtime import Agent
+        from druppie.agents.runtime_v2 import AgentV2 as Agent
         from druppie.llm.fallback import FallbackLLM
 
         agent_state = question.agent_state or {}
@@ -1481,7 +1478,16 @@ class Orchestrator:
                 session_id, agent_run.id, result, agent_id=agent_run.agent_id,
             )
             if status == "completed":
-                await self.execute_pending_runs(session_id)
+                parent_chain_completed = await self._walk_parent_chain(
+                    session_id, agent_run, db,
+                )
+                if parent_chain_completed:
+                    await self.execute_pending_runs(session_id)
+                else:
+                    logger.info(
+                        "parent_chain_incomplete_waiting_for_siblings",
+                        session_id=str(session_id),
+                    )
         else:
             logger.info(
                 "fallback_rejected_by_user",
@@ -1918,62 +1924,5 @@ class Orchestrator:
         # The sandbox pushed to Gitea but the shared workspace volume
         # still has the old HEAD.
         self._sync_workspace(session_id)
-
-        # Set statuses back to running
-        self.execution_repo.update_status(agent_run.id, AgentRunStatus.RUNNING)
-        self.session_repo.update_status(session_id, SessionStatus.ACTIVE)
-        self.execution_repo.commit()
-
-        _event_mgr = get_event_manager()
-        await _event_mgr.broadcast_agent_run_updated(
-            session_id=session_id,
-            agent_run_id=agent_run.id,
-            status=AgentRunStatus.RUNNING.value,
-        )
-
-        # Build fresh context and continue the agent
-        db = self.execution_repo.db
-        context = self.build_project_context(session_id)
-        agent = Agent(agent_run.agent_id, db=db, session_id=str(session_id))
-        try:
-            result = await agent.continue_run(
-                session_id=session_id,
-                agent_run_id=agent_run.id,
-                context=context,
-            )
-        except Exception as e:
-            error_msg = clean_llm_error(f"{type(e).__name__}: {e}")
-            self.execution_repo.update_status(
-                agent_run.id,
-                AgentRunStatus.FAILED,
-                error_message=error_msg,
-            )
-            self.execution_repo.commit()
-            raise
-
-        # Handle result — agent may pause again
-        status = self._handle_agent_resume_result(session_id, agent_run.id, result, agent_id=agent_run.agent_id)
-
-        if status == "completed":
-            logger.info(
-                "agent_resumed_after_sandbox_completed",
-                agent_run_id=str(agent_run.id),
-                agent_id=agent_run.agent_id,
-            )
-            await _event_mgr.broadcast_agent_run_updated(
-                session_id=session_id,
-                agent_run_id=agent_run.id,
-                status=AgentRunStatus.COMPLETED.value,
-            )
-            parent_chain_completed = await self._walk_parent_chain(
-                session_id, agent_run, db,
-            )
-            if parent_chain_completed:
-                await self.execute_pending_runs(session_id)
-            else:
-                logger.info(
-                    "parent_chain_incomplete_waiting_for_siblings",
-                    session_id=str(session_id),
-                )
 
         return await self._resume_agent(session_id, agent_run.id, agent_run.agent_id)

--- a/druppie/execution/tool_executor.py
+++ b/druppie/execution/tool_executor.py
@@ -1050,12 +1050,13 @@ class ToolExecutor:
         )
 
         seq = self.execution_repo.get_next_sequence_number(session_id)
-        msg_id = self.execution_repo.create_message(
+        msg = self.execution_repo.create_message(
             session_id=session_id,
             role="system",
             content=message,
             sequence_number=seq,
         )
+        msg_id = msg.id
         self._active_db.flush()
         logger.info("translation_fallback_to_english", session_id=str(session_id))
 
@@ -1164,7 +1165,7 @@ class ToolExecutor:
             session_id=tool_call.session_id,
             approval_id=approval.id,
             tool_name=tool_call.tool_name,
-            required_role=required_role,
+            required_role=required_role or "developer",
         )
 
         return ToolCallStatus.WAITING_APPROVAL

--- a/druppie/services/session_service.py
+++ b/druppie/services/session_service.py
@@ -271,7 +271,7 @@ class SessionService:
             SessionStatus.PAUSED.value,
             SessionStatus.PAUSED_HITL.value,
             SessionStatus.PAUSED_CRASHED.value,
-            SessionStatus.PAUSED_HITL.value,
+            SessionStatus.PAUSED_APPROVAL.value,
             SessionStatus.PAUSED_ENTRA_AUTH.value,
             SessionStatus.PAUSED_SANDBOX.value,
             SessionStatus.FAILED.value,
@@ -291,7 +291,11 @@ class SessionService:
         session.status = SessionStatus.ACTIVE.value
         self.session_repo.commit()
 
-    def lock_for_hitl_resume(self, session_id: UUID) -> None:
+    def lock_for_hitl_resume(self, session_id: UUID) -> str:
+        """Atomically lock and transition session to ACTIVE for HITL resume.
+
+        Returns the previous session status so callers can revert on failure.
+        """
         session = self.session_repo.get_by_id_for_update(session_id)
         if not session:
             raise NotFoundError("session", str(session_id))
@@ -302,5 +306,21 @@ class SessionService:
         }
         if session.status not in resumable:
             raise ValueError(f"Cannot resume HITL for session with status '{session.status}'")
+        previous_status = session.status
         session.status = SessionStatus.ACTIVE.value
+        self.session_repo.commit()
+        return previous_status
+
+    def revert_to_hitl_paused(self, session_id: UUID, previous_status: str | None = None) -> None:
+        """Revert session status after a failed HITL resume attempt.
+
+        If previous_status is provided, restores to that exact status.
+        Otherwise defaults to paused_hitl.
+        """
+        target = previous_status or SessionStatus.PAUSED_HITL.value
+        try:
+            target_enum = SessionStatus(target)
+        except ValueError:
+            target_enum = SessionStatus.PAUSED_HITL
+        self.session_repo.update_status(session_id, target_enum)
         self.session_repo.commit()

--- a/frontend/src/components/chat/SessionDetail.jsx
+++ b/frontend/src/components/chat/SessionDetail.jsx
@@ -8,7 +8,7 @@ import { Send, CheckCircle, XCircle, Shield, ShieldOff, Loader2, ExternalLink, M
 import { Link } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { getSession, sendChat, cancelChat, resumeSession, authorizeEntra, getResumableRuns, approveApproval, rejectApproval, answerQuestion, getToolCallLiveOutput, getSandboxEvents, downloadAttachment } from '../../services/api'
+import { getSession, sendChat, cancelChat, resumeSession, authorizeEntra, getResumableRuns, approveApproval, rejectApproval, answerQuestion, getToolCallLiveOutput, getSandboxEvents, downloadAttachment, getAttachmentUrl } from '../../services/api'
 import { getUserInfo, getKeycloak } from '../../services/keycloak'
 import { useAuth } from '../../App'
 import { getAgentConfig, getAgentMessageColors, formatToolName } from '../../utils/agentConfig'
@@ -991,8 +991,7 @@ const MessageItem = ({ message, agentRun, sessionId }) => {
 
 const VALID_VIEW_MODES = new Set(['chat', 'annotated', 'inspect'])
 // AgentRunStatus values that indicate the agent has started processing (not pending)
-// Note: 'paused_user' was removed as it doesn't exist; 'paused_crashed' added
-const STARTED_STATUSES = new Set(['running', 'completed', 'failed', 'paused_hitl', 'paused_tool', 'paused_entra_auth', 'paused_sandbox', 'paused_crashed', 'waiting_approval', 'waiting_answer'])
+const STARTED_STATUSES = new Set(['running', 'completed', 'failed', 'paused_hitl', 'paused_tool', 'paused_user', 'paused_entra_auth', 'paused_sandbox', 'paused_crashed', 'waiting_approval', 'waiting_answer'])
 
 const SessionDetail = ({ sessionId, initialViewMode }) => {
   const timelineEndRef = useRef(null)
@@ -1610,7 +1609,7 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
               </span>
             )}
             {/* Continue button — when fully stopped, crashed, or failed */}
-            {canControlSession && ['paused', 'paused_hitl', 'paused_crashed', 'failed'].includes(data.status) && !isStopping && (
+            {canControlSession && ['paused', 'paused_crashed', 'failed'].includes(data.status) && !isStopping && (
               <button
                 onClick={() => setShowContinueDialog(true)}
                 className="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-green-600 bg-green-50 border border-green-200 rounded-lg hover:bg-green-100 transition-colors"
@@ -2015,7 +2014,7 @@ const SessionDetail = ({ sessionId, initialViewMode }) => {
                     <StopCircle className="w-4 h-4" />
                   )}
                 </button>
-              ) : ['paused', 'paused_hitl', 'paused_crashed', 'failed'].includes(data.status) ? (
+              ) : ['paused', 'paused_crashed', 'failed'].includes(data.status) ? (
                 <button
                   onClick={() => setShowContinueDialog(true)}
                   className="flex-shrink-0 p-2 rounded-xl bg-green-600 text-white hover:bg-green-700 transition-colors"


### PR DESCRIPTION
## Summary

- **Double agent execution** — `resume_after_answer`, `resume_after_approval`, and `resume_after_sandbox` called `continue_run()` twice (inline + via `_resume_agent()`), causing duplicate HITL questions and double agent runs
- **Missing `Agent` imports** — three resume methods crashed with `NameError: name 'Agent' is not defined`
- **Hidden BA messages** — `paused_user` was removed from `STARTED_STATUSES` with an incorrect comment, hiding all business analyst timeline entries
- **Wrong button for HITL** — "Continue" button shown instead of answer input when session was `paused_hitl`
- **WebSocket double delivery** — events delivered twice on single-replica setups (local + Redis self-echo)
- **HITL race condition** — concurrent answer + resume could both succeed; wired `lock_for_hitl_resume()` into question/approval endpoints
- **`create_message` return type** — callers expected UUID but got `DomainMessage` after refactor, breaking attachment linking
- **Other** — undefined vars in `resume_after_entra_auth`, wrong Agent import in `_handle_fallback_answer`, duplicate `PAUSED_HITL` (should be `PAUSED_APPROVAL`), missing `getAttachmentUrl` import, `asyncio.gather` without `return_exceptions`, `required_role` None mismatch

## Files changed (9)

| File | Changes |
|------|---------|
| `druppie/execution/orchestrator.py` | Remove double execution, fix imports, fix entra auth, fix fallback answer |
| `druppie/api/routes/questions.py` | Add session locking, early validation |
| `druppie/api/routes/approvals.py` | Add session locking, early validation |
| `druppie/services/session_service.py` | Fix duplicate PAUSED_HITL, add `revert_to_hitl_paused()`, return previous status from lock |
| `druppie/core/session_event_manager.py` | Add origin_instance_id to prevent self-echo |
| `druppie/agents/builtin_tools.py` | Handle DomainMessage return from create_message |
| `druppie/execution/tool_executor.py` | Handle DomainMessage return, fix required_role |
| `druppie/api/routes/sessions.py` | Add return_exceptions=True to gather |
| `frontend/src/components/chat/SessionDetail.jsx` | Restore paused_user, fix HITL button, add getAttachmentUrl import |

## Test plan

### 1. Session runs without crashing (verifies Agent import + double execution fixes)
- [x] Login as `admin` / `Admin123!`
- [x] Start a new session with a project request (e.g., "Build me a todo app")
- [x] Verify the pipeline progresses through router → planner → BA without `NameError`
- [x] Verify the BA asks exactly ONE question at a time (not duplicates)

### 2. BA messages visible in timeline (verifies paused_user fix)
- [x] Open a session where the BA agent has run
- [x] Verify BA messages, HITL questions, and agent status are all visible
- [x] Verify agent runs with `paused_user` status render correctly (not hidden)

### 3. HITL answer flow (verifies button + locking fixes)
- [x] When BA asks a HITL question, verify the input bar shows a **send button** (not a green "Continue" button)
- [x] Type an answer and send it — verify the agent resumes and processes the answer
- [x] Try answering the same question again — should get rejected (409)

### 4. WebSocket events (verifies dedup fix)
- [x] Open browser DevTools → Network → WS tab
- [x] Watch WebSocket messages during a session run
- [x] Verify each event appears exactly once (no duplicates)

### 5. Attachments (verifies getAttachmentUrl fix)
- [x] If a HITL question or agent message has an attachment, click the download button
- [x] Verify it opens/downloads without a console error

### 6. Quick smoke test
- [x] `curl http://localhost:8100/health` returns healthy
- [x] Existing sessions load correctly in the UI
- [x] No new console errors in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)