### PR TITLE
feat: Auto-resolve @mentions in Azure DevOps comments and descriptions

### DIFF
--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -249,11 +249,20 @@ Project isolation is enforced in two independent layers:
    at another project even if the credential were over-scoped.
 
 Read tools: `list_backlog_items`, `get_work_item`, `search_work_items`,
-`get_current_sprint`, `get_sprint_summary`, `get_work_item_comments` (all
-`requires_approval: false`). Write tools: `create_work_item`, `update_work_item`,
+`get_current_sprint`, `get_sprint_summary`, `get_work_item_comments`, `resolve_user`
+(all `requires_approval: false`). Write tools: `create_work_item`, `update_work_item`,
 `add_work_item_comment` (`requires_approval: true`, `required_role: session_owner`).
 Consumed by the **Product Owner** agent. Isolation is pinned by
 `druppie/tests/test_azuredevops_isolation.py`.
+
+**@mention resolution:** `add_work_item_comment`, `create_work_item`, and
+`update_work_item` automatically resolve `@Display Name` patterns to Azure DevOps
+identity GUIDs via the Identity Picker API (`vssps.dev.azure.com`). Resolved mentions
+are replaced with `<a href="#" data-vss-mention="version:2.0,{GUID}">@Name</a>` HTML
+so that tagged users receive notifications. Resolution results are cached in-memory
+with a 1-hour TTL. Unresolved mentions are left as plain text (graceful degradation).
+The `resolve_user` tool exposes identity lookup directly so agents can verify names
+before mentioning.
 
 ### 2.6 Document Formatter Service
 

--- a/docs/adrs/036-devops-mention-resolution.md
+++ b/docs/adrs/036-devops-mention-resolution.md
@@ -1,0 +1,42 @@
+---
+id: "036"
+title: "Use regex detection and Identity Picker API for @mention resolution"
+status: accepted
+date: 2026-07-27
+deciders:
+  - sjoerd
+supersedes: null
+superseded_by: null
+linked_prd: "docs/prds/031-devops-mention-resolution.md"
+linked_research: null
+---
+
+## Context
+
+Azure DevOps requires `<a href="#" data-vss-mention="version:2.0,{GUID}">@Name</a>` HTML for working mentions. The MCP module passes text through unchanged. We need to detect mention patterns, resolve names to GUIDs, and replace before posting.
+
+## Decision
+
+1. **Regex-based detection:** `_MENTION_RE` matches `@Lastname, Firstname` (comma branch) and `@Firstname Lastname` (space branch with uppercase-only trailing words to avoid capturing prose). Trade-off: multi-word lowercase particles like "van der" need comma format.
+
+2. **Identity Picker API** (POST `vssps.dev.azure.com/_apis/identitypicker/identities`): used over the older GET Identities API because it is more reliable, returns richer data, and matches what the DevOps web UI uses. The `localId` field provides the GUID needed for mentions.
+
+3. **In-memory cache:** 1-hour TTL, caches both hits and misses. Resets on container restart. Same pattern as other MCP modules.
+
+4. **Null-localId filtering:** Some Azure AD identities (e.g. admin accounts) have no `localId`. The resolution logic filters these out and prefers identities with a valid GUID.
+
+5. **Three call sites:** `add_work_item_comment` (text), `create_work_item` (description), `update_work_item` (description). Titles are not processed (plain text only in DevOps).
+
+6. **New `resolve_user` tool:** Exposes identity lookup for agents to verify names before mentioning. Read-only, no approval required.
+
+## Consequences
+
+**Positive:**
+- Mentions work transparently, agents don't need to know about GUIDs, cached lookups are fast.
+- Graceful degradation: unresolved mentions remain as plain text rather than causing errors.
+- The `resolve_user` tool gives agents a way to verify names before writing mentions.
+
+**Negative:**
+- Regex cannot perfectly distinguish names from prose in all cases (mitigated by uppercase-only trailing words and API validation).
+- The `vssps` subdomain derivation assumes modern `dev.azure.com` URL format (legacy `visualstudio.com` URLs would need adjustment).
+- In-memory cache resets on container restart. This is acceptable because the cache is purely an optimization -- every resolution still calls the Identity Picker API on cache miss.

