### PR TITLE
TEST: exempt via docs-exempt LABEL

### DIFF
--- a/druppie/_docs_gate_probe.py
+++ b/druppie/_docs_gate_probe.py
@@ -1,0 +1,2 @@
+# throwaway probe for docs-enforcement test — safe to delete
+PROBE = "label"


### PR DESCRIPTION
Throwaway test. Code file under druppie/, no docs, but docs-exempt LABEL set at creation. Expect: Docs check PASSES. Will be closed.