### PR TITLE
TEST: block on code-without-docs (no exempt)

### DIFF
--- a/druppie/_docs_gate_probe.py
+++ b/druppie/_docs_gate_probe.py
@@ -1,0 +1,2 @@
+# throwaway probe for docs-enforcement test — safe to delete
+PROBE = "noexempt"


### PR DESCRIPTION
Throwaway test of the mandatory-docs gate. Adds a code file under druppie/ with no docs and NO exempt. Expect: Docs check FAILS. Will be closed.