--- a/docs/adrs/CAS.md
+++ b/docs/adrs/CAS.md
@@ -33,3 +33,4 @@ Consolidated view of all **accepted** ADRs. Individual ADRs live in `docs/adrs/`
 | [029](029-ask-first-fallback-pattern.md) | Ask-first fallback pattern for runtime model management |
 | [030](030-sticky-fallback.md) | Sticky LLM fallback per session |
 | [031](031-hybrid-diagramming-strategy.md) | Hybrid ArchiMate + Mermaid diagramming strategy |
+| [036](036-devops-mention-resolution.md) | Use regex detection and Identity Picker API for @mention resolution |

--- a/docs/prds/031-devops-mention-resolution.md
+++ b/docs/prds/031-devops-mention-resolution.md
@@ -1,0 +1,53 @@
+---
+id: "031"
+title: "Azure DevOps @mention resolution in comments and descriptions"
+status: implemented
+author: sjoerd
+date: 2026-07-27
+supersedes: null
+superseded_by: null
+linked_adrs: ["docs/adrs/036-devops-mention-resolution.md"]
+linked_research: []
+linked_specs: []
+linked_workitem: "https://dev.azure.com/MSF-WBS/AI-platform/_workitems/edit/9974"
+---
+
+# PRD 031: Azure DevOps @mention resolution in comments and descriptions
+
+## Problem
+
+When agents write `@Display Name` in work item comments or descriptions via the Azure DevOps MCP, it appears as plain text -- no notification is sent. Azure DevOps requires a specific HTML format with the user's identity GUID for working mentions. This breaks team workflows where agents tag people for review.
+
+## Goal
+
+Automatically resolve `@Display Name` patterns to Azure DevOps identity GUIDs and replace with the HTML mention format that triggers notifications. Works transparently -- agents don't need to change how they write mentions.
+
+## User Journey
+
+1. Agent calls `add_work_item_comment` with text containing `@Noordam, Pieter please review`
+2. MCP server detects the `@Name` pattern via regex
+3. Server resolves "Noordam, Pieter" to identity GUID via the Identity Picker API
+4. Plain-text mention is replaced with `<a href="#" data-vss-mention="version:2.0,{GUID}">@Noordam, Pieter</a>`
+5. Comment is posted -- Pieter receives a notification in Azure DevOps
+
+## Constraints
+
+- Regex-based detection: matches `@Lastname, Firstname` (comma format) and `@Firstname Lastname` (space format, uppercase-only trailing words)
+- Identity Picker API (POST to `vssps.dev.azure.com`) used for resolution
+- In-memory cache with 1-hour TTL; caches misses to avoid repeated API calls
+- Graceful degradation: unresolved mentions stay as plain text
+- Applied in three paths: `add_work_item_comment`, `create_work_item` (description), `update_work_item` (description)
+
+## Out of Scope
+
+- Mentions in titles (titles are plain text, no HTML support)
+- Auto-completing partial names (the regex captures the full pattern as-is)
+- Multi-word lowercase name particles like "van der" in space format (use comma format instead)
+
+## Open Questions
+
+None blocking -- architectural decisions are captured in ADR 036.
+
+## Linked Documents
+
+- ADR 036: `docs/adrs/036-devops-mention-resolution.md` -- Architecture decisions (regex detection, Identity Picker API, in-memory cache, call sites)

--- a/druppie/core/mcp_config.yaml
+++ b/druppie/core/mcp_config.yaml
@@ -473,7 +473,7 @@ mcps:
       user_token:
         from: user.entra_token
         hidden: true
-        tools: [list_backlog_items, get_work_item, search_work_items, get_current_sprint, get_sprint_summary, get_work_item_comments, add_work_item_comment, create_work_item, update_work_item]
+        tools: [list_backlog_items, get_work_item, search_work_items, get_current_sprint, get_sprint_summary, get_work_item_comments, add_work_item_comment, create_work_item, update_work_item, resolve_user]
     tools:
       - name: list_backlog_items
         requires_approval: false
@@ -490,6 +490,8 @@ mcps:
       - name: add_work_item_comment
         requires_approval: true
         required_role: session_owner
+      - name: resolve_user
+        requires_approval: false
       - name: create_work_item
         requires_approval: true
         required_role: session_owner

--- a/druppie/mcp-servers/module-azuredevops/v1/client.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/client.py
@@ -210,5 +210,33 @@ class AzureDevOpsClient:
             user_token=user_token,
         )
 
+    @property
+    def _vssps_url(self) -> str:
+        return self._org_url.replace("://dev.azure.com", "://vssps.dev.azure.com")
+
+    async def search_identity(self, display_name: str, user_token: str | None = None) -> list[dict]:
+        """Search the identity picker for users matching *display_name*."""
+        headers = await self._auth_header(user_token)
+        body = {
+            "query": display_name,
+            "identityTypes": ["user"],
+            "operationScopes": ["ims", "source"],
+            "properties": ["DisplayName", "Mail"],
+            "options": {"MinResults": 1, "MaxResults": 5},
+        }
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{self._vssps_url}/_apis/identitypicker/identities",
+                params={"api-version": "7.0-preview.1"},
+                json=body,
+                headers=headers,
+            )
+            self._raise_for_status(resp)
+            data = resp.json()
+        results = data.get("results", [])
+        if not results:
+            return []
+        return results[0].get("identities", [])
+
     async def close(self) -> None:
         await self._credential.close()

--- a/druppie/mcp-servers/module-azuredevops/v1/module.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/module.py
@@ -8,6 +8,8 @@ caller-supplied project.
 
 import logging
 import os
+import re
+import time
 from datetime import datetime, timezone
 
 import httpx
@@ -35,6 +37,19 @@ _DETAIL_FIELDS = _SUMMARY_FIELDS + [
 ]
 
 VALID_WORK_ITEM_TYPES = {"Epic", "Feature", "Product Backlog Item", "Task", "Bug"}
+
+_MENTION_RE = re.compile(
+    r"@("
+    r"[\wÀ-ɏ][\wÀ-ɏ'-]*"
+    r"(?:"
+    r",\s*[\wÀ-ɏ][\wÀ-ɏ'-]*"
+    r"|"
+    r"(?:\s+[A-ZÀ-ɏ][\wÀ-ɏ'-]*){1,2}"
+    r")?"
+    r")"
+)
+
+_IDENTITY_CACHE_TTL = 3600.0
 
 _FIELD_MAP = {
     "title": "System.Title",
@@ -92,6 +107,8 @@ class AzureDevOpsModule:
             client_id=client_id,
             client_secret=client_secret,
         )
+        self._identity_cache: dict[str, str | None] = {}
+        self._identity_cache_ts: dict[str, float] = {}
         logger.info("Azure DevOps MCP bound to project '%s'", self._project)
 
     @property
@@ -120,6 +137,72 @@ class AzureDevOpsModule:
             return int(url.rstrip("/").split("/")[-1])
         except (ValueError, IndexError):
             return None
+
+    async def _resolve_identity(self, display_name: str, user_token: str | None = None) -> str | None:
+        """Resolve a display name to an Azure DevOps identity GUID, with caching."""
+        key = display_name.lower().strip()
+        now = time.monotonic()
+        if key in self._identity_cache and (now - self._identity_cache_ts.get(key, 0)) < _IDENTITY_CACHE_TTL:
+            return self._identity_cache[key]
+        try:
+            identities = await self._client.search_identity(display_name, user_token)
+            guid = None
+            if identities:
+                with_id = [i for i in identities if i.get("localId")]
+                if with_id:
+                    exact = next(
+                        (i for i in with_id if i.get("displayName", "").lower() == key),
+                        None,
+                    )
+                    guid = (exact or with_id[0])["localId"]
+            self._identity_cache[key] = guid
+            self._identity_cache_ts[key] = now
+            return guid
+        except Exception as exc:
+            logger.warning("_resolve_identity(%s) failed: %s", display_name, exc)
+            self._identity_cache[key] = None
+            self._identity_cache_ts[key] = now
+            return None
+
+    async def _resolve_mentions(self, text: str, user_token: str | None = None) -> str:
+        """Replace ``@Display Name`` patterns with Azure DevOps mention HTML."""
+        matches = list(_MENTION_RE.finditer(text))
+        if not matches:
+            return text
+
+        seen: dict[str, str | None] = {}
+        for m in matches:
+            name = m.group(1)
+            if name not in seen:
+                seen[name] = await self._resolve_identity(name, user_token)
+
+        for m in reversed(matches):
+            name = m.group(1)
+            guid = seen[name]
+            if guid:
+                replacement = f'<a href="#" data-vss-mention="version:2.0,{guid}">@{name}</a>'
+                text = text[:m.start()] + replacement + text[m.end():]
+        return text
+
+    async def resolve_user(self, display_name: str, user_token: str | None = None) -> dict:
+        """Look up Azure DevOps identities matching *display_name*."""
+        try:
+            identities = await self._client.search_identity(display_name, user_token)
+            return {
+                "success": True,
+                "query": display_name,
+                "results": [
+                    {
+                        "display_name": i.get("displayName"),
+                        "guid": i.get("localId"),
+                        "mail": i.get("mail"),
+                    }
+                    for i in identities
+                ],
+                "count": len(identities),
+            }
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
 
     async def get_current_sprint(self, user_token: str | None = None) -> dict:
         """Return info about the current sprint (iteration) based on today's date."""
@@ -423,7 +506,8 @@ class AzureDevOpsModule:
     async def add_work_item_comment(self, item_id: int, text: str, user_token: str | None = None) -> dict:
         """Add a comment to a work item."""
         try:
-            result = await self._client.add_work_item_comment(item_id, text, user_token=user_token)
+            processed_text = await self._resolve_mentions(text, user_token=user_token)
+            result = await self._client.add_work_item_comment(item_id, processed_text, user_token=user_token)
             return {
                 "success": True,
                 "project": self._project,
@@ -476,6 +560,9 @@ class AzureDevOpsModule:
                 "error": f"Invalid work item type '{work_item_type}'. "
                          f"Valid types: {', '.join(sorted(VALID_WORK_ITEM_TYPES))}",
             }
+
+        if description is not None:
+            description = await self._resolve_mentions(description, user_token=user_token)
 
         fields = {
             "title": title,
@@ -571,6 +658,9 @@ class AzureDevOpsModule:
                 "error": "Cannot set both state and board_column — "
                          "board_column automatically updates the state.",
             }
+
+        if description is not None:
+            description = await self._resolve_mentions(description, user_token=user_token)
 
         fields = {
             "title": title,

--- a/druppie/mcp-servers/module-azuredevops/v1/tools.py
+++ b/druppie/mcp-servers/module-azuredevops/v1/tools.py
@@ -168,6 +168,23 @@ async def add_work_item_comment(item_id: int, text: str, user_token: str | None 
 
 
 @mcp.tool()
+async def resolve_user(display_name: str, user_token: str | None = None) -> dict:
+    """Resolve a display name to Azure DevOps identity details.
+
+    Useful for verifying user names before @mentioning them in comments,
+    or for looking up team member details.
+
+    Args:
+        display_name: The display name to search for, e.g. "Noordam, Pieter"
+            or "Pieter Noordam" or partial name like "Pieter".
+
+    Returns:
+        Dict with matching identities (display_name, guid, mail).
+    """
+    return await module.resolve_user(display_name, user_token=user_token)
+
+
+@mcp.tool()
 async def create_work_item(
     work_item_type: str,
     title: str,

--- a/druppie/tests/test_azuredevops_isolation.py
+++ b/druppie/tests/test_azuredevops_isolation.py
@@ -66,6 +66,7 @@ def test_tools_expose_exactly_the_expected_tools():
         "update_work_item",
         "get_work_item_comments",
         "add_work_item_comment",
+        "resolve_user",
     }
 
 
@@ -176,11 +177,11 @@ class _RecordingClient:
     def org_url(self):
         return self._real.org_url
 
-    async def query_wiql(self, wiql, top):
+    async def query_wiql(self, wiql, top, user_token=None):
         self.posts.append((f"{self._real.project}/_apis/wit/wiql", {"query": wiql}))
         return [1, 2]
 
-    async def get_work_items(self, ids, fields=None):
+    async def get_work_items(self, ids, fields=None, user_token=None):
         self.posts.append(
             (f"{self._real.project}/_apis/wit/workitemsbatch", {"ids": ids})
         )
@@ -189,14 +190,14 @@ class _RecordingClient:
             for i in ids
         ]
 
-    async def get_work_item(self, item_id):
+    async def get_work_item(self, item_id, user_token=None):
         self.gets.append((f"{self._real.project}/_apis/wit/workitems/{item_id}", None))
         return {"id": item_id, "fields": {
             "System.Title": "WI",
             "WEF_ABC123_Kanban.Column": "New",
         }}
 
-    async def create_work_item(self, work_item_type, operations):
+    async def create_work_item(self, work_item_type, operations, user_token=None):
         path = f"{self._real.project}/_apis/wit/workitems/${work_item_type}"
         self.posts.append((path, {"operations": operations}))
         return {
@@ -208,7 +209,7 @@ class _RecordingClient:
             },
         }
 
-    async def update_work_item(self, item_id, operations):
+    async def update_work_item(self, item_id, operations, user_token=None):
         path = f"{self._real.project}/_apis/wit/workitems/{item_id}"
         self.patches.append((path, operations))
         return {
@@ -220,7 +221,7 @@ class _RecordingClient:
             },
         }
 
-    async def get_work_item_comments(self, item_id, top=None, order="desc"):
+    async def get_work_item_comments(self, item_id, top=None, order="desc", user_token=None):
         path = f"{self._real.project}/_apis/wit/workItems/{item_id}/comments"
         self.gets.append((path, {"top": top, "order": order}))
         return {
@@ -238,7 +239,7 @@ class _RecordingClient:
             ],
         }
 
-    async def add_work_item_comment(self, item_id, text):
+    async def add_work_item_comment(self, item_id, text, user_token=None):
         path = f"{self._real.project}/_apis/wit/workItems/{item_id}/comments"
         self.posts.append((path, {"text": text}))
         return {
@@ -248,6 +249,15 @@ class _RecordingClient:
             "createdBy": {"displayName": "Test User"},
             "createdDate": "2026-01-01T00:00:00Z",
         }
+
+    async def search_identity(self, display_name, user_token=None):
+        self.posts.append(("_apis/identitypicker/identities", {"query": display_name}))
+        if "test" in display_name.lower():
+            return [{"displayName": display_name, "localId": "e4f7b3db-7db6-6f4a-a83b-512cb72080c8", "mail": "test@example.com"}]
+        return []
+
+    async def get_team_iterations(self, user_token=None):
+        return []
 
 
 @pytest.mark.asyncio
@@ -404,3 +414,67 @@ async def test_update_rejects_state_and_board_column_together(monkeypatch):
     )
     assert result["success"] is False
     assert "Cannot set both" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_add_comment_resolves_mentions(monkeypatch):
+    module_mod = _load_module_under_test(monkeypatch)
+    mod = module_mod.AzureDevOpsModule()
+    rec = _RecordingClient(mod._client)
+    mod._client = rec
+
+    result = await mod.add_work_item_comment(100, "@Test User please review")
+    assert result["success"] is True
+
+    # The comment text posted to the API should contain the mention HTML
+    comment_posts = [
+        body for path, body in rec.posts
+        if path.endswith("/comments")
+    ]
+    assert comment_posts, "expected a comment POST"
+    posted_text = comment_posts[0]["text"]
+    assert "data-vss-mention" in posted_text
+    assert "e4f7b3db-7db6-6f4a-a83b-512cb72080c8" in posted_text
+
+
+@pytest.mark.asyncio
+async def test_add_comment_preserves_unresolved_mentions(monkeypatch):
+    module_mod = _load_module_under_test(monkeypatch)
+    mod = module_mod.AzureDevOpsModule()
+    rec = _RecordingClient(mod._client)
+    mod._client = rec
+
+    result = await mod.add_work_item_comment(100, "@Nobody Known")
+    assert result["success"] is True
+
+    comment_posts = [
+        body for path, body in rec.posts
+        if path.endswith("/comments")
+    ]
+    assert comment_posts
+    posted_text = comment_posts[0]["text"]
+    # Unresolved mention should stay as plain text (no HTML wrapping)
+    assert "data-vss-mention" not in posted_text
+    assert "@Nobody Known" in posted_text
+
+
+@pytest.mark.asyncio
+async def test_create_work_item_resolves_mentions_in_description(monkeypatch):
+    module_mod = _load_module_under_test(monkeypatch)
+    mod = module_mod.AzureDevOpsModule()
+    rec = _RecordingClient(mod._client)
+    mod._client = rec
+
+    result = await mod.create_work_item("Task", "test", description="cc @Test User")
+    assert result["success"] is True
+
+    # Find the create POST and check the description operation
+    create_posts = [
+        body for path, body in rec.posts
+        if "workitems/$" in path
+    ]
+    assert create_posts
+    operations = create_posts[0]["operations"]
+    desc_ops = [op for op in operations if op.get("path") == "/fields/System.Description"]
+    assert desc_ops, "expected a description operation"
+    assert "data-vss-mention" in desc_ops[0]["value"]


### PR DESCRIPTION
## Summary
- Detect `@Display Name` patterns in comments and work item descriptions, resolve to Azure DevOps identity GUIDs via the Identity Picker API, and replace with HTML mention format (`data-vss-mention`) that triggers notifications
- New `resolve_user` tool for agents to look up team member identities
- In-memory cache with 1-hour TTL, null-localId filtering for admin accounts, graceful fallback (unresolved mentions stay as plain text)

## Changes
| File | Change |
|------|--------|
| `client.py` | `_vssps_url` property + `search_identity()` method (Identity Picker API) |
| `module.py` | `_MENTION_RE` regex, `_resolve_identity()` with cache, `_resolve_mentions()`, `resolve_user()`, 3 call sites |
| `tools.py` | `resolve_user` tool definition |
| `mcp_config.yaml` | Tool registration + user_token injection |
| `test_azuredevops_isolation.py` | 3 new tests (17 total passing) |
| `docs/prds/031-*` | PRD for the feature |
| `docs/adrs/036-*` | ADR documenting design decisions |
| `docs/TECHNICAL.md` | Updated Azure DevOps tool table |
| `docs/adrs/CAS.md` | ADR 036 entry |

## Design decisions (ADR 036)
- **Regex**: comma branch (`@Lastname, Firstname`) + space branch with uppercase-only trailing words to avoid capturing prose
- **Identity Picker API** (POST to `vssps.dev.azure.com`) over older GET Identities API — richer response, matches DevOps web UI
- **GUID field**: `localId` (not `originId`); filters out identities with null `localId` (admin accounts)
- **Three call sites**: `add_work_item_comment` (text), `create_work_item` (description), `update_work_item` (description)

## Test plan
- [x] `resolve_user("Boeschoten, Sjoerd")` returns two identities, picks the one with valid GUID
- [x] Comment with `@Boeschoten, Sjoerd` produces clickable mention + notification in DevOps
- [x] Description with `@Boeschoten, Sjoerd` produces clickable mention
- [x] Unresolved `@Name` stays as plain text (no error)
- [x] 17 unit tests pass (14 existing + 3 new)
- [x] Security review: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)